### PR TITLE
[1.28] metar: Update AviationWeather URL

### DIFF
--- a/libmateweather/weather-metar.c
+++ b/libmateweather/weather-metar.c
@@ -510,7 +510,7 @@ metar_finish (SoupSession *session, SoupMessage *msg, gpointer data)
 
     loc = info->location;
 
-    searchkey = g_strdup_printf ("<raw_text>%s", loc->code);
+    searchkey = g_strdup_printf ("<raw_text>METAR %s", loc->code);
     p = strstr (msg->response_body->data, searchkey);
     g_free (searchkey);
     if (p) {
@@ -550,7 +550,7 @@ metar_start_open (WeatherInfo *info)
     }
 
     msg = soup_form_request_new (
-        "GET", "https://aviationweather.gov/cgi-bin/data/dataserver.php",
+        "GET", "https://aviationweather.gov/api/data/dataserver",
         "dataSource", "metars",
         "requestType", "retrieve",
         "format", "xml",


### PR DESCRIPTION
According to their website: "The AviationWeather Data API has been redeveloped in 2025."

Also they put 'METAR' (or 'SPECI') onto the beginning of data to make it ICAO compliant, so we add code to parse that.

Fixes #135