### PR TITLE
update weather.noaa.gov url

### DIFF
--- a/libmateweather/weather-metar.c
+++ b/libmateweather/weather-metar.c
@@ -550,7 +550,7 @@ metar_start_open (WeatherInfo *info)
     }
 
     msg = soup_form_request_new (
-	"GET", "http://weather.noaa.gov/cgi-bin/mgetmetar.pl",
+	"GET", "http://weather.noaa.gov/mgetmetar.php",
 	"cccc", loc->code,
 	NULL);
     soup_session_queue_message (info->session, msg, metar_finish, info);


### PR DESCRIPTION
it's because the .pl url used, redirects. lessen the hops

![2013-04-26_21 49 24](https://f.cloud.github.com/assets/199095/432425/13e74150-aea4-11e2-852b-868b728855e4.png)
