### PR TITLE
build: underline package name and version in configure summary

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -190,7 +190,10 @@ dnl ***************************************************************************
 dnl *** Display Summary                                                     ***
 dnl ***************************************************************************
 echo "
-libmateweather-$VERSION configure summary:
+Configure summary:
+
+	${PACKAGE_STRING}
+	`echo $PACKAGE_STRING | sed "s/./=/g"`
 
 	Prefix:				${prefix}
 	Source code location:		${srcdir}


### PR DESCRIPTION
Test:
```
$ ./autogen.sh --prefix=/usr
<cut>
Configure summary:

	libmateweather 1.25.0
	=====================

	Prefix:				/usr
	Source code location:		.
	Compiler:			gcc
	Compiler flags:                 -g -O2
	Warning flags:                  -Wall -Wmissing-prototypes
	Locations.xml translations:	one file per translation
	Locations.xml compression:	no

Now type `make' to compile libmateweather
```