### PR TITLE
configure.ac: Bump Autoconf version because of LT_INIT

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_INIT([libmateweather], [1.26.0], [https://mate-desktop.org])
-AC_PREREQ(2.59)
+AC_PREREQ(2.60)
 
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_MACRO_DIR([m4])


### PR DESCRIPTION
LT_INIT was introduced on [AUTOCONF-2.59c](https://github.com/autotools-mirror/autoconf/releases/tag/AUTOCONF-2.59c) in the commit https://github.com/autotools-mirror/autoconf/commit/f2b269d60b2040a120bc4aa43cd19c3a5cb3f86b