### PR TITLE
Locations: update ICAO code for Quito, Ecuador.

### DIFF
--- a/data/Locations.xml.in
+++ b/data/Locations.xml.in
@@ -10394,8 +10394,8 @@
         <coordinates>-0.216667 -78.500000</coordinates>
         <location>
           <name>Mariscal Sucre Airport</name>
-          <code>SEQU</code>
-          <coordinates>-0.150000 -78.483333</coordinates>
+          <code>SEQM</code>
+          <coordinates>-0.120000 -78.350000</coordinates>
         </location>
       </city>
     </country>


### PR DESCRIPTION
The physical airport location changed in 2013.
SEQU: https://en.wikipedia.org/wiki/Old_Mariscal_Sucre_International_Airport
SEQM: https://en.wikipedia.org/wiki/Mariscal_Sucre_International_Airport

http://tgftp.nws.noaa.gov/data/observations/metar/decoded/SEQM.TXT

https://www.aviationweather.gov/adds/dataserver_current/httpparam?dataSource=metars&requestType=retrieve&format=xml&hoursBeforeNow=2&stationString=SEQM