### PR TITLE
New hardcoded dataserver url points to a 308 Permanent Redirect

### DIFF
--- a/libmateweather/weather-metar.c
+++ b/libmateweather/weather-metar.c
@@ -550,7 +550,7 @@ metar_start_open (WeatherInfo *info)
     }
 
     msg = soup_form_request_new (
-        "GET", "https://www.aviationweather.gov/cgi-bin/data/dataserver.php",
+        "GET", "https://aviationweather.gov/cgi-bin/data/dataserver.php",
         "dataSource", "metars",
         "requestType", "retrieve",
         "format", "xml",


### PR DESCRIPTION
For some reason (which I guess is my old setup with a lot of customized things), the changed url implemented in 0cc07f7e5163870bcc2fb7281c28e8e39c9cbc54 was not working for me.

After looking at the code and using `gdb` I found out that the URL with the `ẁww.` prefix added is a `308 Permanent Redirect` to the url without the `www.` and it was resulting in an unsuccessful request. It may be related to the `libsoup` version I have installed (`2.64.2-2`) not following the redirect...

So long story short, removing the `www.` from the hardcoded URL did the trick and I think that pointing to the real URL would be best.

O.