### PR TITLE
Restore Polish translation credits from GNOME

### DIFF
--- a/po-locations/pl.po
+++ b/po-locations/pl.po
@@ -1,9 +1,12 @@
-# -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
-# Aviary.pl
-# Jeśli masz jakiekolwiek uwagi odnoszące się do tłumaczenia lub chcesz
-# pomóc w jego rozwijaniu i pielęgnowaniu, napisz do nas:
-# matepl@aviary.pl
-# -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+# Polish translation for libgweather-locations.
+# Copyright © 2005-2010 the libgweather authors.
+# This file is distributed under the same license as the libgweather package.
+# Bartosz Kosiorek <gang65@poczta.onet.pl>, 2005.
+# Artur Flinta <aflinta@at.kernel.pl>, 2006.
+# Tomasz Dominikowski <dominikowski@gmail.com>, 2008-2009.
+# Piotr Drąg <piotrdrag@gmail.com>, 2010.
+# Aviary.pl <gnomepl@aviary.pl>, 2008-2010.
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: weather-locations\n"
@@ -11,7 +14,7 @@ msgstr ""
 "POT-Creation-Date: 2010-03-04 13:11+0100\n"
 "PO-Revision-Date: 2010-03-04 13:06+0100\n"
 "Last-Translator: Piotr Drąg <piotrdrag@gmail.com>\n"
-"Language-Team: Polish <matepl@aviary.pl>\n"
+"Language-Team: Polish <gnomepl@aviary.pl>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"

--- a/po/gnome-copyrights.txt
+++ b/po/gnome-copyrights.txt
@@ -1213,12 +1213,18 @@
 
 
 ========== pl.po ==========
-# -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
-# Aviary.pl
-# Jeśli masz jakiekolwiek uwagi odnoszące się do tłumaczenia lub chcesz
-# pomóc w jego rozwijaniu i pielęgnowaniu, napisz do nas:
-# matepl@aviary.pl
-# -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+# Polish translation for libgweather.
+# Copyright © 1998-2010 the libgweather authors.
+# This file is distributed under the same license as the libgweather package.
+# Zbigniew Chyla <chyla@alice.ci.pwr.wroc.pl>, 1998-2003.
+# Kuba Winnicki <bw@idc.com.pl>, 1999.
+# Artur Flinta <aflinta@at.kernel.pl>, 2003-2006.
+# Zbigniew Braniecki <gandalf@aviary.pl>, 2007.
+# Stanisław Małolepszy <smalolepszy@aviary.pl>, 2007.
+# Tomasz Dominikowski <dominikowski@gmail.com>, 2008-2009.
+# Piotr Drąg <piotrdrag@gmail.com>, 2010.
+# Aviary.pl <gnomepl@aviary.pl>, 2007-2010.
+#
 
 
 


### PR DESCRIPTION
This commit restores proper credits and copyrights for the Polish translation that were somehow lost during forking, using historical information from git.gnome.org.