### PR TITLE
location: provide extra checks to avoid SEGFAULT

### DIFF
--- a/libmateweather/location-entry.c
+++ b/libmateweather/location-entry.c
@@ -223,16 +223,17 @@ mateweather_location_entry_set_location (MateWeatherLocationEntry *entry,
     completion = gtk_entry_get_completion (GTK_ENTRY (entry));
     model = gtk_entry_completion_get_model (completion);
 
-    gtk_tree_model_get_iter_first (model, &iter);
-    do {
-	gtk_tree_model_get (model, &iter,
-			    MATEWEATHER_LOCATION_ENTRY_COL_LOCATION, &cmploc,
-			    -1);
-	if (loc == cmploc) {
-	    set_location_internal (entry, model, &iter);
-	    return;
-	}
-    } while (gtk_tree_model_iter_next (model, &iter));
+    if (gtk_tree_model_get_iter_first (model, &iter)) {
+        do {
+            gtk_tree_model_get (model, &iter,
+                                MATEWEATHER_LOCATION_ENTRY_COL_LOCATION, &cmploc,
+                                -1);
+            if (loc == cmploc) {
+                set_location_internal (entry, model, &iter);
+                return;
+            }
+        } while (gtk_tree_model_iter_next (model, &iter));
+    }
 
     set_location_internal (entry, model, NULL);
 }
@@ -309,28 +310,29 @@ mateweather_location_entry_set_city (MateWeatherLocationEntry *entry,
     completion = gtk_entry_get_completion (GTK_ENTRY (entry));
     model = gtk_entry_completion_get_model (completion);
 
-    gtk_tree_model_get_iter_first (model, &iter);
-    do {
-	gtk_tree_model_get (model, &iter,
-			    MATEWEATHER_LOCATION_ENTRY_COL_LOCATION, &cmploc,
-			    -1);
+    if (gtk_tree_model_get_iter_first (model, &iter)) {
+        do {
+            gtk_tree_model_get (model, &iter,
+                                MATEWEATHER_LOCATION_ENTRY_COL_LOCATION, &cmploc,
+                                -1);
 
-	cmpcode = mateweather_location_get_code (cmploc);
-	if (!cmpcode || strcmp (cmpcode, code) != 0)
-	    continue;
+            cmpcode = mateweather_location_get_code (cmploc);
+            if (!cmpcode || strcmp (cmpcode, code) != 0)
+                continue;
 
-	if (city_name) {
-	    cmpname = mateweather_location_get_city_name (cmploc);
-	    if (!cmpname || strcmp (cmpname, city_name) != 0) {
-		g_free (cmpname);
-		continue;
-	    }
-	    g_free (cmpname);
-	}
+            if (city_name) {
+                cmpname = mateweather_location_get_city_name (cmploc);
+                if (!cmpname || strcmp (cmpname, city_name) != 0) {
+                    g_free (cmpname);
+                    continue;
+                }
+                g_free (cmpname);
+            }
 
-	set_location_internal (entry, model, &iter);
-	return TRUE;
-    } while (gtk_tree_model_iter_next (model, &iter));
+            set_location_internal (entry, model, &iter);
+            return TRUE;
+        } while (gtk_tree_model_iter_next (model, &iter));
+    }
 
     set_location_internal (entry, model, NULL);
 

--- a/libmateweather/mateweather-location.c
+++ b/libmateweather/mateweather-location.c
@@ -494,7 +494,7 @@ mateweather_location_get_children (MateWeatherLocation *loc)
 {
     static MateWeatherLocation *no_children = NULL;
 
-    g_return_val_if_fail (loc != NULL, NULL);
+    g_return_val_if_fail (loc != NULL, &no_children);
 
     if (loc->children)
 	return loc->children;


### PR DESCRIPTION
Different ways to produce segmentation faults, no idea what is the root cause as it is happening recently, maybe related to the switch to libsoup3.

Bug report in Gentoo: https://bugs.gentoo.org/965885