### PR TITLE
locations: remove compression support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -45,18 +45,6 @@ AC_ARG_ENABLE(all-translations-in-one-xml,
         [enable_big_xml=no])
 AM_CONDITIONAL(USE_ONE_BIG_XML, test "x$enable_big_xml" = "xyes")
 
-AC_ARG_ENABLE(locations-compression,
-        [AS_HELP_STRING([--enable-locations-compression],
-                        [Compress Locations.xml files])],
-        [enable_locations_compression=$enableval],
-        [enable_locations_compression=no])
-if test "x$enable_locations_compression" = "xyes"; then
-    COMPRESS_EXT=.gz
-else
-    COMPRESS_EXT=
-fi
-AC_SUBST(COMPRESS_EXT)
-
 MATE_COMPILE_WARNINGS
 
 dnl -- Check for GTK+ (required) ------------------------------------------
@@ -203,5 +191,4 @@ Configure summary:
 	Compiler flags:                 ${CFLAGS}
 	Warning flags:                  ${WARN_CFLAGS}
 	Locations.xml translations:	${LOCATIONS_XML_TRANSLATIONS}
-	Locations.xml compression:	${enable_locations_compression}
 " >&2

--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -6,15 +6,12 @@ libmateweatherlocations_in_files = Locations.xml.in
 
 if USE_ONE_BIG_XML
 
-LOCATIONS_STAMP = 
+LOCATIONS_STAMP =
 
-libmateweatherlocations_DATA = $(libmateweatherlocations_in_files:.xml.in=.xml$(COMPRESS_EXT))
+libmateweatherlocations_DATA = $(libmateweatherlocations_in_files:.xml.in=.xml)
 
-%.xml$(COMPRESS_EXT): %.xml.in $(wildcard $(top_srcdir)/po-locations/*.po)
-	$(AM_V_GEN) GETTEXTDATADIR=$(top_srcdir) $(MSGFMT) --xml --template $< -d $(top_srcdir)/po-locations -o `echo $@ | sed "s/.xml$(COMPRESS_EXT)/.xml/"` && \
-	if test "x$(COMPRESS_EXT)" = "x.gz"; then				\
-		gzip -n --force `echo $@ | sed "s/.xml$(COMPRESS_EXT)/.xml/"`;	\
-	fi
+%.xml: %.xml.in $(wildcard $(top_srcdir)/po-locations/*.po)
+	$(AM_V_GEN) GETTEXTDATADIR=$(top_srcdir) $(MSGFMT) --xml --template $< -d $(top_srcdir)/po-locations -o $@
 
 else # USE_ONE_BIG_XML
 
@@ -25,7 +22,7 @@ PO_LOCATIONS = $(shell if test -n "$(LINGUAS)"; then for lang in $(LINGUAS); do 
 # Helper variable
 libmateweatherlocations_data = $(libmateweatherlocations_in_files:.xml.in=.xml)
 
-libmateweatherlocations_DATA = $(shell echo $(PO_LOCATIONS) | sed "s|$(top_srcdir)/po-locations/|Locations.|g;s|\.po|.xml$(COMPRESS_EXT)|g") $(libmateweatherlocations_data)$(COMPRESS_EXT)
+libmateweatherlocations_DATA = $(shell echo $(PO_LOCATIONS) | sed "s|$(top_srcdir)/po-locations/|Locations.|g;s|\.po|.xml|g") $(libmateweatherlocations_data)
 
 # We need this step so that we merge all the make Locations.xy.xml destinations
 # into one unique destination. This makes -j2 work. (Else, we end up with
@@ -38,14 +35,8 @@ $(LOCATIONS_STAMP): $(libmateweatherlocations_in_files) $(PO_LOCATIONS) Makefile
 		GETTEXTDATADIR=$(top_srcdir) $(MSGFMT) -l $$locale --xml --template $< $(top_srcdir)/po-locations/$$locale.po -o $(libmateweatherlocations_data) && \
 		xmllint --noblanks -o Locations.$$locale.xml $(libmateweatherlocations_data); \
 		rm -f $(libmateweatherlocations_data);			\
-		if test "x$(COMPRESS_EXT)" = "x.gz"; then		\
-			gzip -n --force Locations.$$locale.xml;		\
-		fi;							\
 	done &&								\
 	xmllint --noblanks --dtdvalid $(top_srcdir)/data/$(libmateweatherdtd_DATA) -o Locations.xml $(top_srcdir)/data/$(libmateweatherlocations_in_files) && \
-	if test "x$(COMPRESS_EXT)" = "x.gz"; then			\
-		gzip -n --force Locations.xml;				\
-	fi &&								\
 	touch $@
 
 endif # USE_ONE_BIG_XML

--- a/libmateweather/parser.c
+++ b/libmateweather/parser.c
@@ -157,7 +157,6 @@ MateWeatherParser *
 mateweather_parser_new (gboolean use_regions)
 {
     MateWeatherParser *parser;
-    int zlib_support;
     int i, keep_going;
     char *filename;
     char *tagname, *format;
@@ -168,25 +167,10 @@ mateweather_parser_new (gboolean use_regions)
     parser->use_regions = use_regions;
     parser->locales = g_get_language_names ();
 
-    zlib_support = xmlHasFeature (XML_WITH_ZLIB);
-
     /* First try to load a locale-specific XML. It's much faster. */
     filename = NULL;
     for (i = 0; parser->locales[i] != NULL; i++) {
 	filename = g_strdup_printf ("%s/Locations.%s.xml",
-				    MATEWEATHER_XML_LOCATION_DIR,
-				    parser->locales[i]);
-
-	if (g_file_test (filename, G_FILE_TEST_IS_REGULAR))
-	    break;
-
-	g_free (filename);
-	filename = NULL;
-
-        if (!zlib_support)
-            continue;
-
-	filename = g_strdup_printf ("%s/Locations.%s.xml.gz",
 				    MATEWEATHER_XML_LOCATION_DIR,
 				    parser->locales[i]);
 
@@ -202,11 +186,6 @@ mateweather_parser_new (gboolean use_regions)
      */
     if (!filename)
 	filename = g_build_filename (MATEWEATHER_XML_LOCATION_DIR, "Locations.xml", NULL);
-
-    if (!g_file_test (filename, G_FILE_TEST_IS_REGULAR) && zlib_support) {
-        g_free (filename);
-	filename = g_build_filename (MATEWEATHER_XML_LOCATION_DIR, "Locations.xml.gz", NULL);
-    }
 
     /* Open the xml file containing the different locations */
     parser->xml = xmlNewTextReaderFilename (filename);


### PR DESCRIPTION
libxml2 is removing built-in zlib support, which breaks reading compressed Locations.xml.gz files. Instead of implementing our own decompression, drop compression entirely.

Fixes: #144