### PR TITLE
Fix metar response: Invalid field name(s) found: raw_text

### DIFF
--- a/libmateweather/weather-metar.c
+++ b/libmateweather/weather-metar.c
@@ -550,7 +550,7 @@ metar_start_open (WeatherInfo *info)
     }
 
     msg = soup_form_request_new (
-        "GET", "https://www.aviationweather.gov/adds/dataserver_current/httpparam",
+        "GET", "https://www.aviationweather.gov/adds/dataserver1_3/httpparam",
         "dataSource", "metars",
         "requestType", "retrieve",
         "format", "xml",


### PR DESCRIPTION
**Old URI**

https://aviationweather.gov/adds/dataserver_current/httpparam?dataSource=metars&requestType=retrieve&format=xml&hoursBeforeNow=3&mostRecent=true&stationString=LEDA&fields=raw_text

**New URI**

https://aviationweather.gov/adds/dataserver1_3/httpparam?dataSource=metars&requestType=retrieve&format=xml&hoursBeforeNow=3&mostRecent=true&stationString=LEDA&fields=raw_text

Test: Update weather info on mateweather-applet

`msg->response_body->data` contains raw_text element now

```
(gdb) set print elements 0
(gdb) print "%s", msg->response_body->data
$3 = 0x16464e0 "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n<response xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns:xsi=\"http://www.w3.org/2001/XML-Schema-instance\" version=\"1.2\" xsi:noNamespaceSchemaLocation=\"http://aviationweather.gov/adds/schema/metar1_2.xsd\">\r\n  <request_index>15318</request_index>\r\n  <data_source name=\"metars\" />\r\n  <request type=\"retrieve\" />\r\n  <errors />\r\n  <warnings />\r\n  <time_taken_ms>13</time_taken_ms>\r\n  <data num_results=\"1\">\r\n    <METAR>\r\n      <raw_text>LEDA 291130Z AUTO 18005KT CAVOK 27/12 Q1016</raw_text>\r\n    </METAR>\r\n  </data>\r\n</response>\r\n\r\n"
(gdb) 
```

![metar](https://user-images.githubusercontent.com/10171411/83258964-87580080-a1b7-11ea-8653-82689338b91a.png)


Closes #80