### PR TITLE
Tbilisi, Georgia (Country) IATA Airport code (TBS) changed to ICAO code (UGTB)

### DIFF
--- a/data/Locations.xml.in
+++ b/data/Locations.xml.in
@@ -3560,7 +3560,7 @@
 	  <coordinates>25.038889 102.718333</coordinates>
 	  <location>
 	    <name>Tbilisi</name>
-	    <code>TBS</code>
+	    <code>UGTB</code>
 	    <coordinates>41.669167 44.954722</coordinates>
 	  </location>
 	</city>


### PR DESCRIPTION
According to [this](https://github.com/mate-desktop/libmateweather/issues/59#issuecomment-1269753716)