### PR TITLE
metar: fix pointer offset in metar_finish

### DIFF
--- a/libmateweather/weather-metar.c
+++ b/libmateweather/weather-metar.c
@@ -536,7 +536,10 @@ metar_finish (GObject *source, GAsyncResult *result, gpointer data)
     }
 
     if (p) {
-        p += WEATHER_LOCATION_CODE_LEN + 11;
+        p += strlen (searchkey) + 1;
+    }
+    g_free (searchkey);
+    if (p) {
         endtag = xstrnstr (p, end - p, "</raw_text>");
         if (endtag)
             metar = g_strndup (p, endtag - p);
@@ -544,10 +547,7 @@ metar_finish (GObject *source, GAsyncResult *result, gpointer data)
             metar = g_strndup (p, end - p);
         success = metar_parse (metar, info);
         g_free (metar);
-    }
-    g_free (searchkey);
-
-    if (!success && !xstrnstr (response_body, len, "aviationweather.gov")) {
+    } else if (!xstrnstr (response_body, len, "aviationweather.gov")) {
         /* The response doesn't even seem to have come from NOAA...
          * most likely it is a wifi hotspot login page. Call that a
          * network error.


### PR DESCRIPTION
# PR: metar: fix pointer offset in metar_finish

## Description

After #136 added `METAR `/`SPECI ` to the search key, the pointer offset in `metar_finish()` is 6 characters too short.

The search key is now `<raw_text>METAR KPDX` (20 chars), but the code still advances by `WEATHER_LOCATION_CODE_LEN + 11` (= 15), which was correct for the old format `<raw_text>KPDX` (14 chars + 1 space).

This lands the pointer on ` KPDX 161753Z...` instead of `161753Z...`. The regex parser skips the unrecognized tokens so it often still works, but it passes garbage to `metar_parse()` and could cause subtle parsing failures.

## Fix

Move `g_free(searchkey)` after the offset calculation and use `strlen(searchkey) + 1` instead of the hardcoded offset:

```c
// Before:
g_free (searchkey);
if (p) {
    p += WEATHER_LOCATION_CODE_LEN + 11;

// After:
if (p) {
    p += strlen (searchkey) + 1;  /* was WEATHER_LOCATION_CODE_LEN + 11, now includes METAR/SPECI prefix */
}
g_free (searchkey);
if (p) {
```

This is self-documenting and won't need updating if the key format changes again. `searchkey` is from `g_strdup_printf`, so `strlen` is safe.

An alternative is `WEATHER_LOCATION_CODE_LEN + 17` if you prefer keeping the magic-number style.

## Note

This also affects the 1.28 branch. The SPECI fallback from #140 hasn't been backported there yet either.

Tested on Arch Linux (libmateweather 1.28.2, MATE 1.28) with both `strlen` and `+ 17` variants — both confirmed working.

Relates to issue #21.