### PR TITLE
test_sun_moon.c: remove unused variable try 2

### DIFF
--- a/libmateweather/test_sun_moon.c
+++ b/libmateweather/test_sun_moon.c
@@ -18,7 +18,7 @@ main (int argc, char **argv)
     gchar*          gtime = NULL;
     GDate           gdate;
     struct tm       tm;
-    gboolean        bsun, bmoon;
+    gboolean        bmoon;
     time_t          phases[4];
     const GOptionEntry entries[] = {
 	{ "latitude", 0, 0, G_OPTION_ARG_DOUBLE, &latitude,
@@ -64,7 +64,7 @@ main (int argc, char **argv)
 	info.update = time(NULL);
     }
 
-    bsun = calc_sun_time(&info, info.update);
+    calc_sun_time(&info, info.update);
     bmoon = calc_moon(&info);
 
     printf ("  Latitude %7.3f %c  Longitude %7.3f %c for %s  All times UTC\n",


### PR DESCRIPTION
Run the calc_sun_time(&info, info.update) function but don't load the result into a variable that is never used. Apparently running calc_sun_time sets a result elsewhere that shows up when test_sun_moon is run