### PR TITLE
Fix -Wincompatible-pointer-types-discards-qualifiers warning

### DIFF
--- a/libmateweather/mateweather-location.c
+++ b/libmateweather/mateweather-location.c
@@ -397,16 +397,16 @@ mateweather_location_unref (MateWeatherLocation *loc)
 GType
 mateweather_location_get_type (void)
 {
-    static volatile gsize type_volatile = 0;
+    static gsize initialization_value = 0;
 
-    if (g_once_init_enter (&type_volatile)) {
+    if (g_once_init_enter (&initialization_value)) {
 	GType type = g_boxed_type_register_static (
 	    g_intern_static_string ("MateWeatherLocation"),
 	    (GBoxedCopyFunc) mateweather_location_ref,
 	    (GBoxedFreeFunc) mateweather_location_unref);
-	g_once_init_leave (&type_volatile, type);
+	g_once_init_leave (&initialization_value, type);
     }
-    return type_volatile;
+    return initialization_value;
 }
 
 /**

--- a/libmateweather/mateweather-timezone.c
+++ b/libmateweather/mateweather-timezone.c
@@ -285,16 +285,16 @@ mateweather_timezone_unref (MateWeatherTimezone *zone)
 GType
 mateweather_timezone_get_type (void)
 {
-    static volatile gsize type_volatile = 0;
+    static gsize initialization_value = 0;
 
-    if (g_once_init_enter (&type_volatile)) {
+    if (g_once_init_enter (&initialization_value)) {
 	GType type = g_boxed_type_register_static (
 	    g_intern_static_string ("MateWeatherTimezone"),
 	    (GBoxedCopyFunc) mateweather_timezone_ref,
 	    (GBoxedFreeFunc) mateweather_timezone_unref);
-	g_once_init_leave (&type_volatile, type);
+	g_once_init_leave (&initialization_value, type);
     }
-    return type_volatile;
+    return initialization_value;
 }
 
 /**


### PR DESCRIPTION
```
mateweather-location.c:402:9: warning: passing 'typeof (*(&type_volatile)) *' (aka 'volatile unsigned long *') to parameter of type 'gsize *' (aka 'unsigned long *') discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
    if (g_once_init_enter (&type_volatile)) {
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/glib-2.0/glib/gthread.h:260:7: note: expanded from macro 'g_once_init_enter'
    (!g_atomic_pointer_get (location) &&                             \
      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/glib-2.0/glib/gatomic.h:113:38: note: expanded from macro 'g_atomic_pointer_get'
    __atomic_load (gapg_temp_atomic, &gapg_temp_newval, __ATOMIC_SEQ_CST); \
                                     ^~~~~~~~~~~~~~~~~
```
```
mateweather-timezone.c:290:9: warning: passing 'typeof (*(&type_volatile)) *' (aka 'volatile unsigned long *') to parameter of type 'gsize *' (aka 'unsigned long *') discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
    if (g_once_init_enter (&type_volatile)) {
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/glib-2.0/glib/gthread.h:260:7: note: expanded from macro 'g_once_init_enter'
    (!g_atomic_pointer_get (location) &&                             \
      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/glib-2.0/glib/gatomic.h:113:38: note: expanded from macro 'g_atomic_pointer_get'
    __atomic_load (gapg_temp_atomic, &gapg_temp_newval, __ATOMIC_SEQ_CST); \
                                     ^~~~~~~~~~~~~~~~~
```