### PR TITLE
Chicago area updates

### DIFF
--- a/data/Locations.xml.in
+++ b/data/Locations.xml.in
@@ -34675,13 +34675,6 @@
             <coordinates>42.43 -87.86</coordinates>
           </location>
           <location>
-            <name>Chicago / West Chicago. Dupage Airport</name>
-            <code>KDPA</code>
-            <zone>ILZ013</zone>
-            <radar>ord</radar>
-            <coordinates>41.9 -88.25</coordinates>
-          </location>
-          <location>
             <name>Chicago / Wheeling, Pal-Waukee Airport</name>
             <code>KPWK</code>
             <zone>ILZ103</zone>
@@ -34961,7 +34954,7 @@
           <location>
             <name>Chicago / West Chicago, Dupage Airport</name>
             <code>KDPA</code>
-            <zone>ILZ014</zone>
+            <zone>ILZ013</zone>
             <radar>ord</radar>
             <coordinates>41.896389 -88.251111</coordinates>
           </location>
@@ -35163,7 +35156,7 @@
           <location>
             <name>Chicago / West Chicago, Dupage Airport</name>
             <code>KDPA</code>
-            <zone>ILZ014</zone>
+            <zone>ILZ013</zone>
             <radar>ord</radar>
             <coordinates>41.896389 -88.251111</coordinates>
           </location>

--- a/data/Locations.xml.in
+++ b/data/Locations.xml.in
@@ -34649,7 +34649,7 @@
           <location>
             <name>Chicago Midway Airport</name>
             <code>KMDW</code>
-            <zone>ILZ014</zone>
+            <zone>ILZ104</zone>
             <radar>ord</radar>
             <coordinates>41.784167 -87.755278</coordinates>
           </location>
@@ -34663,23 +34663,30 @@
           <location>
             <name>Lansing Municipal Airport</name>
             <code>KIGQ</code>
-            <zone>ILZ014</zone>
+            <zone>ILZ105</zone>
             <radar>ord</radar>
             <coordinates>41.540000 -87.532222</coordinates>
           </location>
           <location>
-            <name>Chicago / Wheeling, Pal-Waukee Airport</name>
-            <code>KPWK</code>
+            <name>Chicago Waukegan Regional Airport</name>
+            <code>KUGN</code>
             <zone>ILZ006</zone>
             <radar>ord</radar>
-            <coordinates>42.120833 -87.904722</coordinates>
+            <coordinates>42.43 -87.86</coordinates>
           </location>
           <location>
-            <name>Chicago / Romeoville, Lewis University Airport</name>
-            <code>KLOT</code>
-            <zone>ILZ014</zone>
+            <name>Chicago / West Chicago. Dupage Airport</name>
+            <code>KDPA</code>
+            <zone>ILZ013</zone>
             <radar>ord</radar>
-            <coordinates>41.608333 -88.094167</coordinates>
+            <coordinates>41.9 -88.25</coordinates>
+          </location>
+          <location>
+            <name>Chicago / Wheeling, Pal-Waukee Airport</name>
+            <code>KPWK</code>
+            <zone>ILZ103</zone>
+            <radar>ord</radar>
+            <coordinates>42.120833 -87.904722</coordinates>
           </location>
         </city>
         <city>


### PR DESCRIPTION
Some of the Chicago zones report:

Note
This is the final forecast issuance for the Cook County forecast zone (ILZ014). Subsequent Cook County forecasts will be issued for three new zones, Northern Cook County (ILZ103), Central Cook County (ILZ104) and Southern Cook County (ILZ105). For more information, please visit www.weather.gov/lot/Forecast_Zone_Change .

That URL notes that the Chicago area changes in March 2020. I've updated based on the URL's
https://forecast.weather.gov/MapClick.php?zoneid=ILZ103

and likewise for ILZ104, ILZ105, etc.

I understand Mate weather applet is in maintenance mode, but until the cut-over is done, all the current MATE distros are still shipping this (outdated) version.