### PR TITLE
Drop libsoup-gnome requirement

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -32,8 +32,7 @@ AM_CONDITIONAL(OS_WIN32, [test "$mateweather_native_win32" = "yes"])
 
 GTK_REQUIRED=2.11.0
 GLIB_REQUIRED=2.13.0
-LIBSOUP_REQUIRED=2.4.0
-LIBSOUP_GNOME_REQUIRED=1.1.0
+LIBSOUP_REQUIRED=2.34.0
 GIO_REQUIRED=2.25.0
 LIBXML_REQUIRED=2.6.0
 
@@ -126,14 +125,7 @@ AC_SUBST(LIBXML_CFLAGS)
 AC_SUBST(LIBXML_LIBS)
 
 dnl -- check for libsoup (required) -----------------------------------------
-PKG_CHECK_MODULES(LIBSOUP_GNOME,
-		  [libsoup-gnome-2.4 >= $LIBSOUP_GNOME_REQUIRED],
-		  [LIBSOUP_CFLAGS="$LIBSOUP_GNOME_CFLAGS"
-		   LIBSOUP_LIBS="$LIBSOUP_GNOME_LIBS"
-		   AC_DEFINE(HAVE_LIBSOUP_GNOME, 1, [Have libsoup-gnome])],
-		  [PKG_CHECK_MODULES(LIBSOUP, [libsoup-2.4 >= $LIBSOUP_REQUIRED])])
-AC_SUBST(LIBSOUP_CFLAGS)
-AC_SUBST(LIBSOUP_LIBS)
+PKG_CHECK_MODULES(LIBSOUP, [libsoup-2.4 >= $LIBSOUP_REQUIRED])
 
 dnl -- check for gio (required) -----------------------------------------
 PKG_CHECK_MODULES(GIO,

--- a/libmateweather/weather-priv.h
+++ b/libmateweather/weather-priv.h
@@ -24,11 +24,7 @@
 #include <time.h>
 #include <libintl.h>
 #include <math.h>
-#ifdef HAVE_LIBSOUP_GNOME
-#include <libsoup/soup-gnome.h>
-#else
 #include <libsoup/soup.h>
-#endif
 
 #include "weather.h"
 #include "mateweather-location.h"

--- a/libmateweather/weather.c
+++ b/libmateweather/weather.c
@@ -548,10 +548,8 @@ _weather_info_fill (WeatherInfo *info,
     info->cb_data = data;
 
     if (!info->session) {
-	info->session = soup_session_async_new ();
-#ifdef HAVE_LIBSOUP_GNOME
-	soup_session_add_feature_by_type (info->session, SOUP_TYPE_PROXY_RESOLVER_GNOME);
-#endif
+        info->session = soup_session_async_new ();
+        soup_session_add_feature_by_type (info->session, SOUP_TYPE_PROXY_RESOLVER_DEFAULT);
     }
 
     metar_start_open (info);


### PR DESCRIPTION
libsoup-gnome library has been deprecated by upstream. I guess it's quite safe to play along :)
