### PR TITLE
Fix build warnings about missing field initializer

### DIFF
--- a/libmateweather/test_metar.c
+++ b/libmateweather/test_metar.c
@@ -21,7 +21,7 @@ main (int argc, char **argv)
     GOptionEntry entries[] = {
 	{ "file", 'f', 0, G_OPTION_ARG_FILENAME, &filename,
 	  "file constaining metar observations", NULL },
-	{ NULL }
+	{ NULL, 0, 0, G_OPTION_ARG_NONE, NULL, NULL, NULL }
     };
     GOptionContext* context;
     GError* error = NULL;

--- a/libmateweather/test_sun_moon.c
+++ b/libmateweather/test_sun_moon.c
@@ -27,7 +27,7 @@ main (int argc, char **argv)
 	  "observer's longitude in degrees east", NULL },
 	{ "time", 0, 0, G_OPTION_ARG_STRING, &gtime,
 	  "time in seconds from Unix epoch", NULL },
-	{ NULL }
+	{ NULL, 0, 0, G_OPTION_ARG_NONE, NULL, NULL, NULL }
     };
 
     memset(&location, 0, sizeof(WeatherLocation));


### PR DESCRIPTION
```
test_metar.c:24:9: warning: missing field 'short_name' initializer [-Wmissing-field-initializers]
        { NULL }
               ^
--
test_sun_moon.c:30:9: warning: missing field 'short_name' initializer [-Wmissing-field-initializers]
        { NULL }
               ^
```