### PR TITLE
Using soup_session_new replaces the deprecated soup_session_async_new

### DIFF
--- a/libmateweather/weather.c
+++ b/libmateweather/weather.c
@@ -553,9 +553,7 @@ _weather_info_fill (WeatherInfo *info,
     info->cb_data = data;
 
     if (!info->session) {
-        info->session = soup_session_async_new ();
-        soup_session_add_feature_by_type (info->session, SOUP_TYPE_PROXY_RESOLVER_DEFAULT);
-        g_object_set (G_OBJECT (info->session), "ssl-use-system-ca-file", TRUE, NULL);
+        info->session = soup_session_new ();
     }
 
     metar_start_open (info);


### PR DESCRIPTION
Using soup_session_new replaces the deprecated soup_session_async_new 
Fix #96.
We need to merge [mate-desktop/mate-panel#1238](https://github.com/mate-desktop/mate-panel/pull/1208) first
