### PR TITLE
locations: drop Berlin Tegel

### DIFF
--- a/data/Locations.xml.in
+++ b/data/Locations.xml.in
@@ -14725,11 +14725,6 @@
           <name msgctxt="City in Berlin, Germany">Berlin</name>
           <coordinates>52.516667 13.400000</coordinates>
           <location>
-            <name>Berlin-Tegel</name>
-            <code>EDDT</code>
-            <coordinates>52.566667 13.316667</coordinates>
-          </location>
-          <location>
             <name>Berlin-Schoenefeld</name>
             <code>EDDB</code>
             <coordinates>52.383333 13.516667</coordinates>


### PR DESCRIPTION
Berlin Tegel Airport shut down on 4th of May 2021 and will be converted into the 'Urban Tech Republic' quarters.

It currently serves as a COVID-19 vaccination center, it is no longer an airport.