### PR TITLE
locations: add 1,673 active METAR stations

### DIFF
--- a/data/Locations.xml.in
+++ b/data/Locations.xml.in
@@ -101,6 +101,16 @@
       </city>
       <city>
         <!-- A city in Algeria -->
+        <name>Bordj Badji Mokhtar</name>
+        <coordinates>21.375000 0.923890</coordinates>
+        <location>
+          <name>Bordj Badji Mokhtar Airport</name>
+          <code>DATM</code>
+          <coordinates>21.375000 0.923890</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Algeria -->
         <name>Bou Saada</name>
         <coordinates>35.214167 4.182500</coordinates>
         <location>
@@ -147,6 +157,16 @@
           <name>Djanet</name>
           <code>DAAJ</code>
           <coordinates>24.550000 9.466667</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Algeria -->
+        <name>El Bayadh</name>
+        <coordinates>33.683180 1.019270</coordinates>
+        <location>
+          <name>El Bayadh Airport</name>
+          <code>DAOY</code>
+          <coordinates>33.721670 1.092500</coordinates>
         </location>
       </city>
       <city>
@@ -368,16 +388,102 @@
     <country>
       <!-- AO - Angola -->
       <name>Angola</name>
-      <!-- Could not find weather stations for the following major
-           cities:
-           Luanda
-        -->
       <iso-code>AO</iso-code>
       <fips-code>AO</fips-code>
       <timezones>
         <timezone id="Africa/Luanda" />
       </timezones>
       <tz-hint>Africa/Luanda</tz-hint>
+      <city>
+        <!-- A city in Angola -->
+        <name>Cabinda</name>
+        <coordinates>-5.561980 12.194760</coordinates>
+        <location>
+          <name>Cabinda Airport</name>
+          <code>FNCA</code>
+          <coordinates>-5.596990 12.188400</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Angola -->
+        <name>Catumbela</name>
+        <coordinates>-12.430020 13.546770</coordinates>
+        <location>
+          <name>Catumbela Airport</name>
+          <code>FNCT</code>
+          <coordinates>-12.479200 13.486900</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Angola -->
+        <name>Huambo</name>
+        <coordinates>-12.776110 15.739170</coordinates>
+        <location>
+          <name>Nova Lisboa Airport</name>
+          <code>FNHU</code>
+          <coordinates>-12.808900 15.760500</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Angola -->
+        <name>Kuito</name>
+        <coordinates>-12.383330 16.933330</coordinates>
+        <location>
+          <name>Kuito Airport</name>
+          <code>FNKU</code>
+          <coordinates>-12.404600 16.947400</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Angola -->
+        <name>Luanda</name>
+        <coordinates>-8.836820 13.234320</coordinates>
+        <location>
+          <name>Quatro De Fevereiro Airport</name>
+          <code>FNLU</code>
+          <coordinates>-8.858370 13.231200</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Angola -->
+        <name>Luanda (Ícolo e Bengo)</name>
+        <coordinates>-8.836820 13.234320</coordinates>
+        <location>
+          <name>Dr. Antonio Agostinho Neto International Airport</name>
+          <code>FNBJ</code>
+          <coordinates>-9.046778 13.507194</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Angola -->
+        <name>Lubango</name>
+        <coordinates>-14.917170 13.492500</coordinates>
+        <location>
+          <name>Lubango Airport</name>
+          <code>FNUB</code>
+          <coordinates>-14.924700 13.575000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Angola -->
+        <name>Luena</name>
+        <coordinates>-11.783330 19.916670</coordinates>
+        <location>
+          <name>Luena Airport</name>
+          <code>FNUE</code>
+          <coordinates>-11.768100 19.897700</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Angola -->
+        <name>Ngiva</name>
+        <coordinates>-17.043500 15.683800</coordinates>
+        <location>
+          <name>Ngjiva Pereira Airport</name>
+          <code>FNGI</code>
+          <coordinates>-17.043500 15.683800</coordinates>
+        </location>
+      </city>
     </country>
     <country>
       <!-- BJ - Benin -->
@@ -427,6 +533,12 @@
           <code>FBFT</code>
           <coordinates>-21.216667 27.500000</coordinates>
         </location>
+        <location>
+          <name>Phillip Gaonwe Matante International Airport</name>
+          <code>FBPM</code>
+          <tz-hint>Africa/Gaborone</tz-hint>
+          <coordinates>-21.159183 27.468826</coordinates>
+        </location>
       </city>
       <city>
         <!-- The capital of Botswana -->
@@ -456,6 +568,16 @@
           <name>Kasane</name>
           <code>FBKE</code>
           <coordinates>-17.816667 25.150000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Botswana -->
+        <name>Khwai River Lodge</name>
+        <coordinates>-19.150000 23.783000</coordinates>
+        <location>
+          <name>Khwai River Lodge Airport</name>
+          <code>FBKR</code>
+          <coordinates>-19.150000 23.783000</coordinates>
         </location>
       </city>
       <city>
@@ -529,6 +651,16 @@
       </timezones>
       <tz-hint>Africa/Ouagadougou</tz-hint>
       <city>
+        <!-- A city in Burkina Faso -->
+        <name>Bobo Dioulasso</name>
+        <coordinates>11.180640 -4.294890</coordinates>
+        <location>
+          <name>Bobo Dioulasso Airport</name>
+          <code>DFOO</code>
+          <coordinates>11.160100 -4.330970</coordinates>
+        </location>
+      </city>
+      <city>
         <!-- The capital of Burkina Faso -->
         <name>Ouagadougou</name>
         <coordinates>12.370278 -1.524722</coordinates>
@@ -562,10 +694,6 @@
     <country>
       <!-- CM - Cameroon -->
       <name>Cameroon</name>
-      <!-- Could not find information about the following stations,
-           which may be in Cameroon:
-           FKKL 
-        -->
       <iso-code>CM</iso-code>
       <fips-code>CM</fips-code>
       <timezones>
@@ -594,6 +722,16 @@
       </city>
       <city>
         <!-- A city in Cameroon -->
+        <name>Maroua</name>
+        <coordinates>10.590950 14.315930</coordinates>
+        <location>
+          <name>Salak Airport</name>
+          <code>FKKL</code>
+          <coordinates>10.451400 14.257400</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Cameroon -->
         <name>Ngaoundere</name>
         <coordinates>7.316667 13.583333</coordinates>
         <location>
@@ -616,14 +754,6 @@
     <country>
       <!-- CV - Cape Verde -->
       <name>Cape Verde</name>
-      <!-- Could not find information about the following stations,
-           which may be in Cape Verde:
-           GVNP 
-        -->
-      <!-- Could not find weather stations for the following major
-           cities:
-           Praia
-        -->
       <iso-code>CV</iso-code>
       <fips-code>CV</fips-code>
       <timezones>
@@ -632,12 +762,42 @@
       <tz-hint>Atlantic/Cape_Verde</tz-hint>
       <city>
         <!-- A city in Cape Verde -->
+        <name>Praia</name>
+        <coordinates>14.931520 -23.512540</coordinates>
+        <location>
+          <name>Praia International Airport</name>
+          <code>GVNP</code>
+          <coordinates>14.924500 -23.493500</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Cape Verde -->
         <name>Preguiça</name>
         <coordinates>16.750000 -22.950000</coordinates>
         <location>
           <name>Sal</name>
           <code>GVAC</code>
           <coordinates>16.733333 -22.950000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Cape Verde -->
+        <name>Rabil</name>
+        <coordinates>16.136500 -22.888900</coordinates>
+        <location>
+          <name>Rabil Airport</name>
+          <code>GVBA</code>
+          <coordinates>16.136500 -22.888900</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Cape Verde -->
+        <name>São Pedro</name>
+        <coordinates>16.833200 -25.055300</coordinates>
+        <location>
+          <name>Sao Pedro Airport</name>
+          <code>GVSV</code>
+          <coordinates>16.833200 -25.055300</coordinates>
         </location>
       </city>
     </country>
@@ -690,6 +850,26 @@
         <timezone id="Africa/Ndjamena" />
       </timezones>
       <tz-hint>Africa/Ndjamena</tz-hint>
+      <city>
+        <!-- A city in Chad -->
+        <name>Abeche</name>
+        <coordinates>13.829160 20.832400</coordinates>
+        <location>
+          <name>Abeche Airport</name>
+          <code>FTTC</code>
+          <coordinates>13.847000 20.844300</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Chad -->
+        <name>Faya-Largeau</name>
+        <coordinates>17.925700 19.104280</coordinates>
+        <location>
+          <name>Faya Largeau Airport</name>
+          <code>FTTY</code>
+          <coordinates>17.917100 19.111100</coordinates>
+        </location>
+      </city>
       <city>
         <!-- A city in Chad -->
         <name>Moundou</name>
@@ -777,6 +957,17 @@
         </timezone>
       </timezones>
       <city>
+        <!-- A city in Congo, Democratic Republic of the -->
+        <name>Kalemie</name>
+        <coordinates>-5.947490 29.194710</coordinates>
+        <location>
+          <name>Kalemie Airport</name>
+          <code>FZRF</code>
+          <tz-hint>Africa/Lubumbashi</tz-hint>
+          <coordinates>-5.875560 29.250000</coordinates>
+        </location>
+      </city>
+      <city>
         <!-- The capital of the Democratic Republic of the Congo -->
         <name>Kinshasa</name>
         <coordinates>-4.329722 15.315000</coordinates>
@@ -785,6 +976,39 @@
           <code>FZAA</code>
           <tz-hint>Africa/Kinshasa</tz-hint>
           <coordinates>-4.383333 15.433333</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Congo, Democratic Republic of the -->
+        <name>Kisangani</name>
+        <coordinates>0.515280 25.190990</coordinates>
+        <location>
+          <name>Bangoka International Airport</name>
+          <code>FZIC</code>
+          <tz-hint>Africa/Lubumbashi</tz-hint>
+          <coordinates>0.481640 25.338000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Congo, Democratic Republic of the -->
+        <name>Lubumbashi</name>
+        <coordinates>-11.660890 27.479380</coordinates>
+        <location>
+          <name>Lubumbashi International Airport</name>
+          <code>FZQA</code>
+          <tz-hint>Africa/Lubumbashi</tz-hint>
+          <coordinates>-11.591300 27.530900</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Congo, Democratic Republic of the -->
+        <name>Mbuji Mayi</name>
+        <coordinates>-6.121240 23.569000</coordinates>
+        <location>
+          <name>Mbuji Mayi Airport</name>
+          <code>FZWA</code>
+          <tz-hint>Africa/Lubumbashi</tz-hint>
+          <coordinates>-6.121240 23.569000</coordinates>
         </location>
       </city>
     </country>
@@ -809,6 +1033,17 @@
           <name>Maya-Maya Airport</name>
           <code>FCBB</code>
           <coordinates>-4.250000 15.250000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Congo, Republic of the -->
+        <name>Oyo</name>
+        <coordinates>-1.165000 15.970000</coordinates>
+        <location>
+          <name>Oyo Ollombo Airport</name>
+          <code>FCOD</code>
+          <tz-hint>Africa/Brazzaville</tz-hint>
+          <coordinates>-1.226666 15.910000</coordinates>
         </location>
       </city>
       <city>
@@ -871,7 +1106,7 @@
       <name>Egypt</name>
       <!-- Could not find information about the following stations,
            which may be in Egypt:
-           HEBL HEIS HEMA HESC 
+           HESC
         -->
       <iso-code>EG</iso-code>
       <fips-code>EG</fips-code>
@@ -879,6 +1114,16 @@
         <timezone id="Africa/Cairo" />
       </timezones>
       <tz-hint>Africa/Cairo</tz-hint>
+      <city>
+        <!-- A city in Egypt -->
+        <name>Abu Simbel</name>
+        <coordinates>22.345700 31.616240</coordinates>
+        <location>
+          <name>Abu Simbel Airport</name>
+          <code>HEBL</code>
+          <coordinates>22.376000 31.611700</coordinates>
+        </location>
+      </city>
       <city>
         <!-- A city in Egypt -->
         <name>Al 'Arish</name>
@@ -897,6 +1142,16 @@
           <name>Hurguada</name>
           <code>HEGN</code>
           <coordinates>27.150000 33.716667</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Egypt -->
+        <name>Al Jiza</name>
+        <coordinates>30.114720 30.893330</coordinates>
+        <location>
+          <name>Sphinx International Airport</name>
+          <code>HESX</code>
+          <coordinates>30.114720 30.893330</coordinates>
         </location>
       </city>
       <city>
@@ -948,6 +1203,16 @@
         </location>
       </city>
       <city>
+        <!-- A city in Egypt -->
+        <name>At Tur</name>
+        <coordinates>28.241680 33.622200</coordinates>
+        <location>
+          <name>El Tor Airport</name>
+          <code>HETR</code>
+          <coordinates>28.209000 33.645500</coordinates>
+        </location>
+      </city>
+      <city>
         <!-- The capital of Egypt.
              "Cairo" is the traditional English name.
              The local name in Arabic is "Al Qahirah".
@@ -958,6 +1223,26 @@
           <name>Cairo Airport</name>
           <code>HECA</code>
           <coordinates>30.133333 31.400000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Egypt -->
+        <name>El Alamein</name>
+        <coordinates>30.830070 28.955020</coordinates>
+        <location>
+          <name>El Alamein International Airport</name>
+          <code>HEAL</code>
+          <coordinates>30.924500 28.461400</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Egypt -->
+        <name>Ismailia</name>
+        <coordinates>30.604270 32.272250</coordinates>
+        <location>
+          <name>Ismailia</name>
+          <code>HEIS</code>
+          <coordinates>30.600000 32.250000</coordinates>
         </location>
       </city>
       <city>
@@ -975,6 +1260,16 @@
       </city>
       <city>
         <!-- A city in Egypt -->
+        <name>Marsa Alam</name>
+        <coordinates>25.063050 34.890050</coordinates>
+        <location>
+          <name>Marsa Alam International Airport</name>
+          <code>HEMA</code>
+          <coordinates>25.557100 34.583700</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Egypt -->
         <name>Marsa Matruh</name>
         <coordinates>31.350000 27.233333</coordinates>
         <location>
@@ -985,12 +1280,42 @@
       </city>
       <city>
         <!-- A city in Egypt -->
+        <name>New Cairo</name>
+        <coordinates>30.030000 31.470000</coordinates>
+        <location>
+          <name>Capital International Airport</name>
+          <code>HECP</code>
+          <coordinates>30.072167 31.833333</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Egypt -->
         <name>Sharm ash Shaykh</name>
         <coordinates>27.863611 34.288056</coordinates>
         <location>
           <name>Sharm ash Shaykh International Airport</name>
           <code>HESH</code>
           <coordinates>27.966667 34.383333</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Egypt -->
+        <name>Suhaj</name>
+        <coordinates>26.556950 31.694780</coordinates>
+        <location>
+          <name>Sohag International Airport</name>
+          <code>HESG</code>
+          <coordinates>26.342515 31.743017</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Egypt -->
+        <name>Sīwah</name>
+        <coordinates>29.203200 25.519650</coordinates>
+        <location>
+          <name>Siwa Oasis Airport</name>
+          <code>HESW</code>
+          <coordinates>29.346000 25.507000</coordinates>
         </location>
       </city>
       <city>
@@ -1007,16 +1332,22 @@
     <country>
       <!-- GQ - Equatorial Guinea -->
       <name>Equatorial Guinea</name>
-      <!-- Could not find information about the following stations,
-           which may be in Equatorial Guinea:
-           FGBT 
-        -->
       <iso-code>GQ</iso-code>
       <fips-code>EK</fips-code>
       <timezones>
         <timezone id="Africa/Malabo" />
       </timezones>
       <tz-hint>Africa/Malabo</tz-hint>
+      <city>
+        <!-- A city in Equatorial Guinea -->
+        <name>Bata</name>
+        <coordinates>1.863910 9.765820</coordinates>
+        <location>
+          <name>Bata Airport</name>
+          <code>FGBT</code>
+          <coordinates>1.905470 9.805680</coordinates>
+        </location>
+      </city>
       <city>
         <!-- The capital of Equatorial Guinea -->
         <name>Malabo</name>
@@ -1045,16 +1376,22 @@
     <country>
       <!-- ET - Ethiopia -->
       <name>Ethiopia</name>
-      <!-- Could not find weather stations for the following major
-           cities:
-           Addis Ababa
-        -->
       <iso-code>ET</iso-code>
       <fips-code>ET</fips-code>
       <timezones>
         <timezone id="Africa/Addis_Ababa" />
       </timezones>
       <tz-hint>Africa/Addis_Ababa</tz-hint>
+      <city>
+        <!-- A city in Ethiopia -->
+        <name>Addis Ababa</name>
+        <coordinates>9.024970 38.746890</coordinates>
+        <location>
+          <name>Bole International Airport</name>
+          <code>HAAB</code>
+          <coordinates>8.977890 38.799300</coordinates>
+        </location>
+      </city>
     </country>
     <country>
       <!-- TF - French Southern Territories, a territory of France
@@ -1149,6 +1486,36 @@
           <coordinates>5.600000 -0.166667</coordinates>
         </location>
       </city>
+      <city>
+        <!-- A city in Ghana -->
+        <name>Kumasi</name>
+        <coordinates>6.688480 -1.624430</coordinates>
+        <location>
+          <name>Kumasi Airport</name>
+          <code>DGSI</code>
+          <coordinates>6.714560 -1.590820</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Ghana -->
+        <name>Sekondi-Takoradi</name>
+        <coordinates>4.926780 -1.757730</coordinates>
+        <location>
+          <name>Takoradi Airport</name>
+          <code>DGTK</code>
+          <coordinates>4.896060 -1.774760</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Ghana -->
+        <name>Tamale</name>
+        <coordinates>9.400790 -0.839300</coordinates>
+        <location>
+          <name>Tamale Airport</name>
+          <code>DGLE</code>
+          <coordinates>9.557190 -0.863210</coordinates>
+        </location>
+      </city>
     </country>
     <country>
       <!-- GN - Guinea -->
@@ -1169,20 +1536,46 @@
           <coordinates>9.566667 -13.616667</coordinates>
         </location>
       </city>
+      <city>
+        <!-- A city in Guinea -->
+        <name>Kankan</name>
+        <coordinates>10.385420 -9.305680</coordinates>
+        <location>
+          <name>Kankan Airport</name>
+          <code>GUXN</code>
+          <coordinates>10.394000 -9.303800</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Guinea -->
+        <name>Nzérékoré</name>
+        <coordinates>7.756240 -8.817900</coordinates>
+        <location>
+          <name>Nzerekore Airport</name>
+          <code>GUNZ</code>
+          <coordinates>7.806020 -8.701800</coordinates>
+        </location>
+      </city>
     </country>
     <country>
       <!-- GW - Guinea-Bissau -->
       <name>Guinea-Bissau</name>
-      <!-- Could not find weather stations for the following major
-           cities:
-           Bissau
-        -->
       <iso-code>GW</iso-code>
       <fips-code>PU</fips-code>
       <timezones>
         <timezone id="Africa/Bissau" />
       </timezones>
       <tz-hint>Africa/Bissau</tz-hint>
+      <city>
+        <!-- A city in Guinea-Bissau -->
+        <name>Bissau</name>
+        <coordinates>11.863570 -15.597670</coordinates>
+        <location>
+          <name>Osvaldo Vieira International Airport</name>
+          <code>GGOV</code>
+          <coordinates>11.894800 -15.653700</coordinates>
+        </location>
+      </city>
     </country>
     <country>
       <!-- KE - Kenya -->
@@ -1205,12 +1598,83 @@
       </city>
       <city>
         <!-- A city in Kenya -->
+        <name>Embu</name>
+        <coordinates>-0.539870 37.457430</coordinates>
+        <location>
+          <name>Embu Airport</name>
+          <code>HKEM</code>
+          <coordinates>-0.567000 37.483000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Kenya -->
+        <name>Garissa</name>
+        <coordinates>-0.452750 39.646010</coordinates>
+        <location>
+          <name>Garissa Airport</name>
+          <code>HKGA</code>
+          <coordinates>-0.463510 39.648300</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Kenya -->
         <name>Kisumu</name>
         <coordinates>-0.100000 34.750000</coordinates>
         <location>
           <name>Kisumu</name>
           <code>HKKI</code>
           <coordinates>-0.100000 34.750000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Kenya -->
+        <name>Kitale</name>
+        <coordinates>1.015720 35.006220</coordinates>
+        <location>
+          <name>Kitale Airport</name>
+          <code>HKKT</code>
+          <coordinates>0.971990 34.958600</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Kenya -->
+        <name>Lamu</name>
+        <coordinates>-2.271690 40.902010</coordinates>
+        <location>
+          <name>Manda Airstrip</name>
+          <code>HKLU</code>
+          <coordinates>-2.252420 40.913100</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Kenya -->
+        <name>Lodwar</name>
+        <coordinates>3.119880 35.596420</coordinates>
+        <location>
+          <name>Lodwar Airport</name>
+          <code>HKLO</code>
+          <coordinates>3.121970 35.608700</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Kenya -->
+        <name>Malindi</name>
+        <coordinates>-3.217990 40.116920</coordinates>
+        <location>
+          <name>Malindi Airport</name>
+          <code>HKML</code>
+          <coordinates>-3.229310 40.101700</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Kenya -->
+        <name>Meru</name>
+        <coordinates>0.046260 37.655870</coordinates>
+        <location>
+          <name>Meru</name>
+          <code>HKME</code>
+          <tz-hint>Africa/Nairobi</tz-hint>
+          <coordinates>0.083000 37.650000</coordinates>
         </location>
       </city>
       <city>
@@ -1232,6 +1696,41 @@
           <code>HKJK</code>
           <coordinates>-1.316667 36.916667</coordinates>
         </location>
+        <location>
+          <name>Nairobi Wilson Airport</name>
+          <code>HKNW</code>
+          <coordinates>-1.321720 36.814800</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Kenya -->
+        <name>Nakuru</name>
+        <coordinates>-0.307190 36.072250</coordinates>
+        <location>
+          <name>Nakuru Airport</name>
+          <code>HKNK</code>
+          <coordinates>-0.298070 36.159300</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Kenya -->
+        <name>Nyeri</name>
+        <coordinates>-0.420130 36.947590</coordinates>
+        <location>
+          <name>Nyeri Airport</name>
+          <code>HKNI</code>
+          <coordinates>-0.364410 36.978490</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Kenya -->
+        <name>Wajir</name>
+        <coordinates>1.747100 40.057320</coordinates>
+        <location>
+          <name>Wajir Airport</name>
+          <code>HKWJ</code>
+          <coordinates>1.733240 40.091600</coordinates>
+        </location>
       </city>
     </country>
     <country>
@@ -1247,20 +1746,36 @@
         <timezone id="Africa/Maseru" />
       </timezones>
       <tz-hint>Africa/Maseru</tz-hint>
+      <city>
+        <!-- A city in Lesotho -->
+        <name>Maseru (Mazenod)</name>
+        <coordinates>-29.316670 27.483330</coordinates>
+        <location>
+          <name>Moshoeshoe I International Airport</name>
+          <code>FXMM</code>
+          <coordinates>-29.462300 27.552500</coordinates>
+        </location>
+      </city>
     </country>
     <country>
       <!-- LR - Liberia -->
       <name msgctxt="Country">Liberia</name>
-      <!-- Could not find weather stations for the following major
-           cities:
-           Monrovia
-        -->
       <iso-code>LR</iso-code>
       <fips-code>LI</fips-code>
       <timezones>
         <timezone id="Africa/Monrovia" />
       </timezones>
       <tz-hint>Africa/Monrovia</tz-hint>
+      <city>
+        <!-- A city in Liberia -->
+        <name>Monrovia</name>
+        <coordinates>6.300540 -10.796900</coordinates>
+        <location>
+          <name>Roberts International Airport</name>
+          <code>GLRB</code>
+          <coordinates>6.233790 -10.362300</coordinates>
+        </location>
+      </city>
     </country>
     <country>
       <!-- LY - Libyan Arab Jamahiriya -->
@@ -1279,6 +1794,17 @@
           <name>Baninah</name>
           <code>HLLB</code>
           <coordinates>32.100000 20.266667</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Libya -->
+        <name>Misrata</name>
+        <coordinates>32.375350 15.092540</coordinates>
+        <location>
+          <name>Misrata International Airport</name>
+          <code>HLMS</code>
+          <tz-hint>Africa/Tripoli</tz-hint>
+          <coordinates>32.325001 15.061000</coordinates>
         </location>
       </city>
       <city>
@@ -1302,6 +1828,22 @@
           <name>Tripoli International Airport</name>
           <code>HLLT</code>
           <coordinates>32.666667 13.150000</coordinates>
+        </location>
+        <location>
+          <name>Mitiga Airport</name>
+          <code>HLLM</code>
+          <coordinates>32.894100 13.276000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Libya -->
+        <name>Ubari</name>
+        <coordinates>26.590340 12.775110</coordinates>
+        <location>
+          <name>Ubari Airport</name>
+          <code>HLUB</code>
+          <tz-hint>Africa/Tripoli</tz-hint>
+          <coordinates>26.567499 12.823100</coordinates>
         </location>
       </city>
     </country>
@@ -1398,20 +1940,107 @@
         <timezone id="Africa/Blantyre" />
       </timezones>
       <tz-hint>Africa/Blantyre</tz-hint>
+      <city>
+        <!-- A city in Malawi -->
+        <name>Blantyre</name>
+        <coordinates>-15.784990 35.008540</coordinates>
+        <location>
+          <name>Chileka International Airport</name>
+          <code>FWCL</code>
+          <coordinates>-15.679100 34.974000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Malawi -->
+        <name>Karonga</name>
+        <coordinates>-9.933330 33.933330</coordinates>
+        <location>
+          <name>Karonga Airport</name>
+          <code>FWKA</code>
+          <coordinates>-9.953570 33.893000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Malawi -->
+        <name>Lumbadzi</name>
+        <coordinates>-13.789400 33.781000</coordinates>
+        <location>
+          <name>Lilongwe International Airport</name>
+          <code>FWKI</code>
+          <coordinates>-13.789400 33.781000</coordinates>
+        </location>
+      </city>
     </country>
     <country>
       <!-- ML - Mali -->
       <name>Mali</name>
-      <!-- Could not find weather stations for the following major
-           cities:
-           Bamako
-        -->
       <iso-code>ML</iso-code>
       <fips-code>ML</fips-code>
       <timezones>
         <timezone id="Africa/Bamako" />
       </timezones>
       <tz-hint>Africa/Bamako</tz-hint>
+      <city>
+        <!-- A city in Mali -->
+        <name>Bamako</name>
+        <coordinates>12.609150 -7.975220</coordinates>
+        <location>
+          <name>Senou Airport</name>
+          <code>GABS</code>
+          <coordinates>12.533500 -7.949940</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Mali -->
+        <name>Gao</name>
+        <coordinates>16.271670 -0.044720</coordinates>
+        <location>
+          <name>Gao Airport</name>
+          <code>GAGO</code>
+          <coordinates>16.248400 -0.005460</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Mali -->
+        <name>Kayes</name>
+        <coordinates>14.447760 -11.443930</coordinates>
+        <location>
+          <name>Kayes Dag Dag Airport</name>
+          <code>GAKD</code>
+          <tz-hint>Africa/Bamako</tz-hint>
+          <coordinates>14.482521 -11.399335</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Mali -->
+        <name>Nioro du Sahel</name>
+        <coordinates>15.230740 -9.593560</coordinates>
+        <location>
+          <name>Nioro du Sahel Airport</name>
+          <code>GANR</code>
+          <coordinates>15.238100 -9.576110</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Mali -->
+        <name>Sévaré</name>
+        <coordinates>14.512800 -4.079560</coordinates>
+        <location>
+          <name>Ambodedjo Airport</name>
+          <code>GAMB</code>
+          <coordinates>14.512800 -4.079560</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Mali -->
+        <name>Timbuktu</name>
+        <coordinates>16.773480 -3.007420</coordinates>
+        <location>
+          <name>Timbuktu Airport</name>
+          <code>GATB</code>
+          <coordinates>16.730500 -3.007580</coordinates>
+        </location>
+      </city>
     </country>
     <country>
       <!-- MR - Mauritania -->
@@ -1422,6 +2051,16 @@
         <timezone id="Africa/Nouakchott" />
       </timezones>
       <tz-hint>Africa/Nouakchott</tz-hint>
+      <city>
+        <!-- A city in Mauritania -->
+        <name>Atar</name>
+        <coordinates>20.518750 -13.046370</coordinates>
+        <location>
+          <name>Atar International Airport</name>
+          <code>GQPA</code>
+          <coordinates>20.506800 -13.043200</coordinates>
+        </location>
+      </city>
       <city>
         <!-- A city in Mauritania -->
         <name>Nouadhibou</name>
@@ -1440,6 +2079,22 @@
           <name>Nouakchott</name>
           <code>GQNN</code>
           <coordinates>18.100000 -15.950000</coordinates>
+        </location>
+        <location>
+          <name>Nouakchott–Oumtounsy International Airport</name>
+          <code>GQNO</code>
+          <tz-hint>Africa/Nouakchott</tz-hint>
+          <coordinates>18.310000 -15.969722</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Mauritania -->
+        <name>Néma</name>
+        <coordinates>16.617020 -7.256490</coordinates>
+        <location>
+          <name>Nema Airport</name>
+          <code>GQNI</code>
+          <coordinates>16.622000 -7.316600</coordinates>
         </location>
       </city>
     </country>
@@ -1482,6 +2137,16 @@
           <coordinates>-19.683333 63.416667</coordinates>
         </location>
       </city>
+      <city>
+        <!-- A city in Mauritius -->
+        <name>Vingt Cinq</name>
+        <coordinates>-10.388030 56.617950</coordinates>
+        <location>
+          <name>Agalega Island Airstrip</name>
+          <code>FIMA</code>
+          <coordinates>-10.373100 56.609800</coordinates>
+        </location>
+      </city>
     </country>
     <country>
       <!-- YT - Mayotte -->
@@ -1516,9 +2181,6 @@
     <country>
       <!-- MA - Morocco -->
       <name>Morocco</name>
-      <!-- Could not find cities for the following weather stations:
-           GMML - Laayoune, Hassan Isl Airport (27.166667 -13.216389)
-        -->
       <iso-code>MA</iso-code>
       <fips-code>MO</fips-code>
       <timezones>
@@ -1547,12 +2209,62 @@
       </city>
       <city>
         <!-- A city in Morocco -->
+        <name>Ben Slimane</name>
+        <coordinates>33.655400 -7.221450</coordinates>
+        <location>
+          <name>Ben Slimane Airport</name>
+          <code>GMMB</code>
+          <coordinates>33.655400 -7.221450</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Morocco -->
+        <name>Casablanca</name>
+        <coordinates>33.588310 -7.611380</coordinates>
+        <location>
+          <name>Anfa</name>
+          <code>GMMC</code>
+          <coordinates>33.557000 -7.660000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Morocco -->
+        <name>Errachidia</name>
+        <coordinates>31.931400 -4.426630</coordinates>
+        <location>
+          <name>Moulay Ali Cherif Airport</name>
+          <code>GMFK</code>
+          <coordinates>31.947500 -4.398330</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Morocco -->
+        <name>Essaouira</name>
+        <coordinates>31.512500 -9.770000</coordinates>
+        <location>
+          <name>Mogador Airport</name>
+          <code>GMMI</code>
+          <coordinates>31.397500 -9.681670</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Morocco -->
         <name>Fes</name>
         <coordinates>34.050000 -4.980000</coordinates>
         <location>
           <name>Fes-Sais</name>
           <code>GMFF</code>
           <coordinates>33.933333 -4.983333</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Morocco -->
+        <name>Guelmim</name>
+        <coordinates>28.986960 -10.057380</coordinates>
+        <location>
+          <name>Guelmim Airport</name>
+          <code>GMAG</code>
+          <coordinates>29.026699 -10.050300</coordinates>
         </location>
       </city>
       <city>
@@ -1616,6 +2328,16 @@
         </location>
       </city>
       <city>
+        <!-- A city in Morocco -->
+        <name>Oulad Yaich</name>
+        <coordinates>32.434980 -6.324500</coordinates>
+        <location>
+          <name>Beni Mellal Airport</name>
+          <code>GMMD</code>
+          <coordinates>32.400000 -6.333330</coordinates>
+        </location>
+      </city>
+      <city>
         <!-- The capital of Morocco -->
         <name>Rabat</name>
         <coordinates>34.020000 -6.830000</coordinates>
@@ -1623,6 +2345,16 @@
           <name>Rabat-Sale</name>
           <code>GMME</code>
           <coordinates>34.050000 -6.766667</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Morocco -->
+        <name>Tan Tan</name>
+        <coordinates>28.448200 -11.161300</coordinates>
+        <location>
+          <name>Tan Tan Airport</name>
+          <code>GMAT</code>
+          <coordinates>28.448200 -11.161300</coordinates>
         </location>
       </city>
       <city>
@@ -1680,6 +2412,16 @@
       </city>
       <city>
         <!-- A city in Mozambique -->
+        <name>Inhambane</name>
+        <coordinates>-23.865000 35.383330</coordinates>
+        <location>
+          <name>Inhambane Airport</name>
+          <code>FQIN</code>
+          <coordinates>-23.876400 35.408500</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Mozambique -->
         <name>Lichinga</name>
         <coordinates>-13.312778 35.240556</coordinates>
         <location>
@@ -1696,6 +2438,16 @@
           <name>Maputo / Mavalane</name>
           <code>FQMA</code>
           <coordinates>-25.916667 32.566667</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Mozambique -->
+        <name>Nacala</name>
+        <coordinates>-14.562570 40.685380</coordinates>
+        <location>
+          <name>Nacala Airport</name>
+          <code>FQNC</code>
+          <coordinates>-14.488200 40.712200</coordinates>
         </location>
       </city>
       <city>
@@ -1728,6 +2480,36 @@
           <coordinates>-17.883333 36.883333</coordinates>
         </location>
       </city>
+      <city>
+        <!-- A city in Mozambique -->
+        <name>Tete</name>
+        <coordinates>-16.156390 33.586670</coordinates>
+        <location>
+          <name>Chingozi Airport</name>
+          <code>FQTT</code>
+          <coordinates>-16.104800 33.640200</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Mozambique -->
+        <name>Vilanculo</name>
+        <coordinates>-22.000000 35.316670</coordinates>
+        <location>
+          <name>Vilankulo Airport</name>
+          <code>FQVL</code>
+          <coordinates>-22.018400 35.313300</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Mozambique -->
+        <name>Xai-Xai</name>
+        <coordinates>-25.051940 33.644170</coordinates>
+        <location>
+          <name>Xai-Xai Airport</name>
+          <code>FQXA</code>
+          <coordinates>-25.037800 33.627400</coordinates>
+        </location>
+      </city>
     </country>
     <country>
       <!-- NA - Namibia -->
@@ -1739,6 +2521,77 @@
       </timezones>
       <tz-hint>Africa/Windhoek</tz-hint>
       <city>
+        <!-- A city in Namibia -->
+        <name>Grootfontein</name>
+        <coordinates>-19.573280 18.100300</coordinates>
+        <location>
+          <name>Grootfontein Airport</name>
+          <code>FYGF</code>
+          <coordinates>-19.602200 18.122700</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Namibia -->
+        <name>Luderitz</name>
+        <coordinates>-26.648070 15.153830</coordinates>
+        <location>
+          <name>Luderitz Airport</name>
+          <code>FYLZ</code>
+          <coordinates>-26.687400 15.242900</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Namibia -->
+        <name>Mpacha</name>
+        <coordinates>-17.634400 24.176700</coordinates>
+        <location>
+          <name>Katima Mulilo Airport</name>
+          <code>FYKM</code>
+          <coordinates>-17.634400 24.176700</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Namibia -->
+        <name>Ondangwa</name>
+        <coordinates>-17.908240 15.980370</coordinates>
+        <location>
+          <name>Ondangwa Airport</name>
+          <code>FYOA</code>
+          <coordinates>-17.878200 15.952600</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Namibia -->
+        <name>Oranjemund</name>
+        <coordinates>-28.551530 16.427280</coordinates>
+        <location>
+          <name>Oranjemund Airport</name>
+          <code>FYOG</code>
+          <coordinates>-28.584700 16.446700</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Namibia -->
+        <name>Rundu</name>
+        <coordinates>-17.917960 19.773140</coordinates>
+        <location>
+          <name>Rundu Airport</name>
+          <code>FYRU</code>
+          <coordinates>-17.956500 19.719400</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Namibia -->
+        <name>Walvis Bay (Rooikop)</name>
+        <coordinates>-22.957500 14.505280</coordinates>
+        <location>
+          <name>Walvis Bay Airport</name>
+          <code>FYWB</code>
+          <coordinates>-22.979900 14.645300</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Namibia -->
 	<name>Windhoek</name>
 	<coordinates>-22.57 17.083611</coordinates>
 	<location>
@@ -1746,6 +2599,11 @@
 	  <code>FYWH</code>
 	  <coordinates>-22.486667 17.4625</coordinates>
 	</location>
+        <location>
+          <name>Eros Airport</name>
+          <code>FYWE</code>
+          <coordinates>-22.612200 17.080400</coordinates>
+        </location>
       </city>
     </country>
     <country>
@@ -1768,6 +2626,26 @@
         </location>
       </city>
       <city>
+        <!-- A city in Niger -->
+        <name>Diffa</name>
+        <coordinates>13.315360 12.611350</coordinates>
+        <location>
+          <name>Diffa Airport</name>
+          <code>DRZF</code>
+          <coordinates>13.372900 12.626700</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Niger -->
+        <name>Maradi</name>
+        <coordinates>13.500000 7.101740</coordinates>
+        <location>
+          <name>Maradi Airport</name>
+          <code>DRRM</code>
+          <coordinates>13.502500 7.126750</coordinates>
+        </location>
+      </city>
+      <city>
         <!-- The capital of Niger -->
         <name>Niamey</name>
         <coordinates>13.516667 2.116667</coordinates>
@@ -1775,6 +2653,16 @@
           <name>Niamey Airport</name>
           <code>DRRN</code>
           <coordinates>13.483333 2.166667</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Niger -->
+        <name>Tahoua</name>
+        <coordinates>14.888800 5.269200</coordinates>
+        <location>
+          <name>Tahoua Airport</name>
+          <code>DRRT</code>
+          <coordinates>14.875700 5.265360</coordinates>
         </location>
       </city>
       <city>
@@ -1791,10 +2679,6 @@
     <country>
       <!-- NG - Nigeria -->
       <name>Nigeria</name>
-      <!-- Could not find information about the following stations,
-           which may be in Nigeria:
-           DNAA DNMN 
-        -->
       <iso-code>NG</iso-code>
       <fips-code>NI</fips-code>
       <timezones>
@@ -1802,12 +2686,73 @@
       </timezones>
       <tz-hint>Africa/Lagos</tz-hint>
       <city>
+        <!-- A city in Nigeria -->
 	<name>Abuja</name>
 	<coordinates>9.0066666667 7.2630555556</coordinates>
 	<location>
 	  <name>Abuja</name>
 	  <code>DNAA</code>
 	  <coordinates>9.0066666667 7.2630555556</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Nigeria -->
+        <name>Akure</name>
+        <coordinates>7.252560 5.193120</coordinates>
+        <location>
+          <name>Akure Airport</name>
+          <code>DNAK</code>
+          <coordinates>7.246740 5.301010</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Nigeria -->
+        <name>Benin</name>
+        <coordinates>6.338150 5.625750</coordinates>
+        <location>
+          <name>Benin Airport</name>
+          <code>DNBE</code>
+          <coordinates>6.316980 5.599500</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Nigeria -->
+        <name>Calabar</name>
+        <coordinates>4.958930 8.326950</coordinates>
+        <location>
+          <name>Margaret Ekpo International Airport</name>
+          <code>DNCA</code>
+          <coordinates>4.976020 8.347200</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Nigeria -->
+        <name>Enegu</name>
+        <coordinates>6.474270 7.561960</coordinates>
+        <location>
+          <name>Akanu Ibiam International Airport</name>
+          <code>DNEN</code>
+          <coordinates>6.474270 7.561960</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Nigeria -->
+        <name>Gombe</name>
+        <coordinates>10.289690 11.167290</coordinates>
+        <location>
+          <name>Gombe Lawanti International Airport</name>
+          <code>DNGO</code>
+          <coordinates>10.298330 10.896390</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Nigeria -->
+        <name>Ibadan</name>
+        <coordinates>7.377560 3.905910</coordinates>
+        <location>
+          <name>Ibadan Airport</name>
+          <code>DNIB</code>
+          <coordinates>7.362460 3.978330</coordinates>
         </location>
       </city>
       <city>
@@ -1832,6 +2777,16 @@
       </city>
       <city>
         <!-- A city in Nigeria -->
+        <name>Jos</name>
+        <coordinates>9.928490 8.892120</coordinates>
+        <location>
+          <name>Yakubu Gowon Airport</name>
+          <code>DNJO</code>
+          <coordinates>9.639830 8.869050</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Nigeria -->
         <name>Kaduna</name>
         <coordinates>10.523056 7.440278</coordinates>
         <location>
@@ -1852,6 +2807,56 @@
       </city>
       <city>
         <!-- A city in Nigeria -->
+        <name>Katsina</name>
+        <coordinates>12.990820 7.601770</coordinates>
+        <location>
+          <name>Umaru Musa Yar'adua Airport</name>
+          <code>DNKT</code>
+          <coordinates>13.007800 7.660450</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Nigeria -->
+        <name>Maiduguri</name>
+        <coordinates>11.846920 13.157120</coordinates>
+        <location>
+          <name>Maiduguri International Airport</name>
+          <code>DNMA</code>
+          <coordinates>11.855300 13.080900</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Nigeria -->
+        <name>Minna</name>
+        <coordinates>9.615240 6.547760</coordinates>
+        <location>
+          <name>Minna Airport</name>
+          <code>DNMN</code>
+          <coordinates>9.652170 6.462260</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Nigeria -->
+        <name>Okpe</name>
+        <coordinates>5.598210 5.818700</coordinates>
+        <location>
+          <name>Warri Airport</name>
+          <code>DNSU</code>
+          <coordinates>5.598210 5.818700</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Nigeria -->
+        <name>Owerri</name>
+        <coordinates>5.483630 7.033250</coordinates>
+        <location>
+          <name>Sam Mbakwe International Airport</name>
+          <code>DNIM</code>
+          <coordinates>5.427060 7.206030</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Nigeria -->
         <name>Port Harcourt</name>
         <coordinates>4.789167 6.998611</coordinates>
         <location>
@@ -1860,20 +2865,56 @@
           <coordinates>4.850000 7.016667</coordinates>
         </location>
       </city>
+      <city>
+        <!-- A city in Nigeria -->
+        <name>Sokoto</name>
+        <coordinates>13.062690 5.243220</coordinates>
+        <location>
+          <name>Sadiq Abubakar III International Airport</name>
+          <code>DNSO</code>
+          <coordinates>12.916300 5.207190</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Nigeria -->
+        <name>Yola</name>
+        <coordinates>9.208390 12.481460</coordinates>
+        <location>
+          <name>Yola Airport</name>
+          <code>DNYO</code>
+          <coordinates>9.257550 12.430400</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Nigeria -->
+        <name>Zaria</name>
+        <coordinates>11.111280 7.722700</coordinates>
+        <location>
+          <name>Zaria Airport</name>
+          <code>DNZA</code>
+          <coordinates>11.130200 7.685810</coordinates>
+        </location>
+      </city>
     </country>
     <country>
       <!-- RW - Rwanda -->
       <name>Rwanda</name>
-      <!-- Could not find weather stations for the following major
-           cities:
-           Kigali
-        -->
       <iso-code>RW</iso-code>
       <fips-code>RW</fips-code>
       <timezones>
         <timezone id="Africa/Kigali" />
       </timezones>
       <tz-hint>Africa/Kigali</tz-hint>
+      <city>
+        <!-- A city in Rwanda -->
+        <name>Kigali</name>
+        <coordinates>-1.949950 30.058850</coordinates>
+        <location>
+          <name>Kigali International Airport</name>
+          <code>HRYR</code>
+          <coordinates>-1.968630 30.139500</coordinates>
+        </location>
+      </city>
     </country>
     <country>
       <!-- RE - Réunion, an overseas department of France in the Indian
@@ -1913,16 +2954,22 @@
            name does not have the accents.
         -->
       <name>Sao Tome and Principe</name>
-      <!-- Could not find weather stations for the following major
-           cities:
-           São Tomé
-        -->
       <iso-code>ST</iso-code>
       <fips-code>TP</fips-code>
       <timezones>
         <timezone id="Africa/Sao_Tome" />
       </timezones>
       <tz-hint>Africa/Sao_Tome</tz-hint>
+      <city>
+        <!-- A city in Sao Tome and Principe -->
+        <name>São Tomé</name>
+        <coordinates>0.337560 6.729900</coordinates>
+        <location>
+          <name>Sao Tome International Airport</name>
+          <code>FPST</code>
+          <coordinates>0.378170 6.712150</coordinates>
+        </location>
+      </city>
     </country>
     <country>
       <!-- SN - Senegal -->
@@ -1951,6 +2998,84 @@
           <name>Dakar-Yoff Airport</name>
           <code>GOOY</code>
           <coordinates>14.733333 -17.500000</coordinates>
+        </location>
+        <location>
+          <name>Blaise Diagne International Airport</name>
+          <code>GOBD</code>
+          <coordinates>14.671110 -17.066940</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Senegal -->
+        <name>Diourbel</name>
+        <coordinates>14.647920 -16.243630</coordinates>
+        <location>
+          <name>Diourbel</name>
+          <code>GOOD</code>
+          <tz-hint>Africa/Dakar</tz-hint>
+          <coordinates>14.650000 -16.233000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Senegal -->
+        <name>Kaolack</name>
+        <coordinates>14.151970 -16.072590</coordinates>
+        <location>
+          <name>Kaolack Airport</name>
+          <code>GOOK</code>
+          <coordinates>14.146900 -16.051300</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Senegal -->
+        <name>Kolda</name>
+        <coordinates>12.893900 -14.941250</coordinates>
+        <location>
+          <name>Kolda</name>
+          <code>GOGK</code>
+          <tz-hint>Africa/Dakar</tz-hint>
+          <coordinates>12.883000 -14.967000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Senegal -->
+        <name>Kédougou</name>
+        <coordinates>12.555610 -12.180760</coordinates>
+        <location>
+          <name>Kedougou Airport</name>
+          <code>GOTK</code>
+          <coordinates>12.572300 -12.220300</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Senegal -->
+        <name>Linguère</name>
+        <coordinates>15.395300 -15.119300</coordinates>
+        <location>
+          <name>Linguère Airport</name>
+          <code>GOOG</code>
+          <tz-hint>Africa/Dakar</tz-hint>
+          <coordinates>15.402134 -15.080629</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Senegal -->
+        <name>Ouro Sogui</name>
+        <coordinates>15.605880 -13.322300</coordinates>
+        <location>
+          <name>Ouro Sogui Airport</name>
+          <code>GOSM</code>
+          <coordinates>15.593600 -13.322800</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Senegal -->
+        <name>Podor</name>
+        <coordinates>16.648920 -14.960730</coordinates>
+        <location>
+          <name>Podor Airport</name>
+          <code>GOSP</code>
+          <coordinates>16.683000 -14.967000</coordinates>
         </location>
       </city>
       <city>
@@ -2047,23 +3172,39 @@
     <country>
       <!-- SO - Somalia -->
       <name>Somalia</name>
-      <!-- Could not find weather stations for the following major
-           cities:
-           Mogadishu
-        -->
       <iso-code>SO</iso-code>
       <fips-code>SO</fips-code>
       <timezones>
         <timezone id="Africa/Mogadishu" />
       </timezones>
       <tz-hint>Africa/Mogadishu</tz-hint>
+      <city>
+        <!-- A city in Somalia -->
+        <name>Bosaso</name>
+        <coordinates>11.284210 49.181580</coordinates>
+        <location>
+          <name>Bosaso Airport</name>
+          <code>HCMF</code>
+          <coordinates>11.275300 49.149400</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Somalia -->
+        <name>Mogadishu</name>
+        <coordinates>2.037110 45.343750</coordinates>
+        <location>
+          <name>Aden Adde International Airport</name>
+          <code>HCMM</code>
+          <coordinates>2.014440 45.304700</coordinates>
+        </location>
+      </city>
     </country>
     <country>
       <!-- ZA - South Africa -->
       <name>South Africa</name>
       <!-- Could not find information about the following stations,
            which may be in South Africa:
-           FAGC FAJB FAKN FAPN FAPP 
+           FAGC
         -->
       <iso-code>ZA</iso-code>
       <fips-code>SF</fips-code>
@@ -2073,12 +3214,32 @@
       <tz-hint>Africa/Johannesburg</tz-hint>
       <city>
         <!-- A city in South Africa -->
+        <name>Bethlehem</name>
+        <coordinates>-28.230780 28.307070</coordinates>
+        <location>
+          <name>Bethlehem Airport</name>
+          <code>FABM</code>
+          <coordinates>-28.248400 28.336100</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in South Africa -->
         <name>Bloemfontein</name>
         <coordinates>-29.133333 26.200000</coordinates>
         <location>
           <name>Bloemfontein Airport</name>
           <code>FABL</code>
           <coordinates>-29.100000 26.300000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in South Africa -->
+        <name>Calvinia</name>
+        <coordinates>-31.470690 19.776010</coordinates>
+        <location>
+          <name>Calvinia Airport</name>
+          <code>FACV</code>
+          <coordinates>-31.500300 19.725900</coordinates>
         </location>
       </city>
       <city>
@@ -2093,12 +3254,67 @@
       </city>
       <city>
         <!-- A city in South Africa -->
+        <name>De Aar</name>
+        <coordinates>-30.649660 24.012300</coordinates>
+        <location>
+          <name>De Aar Military Airport</name>
+          <code>FADY</code>
+          <coordinates>-30.636510 23.919730</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in South Africa -->
         <name>Durban</name>
         <coordinates>-29.850000 31.016667</coordinates>
         <location>
           <name>Durban International Airport</name>
           <code>FADN</code>
           <coordinates>-29.966667 30.950000</coordinates>
+        </location>
+        <location>
+          <name>King Shaka International Airport</name>
+          <code>FALE</code>
+          <coordinates>-29.614440 31.119720</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in South Africa -->
+        <name>East London</name>
+        <coordinates>-33.015290 27.911620</coordinates>
+        <location>
+          <name>Ben Schoeman Airport</name>
+          <code>FAEL</code>
+          <coordinates>-33.035600 27.825900</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in South Africa -->
+        <name>Ermelo</name>
+        <coordinates>-26.533330 29.983330</coordinates>
+        <location>
+          <name>Ermelo Airport</name>
+          <code>FAEO</code>
+          <coordinates>-26.495600 29.979800</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in South Africa -->
+        <name>George</name>
+        <coordinates>-33.963000 22.461730</coordinates>
+        <location>
+          <name>George Airport</name>
+          <code>FAGG</code>
+          <coordinates>-34.005600 22.378900</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in South Africa -->
+        <name>Hoedspruit</name>
+        <coordinates>-24.351220 30.953320</coordinates>
+        <location>
+          <name>Hoedspruit Air Force Base Airport</name>
+          <code>FAHS</code>
+          <coordinates>-24.368600 31.048700</coordinates>
         </location>
       </city>
       <city>
@@ -2115,6 +3331,26 @@
           <code>FALA</code>
           <coordinates>-25.933333 27.933333</coordinates>
         </location>
+        <location>
+          <name>O. R. Tambo International Airport</name>
+          <code>FAOR</code>
+          <coordinates>-26.133670 28.242330</coordinates>
+        </location>
+        <location>
+          <name>Rand Airport</name>
+          <code>FAGM</code>
+          <coordinates>-26.242500 28.151200</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in South Africa -->
+        <name>Kimberley</name>
+        <coordinates>-28.732260 24.762320</coordinates>
+        <location>
+          <name>Kimberley Airport</name>
+          <code>FAKM</code>
+          <coordinates>-28.802800 24.765200</coordinates>
+        </location>
       </city>
       <city>
         <!-- A city in South Africa -->
@@ -2124,6 +3360,66 @@
           <name>Klerksdorp</name>
           <code>FAKD</code>
           <coordinates>-26.866667 26.716667</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in South Africa -->
+        <name>Langebaanweg</name>
+        <coordinates>-32.968900 18.160300</coordinates>
+        <location>
+          <name>Langebaanweg Airport</name>
+          <code>FALW</code>
+          <coordinates>-32.968900 18.160300</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in South Africa -->
+        <name>Mafeking</name>
+        <coordinates>-25.865220 25.644210</coordinates>
+        <location>
+          <name>Mmabatho International Airport</name>
+          <code>FAMM</code>
+          <coordinates>-25.798400 25.548000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in South Africa -->
+        <name>Mbombela</name>
+        <coordinates>-25.475120 30.969350</coordinates>
+        <location>
+          <name>Kruger Mpumalanga International Airport</name>
+          <code>FAKN</code>
+          <coordinates>-25.383200 31.105600</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in South Africa -->
+        <name>Mthatha</name>
+        <coordinates>-31.588930 28.784430</coordinates>
+        <location>
+          <name>K. D. Matanzima Airport</name>
+          <code>FAUT</code>
+          <coordinates>-31.547900 28.674300</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in South Africa -->
+        <name>Pilanesberg</name>
+        <coordinates>-25.333800 27.173400</coordinates>
+        <location>
+          <name>Pilanesberg International Airport</name>
+          <code>FAPN</code>
+          <coordinates>-25.333800 27.173400</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in South Africa -->
+        <name>Polokwane</name>
+        <coordinates>-23.904490 29.468850</coordinates>
+        <location>
+          <name>Polokwane International Airport</name>
+          <code>FAPP</code>
+          <coordinates>-23.845300 29.458600</coordinates>
         </location>
       </city>
       <city>
@@ -2154,6 +3450,41 @@
           <name>Lanseria</name>
           <code>FALA</code>
           <coordinates>-25.933333 27.933333</coordinates>
+        </location>
+        <location>
+          <name>Pretoria/Irene</name>
+          <code>FAIR</code>
+          <coordinates>-25.911000 28.210000</coordinates>
+        </location>
+        <location>
+          <name>Waterkloof Air Force Base</name>
+          <code>FAWK</code>
+          <coordinates>-25.830000 28.222500</coordinates>
+        </location>
+        <location>
+          <name>Wonderboom Airport</name>
+          <code>FAWB</code>
+          <coordinates>-25.653900 28.224200</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in South Africa -->
+        <name>Soweto</name>
+        <coordinates>-26.267810 27.858490</coordinates>
+        <location>
+          <name>Johannesburg Baragwanath</name>
+          <code>FAJB</code>
+          <coordinates>-26.348000 27.778000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in South Africa -->
+        <name>Springbok</name>
+        <coordinates>-29.664340 17.886500</coordinates>
+        <location>
+          <name>Springbok Airport</name>
+          <code>FASB</code>
+          <coordinates>-29.689300 17.939600</coordinates>
         </location>
       </city>
       <city>
@@ -2253,14 +3584,20 @@
           <coordinates>-26.533333 31.300000</coordinates>
         </location>
       </city>
+      <city>
+        <!-- A city in Swaziland -->
+        <name>Mpaka</name>
+        <coordinates>-26.356940 31.717220</coordinates>
+        <location>
+          <name>King Mswati III Intl</name>
+          <code>FDSK</code>
+          <coordinates>-26.356940 31.717220</coordinates>
+        </location>
+      </city>
     </country>
     <country>
       <!-- TZ - United Republic of Tanzania -->
       <name>Tanzania</name>
-      <!-- Could not find information about the following stations,
-           which may be in Tanzania:
-           HTSU 
-        -->
       <iso-code>TZ</iso-code>
       <fips-code>TZ</fips-code>
       <timezones>
@@ -2336,6 +3673,12 @@
           <code>HTMB</code>
           <coordinates>-8.933333 33.466667</coordinates>
         </location>
+        <location>
+          <name>Songwe Airport</name>
+          <code>HTGW</code>
+          <tz-hint>Africa/Dar_es_Salaam</tz-hint>
+          <coordinates>-8.919942 33.273981</coordinates>
+        </location>
       </city>
       <city>
         <!-- A city in Tanzania -->
@@ -2355,6 +3698,16 @@
           <name>Kilimanjaro Airport</name>
           <code>HTKJ</code>
           <coordinates>-3.416667 37.066667</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Tanzania -->
+        <name>Mpanda</name>
+        <coordinates>-6.343790 31.069510</coordinates>
+        <location>
+          <name>Mpanda Airport</name>
+          <code>HTMP</code>
+          <coordinates>-6.350000 31.083000</coordinates>
         </location>
       </city>
       <city>
@@ -2399,12 +3752,32 @@
       </city>
       <city>
         <!-- A city in Tanzania -->
+        <name>Sumbawanga</name>
+        <coordinates>-7.966670 31.616670</coordinates>
+        <location>
+          <name>Sumbawanga Airport</name>
+          <code>HTSU</code>
+          <coordinates>-7.967000 31.667000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Tanzania -->
         <name>Tabora</name>
         <coordinates>-5.016667 32.800000</coordinates>
         <location>
           <name>Tabora Airport</name>
           <code>HTTB</code>
           <coordinates>-5.083333 32.833333</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Tanzania -->
+        <name>Tanga</name>
+        <coordinates>-5.068930 39.098750</coordinates>
+        <location>
+          <name>Tanga Airport</name>
+          <code>HTTG</code>
+          <coordinates>-5.092360 39.071200</coordinates>
         </location>
       </city>
       <city>
@@ -2447,6 +3820,16 @@
           <coordinates>9.766667 1.100000</coordinates>
         </location>
       </city>
+      <city>
+        <!-- A city in Togo -->
+        <name>Sokodé</name>
+        <coordinates>8.983330 1.133330</coordinates>
+        <location>
+          <name>Sokode Airport</name>
+          <code>DXSK</code>
+          <coordinates>8.983000 1.150000</coordinates>
+        </location>
+      </city>
     </country>
     <country>
       <!-- TN - Tunisia -->
@@ -2475,6 +3858,16 @@
           <name>El Borma</name>
           <code>DTTR</code>
           <coordinates>31.683333 9.166667</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Tunisia -->
+        <name>Enfidha</name>
+        <coordinates>36.135280 10.380830</coordinates>
+        <location>
+          <name>Enfidha-Hammamet International Airport</name>
+          <code>DTNH</code>
+          <coordinates>36.075830 10.438610</coordinates>
         </location>
       </city>
       <city>
@@ -2629,6 +4022,26 @@
       </city>
       <city>
         <!-- A city in Uganda -->
+        <name>Gulu</name>
+        <coordinates>2.774570 32.298990</coordinates>
+        <location>
+          <name>Gulu Airport</name>
+          <code>HUGU</code>
+          <coordinates>2.805560 32.271800</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Uganda -->
+        <name>Jinja</name>
+        <coordinates>0.439020 33.203170</coordinates>
+        <location>
+          <name>Jinja Airport</name>
+          <code>HUJI</code>
+          <coordinates>0.450000 33.200000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Uganda -->
         <name>Kabale</name>
         <coordinates>-1.326111 30.003889</coordinates>
         <location>
@@ -2647,6 +4060,66 @@
           <coordinates>0.050000 32.450000</coordinates>
         </location>
       </city>
+      <city>
+        <!-- A city in Uganda -->
+        <name>Kasese</name>
+        <coordinates>0.183330 30.083330</coordinates>
+        <location>
+          <name>Kasese Airport</name>
+          <code>HUKS</code>
+          <coordinates>0.183000 30.100000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Uganda -->
+        <name>Lira</name>
+        <coordinates>2.249900 32.899850</coordinates>
+        <location>
+          <name>Lira Airport</name>
+          <code>HULI</code>
+          <coordinates>2.250000 32.917000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Uganda -->
+        <name>Masindi</name>
+        <coordinates>1.674440 31.715000</coordinates>
+        <location>
+          <name>Masindi Airport</name>
+          <code>HUMI</code>
+          <coordinates>1.758060 31.736700</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Uganda -->
+        <name>Mbarara</name>
+        <coordinates>-0.604670 30.648510</coordinates>
+        <location>
+          <name>Mbarara Airport</name>
+          <code>HUMA</code>
+          <coordinates>-0.555280 30.599400</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Uganda -->
+        <name>Soroti</name>
+        <coordinates>1.714640 33.611130</coordinates>
+        <location>
+          <name>Soroti Airport</name>
+          <code>HUSO</code>
+          <coordinates>1.727690 33.622800</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Uganda -->
+        <name>Tororo</name>
+        <coordinates>0.692990 34.180850</coordinates>
+        <location>
+          <name>Tororo Airport</name>
+          <code>HUTO</code>
+          <coordinates>0.683000 34.167000</coordinates>
+        </location>
+      </city>
     </country>
     <country>
       <!-- EH - Western Sahara, a disputed territory in western Africa -->
@@ -2657,6 +4130,28 @@
         <timezone id="Africa/El_Aaiun" />
       </timezones>
       <tz-hint>Africa/El_Aaiun</tz-hint>
+      <city>
+        <!-- A city in Western Sahara -->
+        <name>Dakhla</name>
+        <coordinates>23.684770 -15.957980</coordinates>
+        <location>
+          <name>Dakhla Airport</name>
+          <code>GMMH</code>
+          <tz-hint>Africa/El_Aaiun</tz-hint>
+          <coordinates>23.718300 -15.932000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Western Sahara -->
+        <name>El Aaiún</name>
+        <coordinates>27.141800 -13.187970</coordinates>
+        <location>
+          <name>Hassan I Airport</name>
+          <code>GMML</code>
+          <tz-hint>Africa/El_Aaiun</tz-hint>
+          <coordinates>27.151700 -13.219200</coordinates>
+        </location>
+      </city>
     </country>
     <country>
       <!-- ZM - Zambia -->
@@ -2686,6 +4181,12 @@
           <code>FLLI</code>
           <coordinates>-17.816667 25.816667</coordinates>
         </location>
+        <location>
+          <name>Harry Mwanga Nkumbula International Airport</name>
+          <code>FLHN</code>
+          <tz-hint>Africa/Lusaka</tz-hint>
+          <coordinates>-17.821524 25.819642</coordinates>
+        </location>
       </city>
       <city>
         <!-- The capital of Zambia -->
@@ -2696,6 +4197,11 @@
           <code>FLLS</code>
           <coordinates>-15.316667 28.450000</coordinates>
         </location>
+        <location>
+          <name>Kenneth Kaunda International Airport</name>
+          <code>FLKK</code>
+          <coordinates>-15.330800 28.452600</coordinates>
+        </location>
       </city>
       <city>
         <!-- A city in Zambia -->
@@ -2705,6 +4211,11 @@
           <name>Ndola</name>
           <code>FLND</code>
           <coordinates>-13.000000 28.650000</coordinates>
+        </location>
+        <location>
+          <name>Simon Mwansa Kapwepwe International Airport</name>
+          <code>FLSK</code>
+          <coordinates>-12.961667 28.516667</coordinates>
         </location>
       </city>
     </country>
@@ -2721,6 +4232,78 @@
         <timezone id="Africa/Harare" />
       </timezones>
       <tz-hint>Africa/Harare</tz-hint>
+      <city>
+        <!-- A city in Zimbabwe -->
+        <name>Bulawayo</name>
+        <coordinates>-20.150000 28.583330</coordinates>
+        <location>
+          <name>Joshua Mqabuko Nkomo International Airport</name>
+          <code>FVJN</code>
+          <tz-hint>Africa/Harare</tz-hint>
+          <coordinates>-20.016284 28.622897</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Zimbabwe -->
+        <name>Chiredzi</name>
+        <coordinates>-21.050000 31.666670</coordinates>
+        <location>
+          <name>Buffalo Range Airport</name>
+          <code>FVCZ</code>
+          <coordinates>-21.008100 31.578600</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Zimbabwe -->
+        <name>Epworth</name>
+        <coordinates>-17.890000 31.147500</coordinates>
+        <location>
+          <name>Robert Gabriel Mugabe International / Harare</name>
+          <code>FVRG</code>
+          <tz-hint>Africa/Harare</tz-hint>
+          <coordinates>-17.930000 31.094000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Zimbabwe -->
+        <name>Gwayi River Farms</name>
+        <coordinates>-18.629900 27.021000</coordinates>
+        <location>
+          <name>Hwange National Park Airport</name>
+          <code>FVWN</code>
+          <coordinates>-18.629900 27.021000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Zimbabwe -->
+        <name>Kariba</name>
+        <coordinates>-16.516670 28.800000</coordinates>
+        <location>
+          <name>Kariba International Airport</name>
+          <code>FVKB</code>
+          <coordinates>-16.519800 28.885000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Zimbabwe -->
+        <name>Masvingo</name>
+        <coordinates>-20.063730 30.827660</coordinates>
+        <location>
+          <name>Masvingo International Airport</name>
+          <code>FVMV</code>
+          <coordinates>-20.055300 30.859100</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Zimbabwe -->
+        <name>Victoria Falls</name>
+        <coordinates>-17.932850 25.830660</coordinates>
+        <location>
+          <name>Victoria Falls International Airport</name>
+          <code>FVFA</code>
+          <coordinates>-18.095900 25.839000</coordinates>
+        </location>
+      </city>
     </country>
   </region>
   <region>
@@ -2806,6 +4389,7 @@
       </timezones>
       <tz-hint>Antarctica/McMurdo</tz-hint>
       <city>
+        <!-- A city in Antarctica -->
         <name>Amundsen-Scott South Pole Station</name>
         <coordinates>-90.000000 00.000000</coordinates>
         <!-- An American research station in Antarctica, which keeps
@@ -2815,6 +4399,44 @@
           <name>Amundsen-Scott South Pole Station</name>
           <code>NZSP</code>
           <coordinates>-90.000000 00.000000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Antarctica -->
+        <name>McMurdo Station</name>
+        <coordinates>-77.867400 167.057010</coordinates>
+        <location>
+          <name>McMurdo Sound Naval Air Facility</name>
+          <code>NZCM</code>
+          <tz-hint>Antarctica/South_Pole</tz-hint>
+          <coordinates>-77.883000 166.733000</coordinates>
+        </location>
+        <location>
+          <name>Williams Field</name>
+          <code>NZWD</code>
+          <coordinates>-77.867400 167.057010</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Antarctica -->
+        <name>Seymour Island</name>
+        <coordinates>-64.238300 -56.630800</coordinates>
+        <location>
+          <name>Marambio Base</name>
+          <code>SAWB</code>
+          <tz-hint>Antarctica/Palmer</tz-hint>
+          <coordinates>-64.238300 -56.630800</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Antarctica -->
+        <name>Villa Las Estrellas</name>
+        <coordinates>-62.190800 -58.986700</coordinates>
+        <location>
+          <name>Teniente Rodolfo Marsh Martin Base</name>
+          <code>SCRM</code>
+          <tz-hint>Antarctica/Palmer</tz-hint>
+          <coordinates>-62.190800 -58.986700</coordinates>
         </location>
       </city>
     </country>
@@ -2857,16 +4479,22 @@
     <country>
       <!-- AM - Armenia -->
       <name>Armenia</name>
-      <!-- Could not find information about the following stations,
-           which may be in Armenia:
-           UDSG 
-        -->
       <iso-code>AM</iso-code>
       <fips-code>AM</fips-code>
       <timezones>
         <timezone id="Asia/Yerevan" />
       </timezones>
       <tz-hint>Asia/Yerevan</tz-hint>
+      <city>
+        <!-- A city in Armenia -->
+        <name>Gyumri</name>
+        <coordinates>40.793050 43.846350</coordinates>
+        <location>
+          <name>Gyumri Shirak Airport</name>
+          <code>UDSG</code>
+          <coordinates>40.750400 43.859300</coordinates>
+        </location>
+      </city>
       <city>
         <!-- The capital of Armenia -->
         <name>Yerevan</name>
@@ -2881,10 +4509,6 @@
     <country>
       <!-- AZ - Azerbaijan -->
       <name>Azerbaijan</name>
-      <!-- Could not find information about the following stations,
-           which may be in Azerbaijan:
-           UBBN 
-        -->
       <iso-code>AZ</iso-code>
       <fips-code>AJ</fips-code>
       <timezones>
@@ -2906,12 +4530,83 @@
       </city>
       <city>
         <!-- A city in Azerbaijan -->
+        <name>Fuzuli</name>
+        <coordinates>39.600940 47.145290</coordinates>
+        <location>
+          <name>Fuzuli International Airport</name>
+          <code>UBBF</code>
+          <tz-hint>Asia/Baku</tz-hint>
+          <coordinates>39.594578 47.196128</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Azerbaijan -->
+        <name>Gabala</name>
+        <coordinates>40.981390 47.845830</coordinates>
+        <location>
+          <name>Gabala International Airport</name>
+          <code>UBBQ</code>
+          <coordinates>40.826670 47.712500</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Azerbaijan -->
         <name>Ganca</name>
         <coordinates>40.682778 46.360556</coordinates>
         <location>
           <name>Ganca Airport</name>
           <code>UBBG</code>
           <coordinates>40.733333 46.400000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Azerbaijan -->
+        <name>Lankaran</name>
+        <coordinates>38.754280 48.850620</coordinates>
+        <location>
+          <name>Lankaran International Airport</name>
+          <code>UBBL</code>
+          <coordinates>38.746400 48.818000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Azerbaijan -->
+        <name>Nakhchivan</name>
+        <coordinates>39.208890 45.412220</coordinates>
+        <location>
+          <name>Nakhchivan Airport</name>
+          <code>UBBN</code>
+          <coordinates>39.188800 45.458400</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Azerbaijan -->
+        <name>Yevlakh</name>
+        <coordinates>40.618320 47.150140</coordinates>
+        <location>
+          <name>Yevlakh Airport</name>
+          <code>UBEE</code>
+          <coordinates>40.631900 47.141900</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Azerbaijan -->
+        <name>Zangilan</name>
+        <coordinates>39.083710 46.659880</coordinates>
+        <location>
+          <name>Zangilan International Airport</name>
+          <code>UBBZ</code>
+          <coordinates>39.094414 46.734098</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Azerbaijan -->
+        <name>Zaqatala</name>
+        <coordinates>41.631600 46.644790</coordinates>
+        <location>
+          <name>Zaqatala International Airport</name>
+          <code>UBBY</code>
+          <coordinates>41.562220 46.667220</coordinates>
         </location>
       </city>
     </country>
@@ -2951,6 +4646,11 @@
           <code>VGZR</code>
           <coordinates>23.850000 90.400000</coordinates>
         </location>
+        <location>
+          <name>Dhaka / Hazrat Shahjalal International Airport</name>
+          <code>VGHS</code>
+          <coordinates>23.843350 90.397780</coordinates>
+        </location>
       </city>
       <city>
         <!-- A city in Bangladesh -->
@@ -2976,6 +4676,16 @@
         <timezone id="Asia/Thimphu" />
       </timezones>
       <tz-hint>Asia/Thimphu</tz-hint>
+      <city>
+        <!-- A city in Bhutan -->
+        <name>Paro</name>
+        <coordinates>27.430500 89.413340</coordinates>
+        <location>
+          <name>Paro Airport</name>
+          <code>VQPR</code>
+          <coordinates>27.403200 89.424600</coordinates>
+        </location>
+      </city>
     </country>
     <country>
       <!-- BN - Brunei Darussalam -->
@@ -3021,6 +4731,36 @@
       </city>
       <city>
         <!-- A city in Cambodia -->
+        <name>Phnom Penh (Boeng Khyang)</name>
+        <coordinates>11.562450 104.916010</coordinates>
+        <location>
+          <name>Techo International Airport</name>
+          <code>VDTI</code>
+          <coordinates>11.362917 104.916611</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Cambodia -->
+        <name>Preah Sihanouk</name>
+        <coordinates>10.609320 103.529580</coordinates>
+        <location>
+          <name>Sihanoukville International Airport</name>
+          <code>VDSV</code>
+          <coordinates>10.579700 103.637000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Cambodia -->
+        <name>Siem Reap</name>
+        <coordinates>13.361790 103.860560</coordinates>
+        <location>
+          <name>Siem Reap Angkor International Airport</name>
+          <code>VDSA</code>
+          <coordinates>13.369170 104.223060</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Cambodia -->
         <name>Siemreab</name>
         <coordinates>13.366667 103.850000</coordinates>
         <location>
@@ -3035,10 +4775,6 @@
            not include "The People's Republic of".)
         -->
       <name>China</name>
-      <!-- Could not find information about the following stations,
-           which may be in China:
-           ZBSJ ZJHK 
-        -->
       <iso-code>CN</iso-code>
       <fips-code>CH</fips-code>
       <timezones>
@@ -3541,6 +5277,106 @@
           </location>
         </city>
       </state>
+      <city>
+        <!-- A city in China -->
+        <name>Beijing</name>
+        <coordinates>39.907500 116.397230</coordinates>
+        <location>
+          <name>Beijing Daxing International Airport</name>
+          <code>ZBAD</code>
+          <coordinates>39.500000 116.400000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in China -->
+        <name>Chengdu (Jianyang)</name>
+        <coordinates>30.666670 104.066670</coordinates>
+        <location>
+          <name>Chengdu/Tianfu Airport</name>
+          <code>ZUTF</code>
+          <coordinates>30.290000 104.443330</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in China -->
+        <name>Ezhou</name>
+        <coordinates>30.396070 114.886550</coordinates>
+        <location>
+          <name>Ezhou Huahu Airport</name>
+          <code>ZHEC</code>
+          <coordinates>30.342860 115.029610</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in China -->
+        <name>Guiyang (Nanming)</name>
+        <coordinates>26.583330 106.716670</coordinates>
+        <location>
+          <name>Longdongbao Airport</name>
+          <code>ZUGY</code>
+          <coordinates>26.538500 106.801000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in China -->
+        <name>Haikou (Meilan)</name>
+        <coordinates>20.034210 110.346510</coordinates>
+        <location>
+          <name>Haikou Meilan International Airport</name>
+          <code>ZJHK</code>
+          <coordinates>19.934900 110.459000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in China -->
+        <name>Jinan (Licheng)</name>
+        <coordinates>36.668330 116.997220</coordinates>
+        <location>
+          <name>Yaoqiang Airport</name>
+          <code>ZSJN</code>
+          <coordinates>36.857200 117.216000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in China -->
+        <name>Nanchang</name>
+        <coordinates>28.683960 115.853060</coordinates>
+        <location>
+          <name>Nanchang Changbei International Airport</name>
+          <code>ZSCN</code>
+          <coordinates>28.865000 115.900000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in China -->
+        <name>Ningbo</name>
+        <coordinates>29.878190 121.549450</coordinates>
+        <location>
+          <name>Ningbo Lishe International Airport</name>
+          <code>ZSNB</code>
+          <coordinates>29.826700 121.462000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in China -->
+        <name>Shijiazhuang</name>
+        <coordinates>38.041390 114.478610</coordinates>
+        <location>
+          <name>Shijiazhuang Daguocun International Airport</name>
+          <code>ZBSJ</code>
+          <coordinates>38.280700 114.697000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in China -->
+        <name>Yuncheng (Yanhu)</name>
+        <coordinates>35.023060 110.992780</coordinates>
+        <location>
+          <name>Yuncheng Guangong Airport</name>
+          <code>ZBYC</code>
+          <coordinates>35.116390 111.031390</coordinates>
+        </location>
+      </city>
     </country>
     <country>
       <!-- GE - Georgia (the country, not the US state) -->
@@ -3556,6 +5392,7 @@
 	<fips-code>GG51</fips-code>
 	<!-- A city in Georgia -->
 	<city>
+		<!-- A city in Georgia -->
 	  <name>Tbilisi</name>
 	  <coordinates>25.038889 102.718333</coordinates>
 	  <location>
@@ -3565,6 +5402,48 @@
 	  </location>
 	</city>
       </state>
+      <city>
+        <!-- A city in Georgia -->
+        <name>Ambrolauri</name>
+        <coordinates>42.523220 43.149820</coordinates>
+        <location>
+          <name>Ambrolauri Airport</name>
+          <code>UGAM</code>
+          <tz-hint>Asia/Tbilisi</tz-hint>
+          <coordinates>42.526870 43.135380</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Georgia -->
+        <name>Batumi</name>
+        <coordinates>41.640770 41.630600</coordinates>
+        <location>
+          <name>Batumi International Airport</name>
+          <code>UGSB</code>
+          <coordinates>41.610300 41.599700</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Georgia -->
+        <name>Kopitnari</name>
+        <coordinates>42.176700 42.482600</coordinates>
+        <location>
+          <name>Kopitnari Airport</name>
+          <code>UGKO</code>
+          <coordinates>42.176700 42.482600</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Georgia -->
+        <name>Mestia</name>
+        <coordinates>43.043800 42.723680</coordinates>
+        <location>
+          <name>Mestia</name>
+          <code>UGMS</code>
+          <tz-hint>Asia/Tbilisi</tz-hint>
+          <coordinates>43.069000 42.754000</coordinates>
+        </location>
+      </city>
     </country>
     <country>
       <!-- HK - Hong Kong, aka "Hong Kong Special Administrative Region
@@ -3579,7 +5458,7 @@
       <tz-hint>Asia/Hong_Kong</tz-hint>
       <city>
         <!-- A city in Hong Kong -->
-        <name>Kowloon</name>
+        <name>Hong Kong</name>
         <coordinates>22.316667 114.183333</coordinates>
         <location>
           <name>Hong Kong International Airport</name>
@@ -3591,18 +5470,11 @@
     <country>
       <!-- IN - India -->
       <name>India</name>
-      <!-- Could not find information about the following stations,
-           which may be in India:
-           VOBL VOHS 
-        -->
       <!-- Could not find weather stations for the following major
            cities:
            Aizawl, Alappuzha, Azamgarh,
-           Barddhaman, Belgaum, Calicut,
-           Guwahati, Indore, Kollam, Mangalore, Mau, Mysore,
-           Nagercoil, Palakkad, Pondicherry, Shiliguri, Shillong,
-           Shimoga, Soyibug, Thrissur, Tumkur,
-           Tuticorin
+           Barddhaman, Nagercoil, Palakkad,
+           Pondicherry, Shiliguri, Tuticorin
         -->
       <iso-code>IN</iso-code>
       <fips-code>IN</fips-code>
@@ -3619,6 +5491,16 @@
           <name>Agartala Airport</name>
           <code>VEAT</code>
           <coordinates>23.890000 91.242222</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in India -->
+        <name>Agatti</name>
+        <coordinates>10.835220 72.182170</coordinates>
+        <location>
+          <name>Agatti Airport</name>
+          <code>VOAT</code>
+          <coordinates>10.823700 72.176000</coordinates>
         </location>
       </city>
       <city>
@@ -3644,6 +5526,26 @@
         </location>
       </city>
       <city>
+        <!-- A city in India -->
+        <name>Aizawl (Lengpui)</name>
+        <coordinates>23.728940 92.717910</coordinates>
+        <location>
+          <name>Lengpui Airport</name>
+          <code>VELP</code>
+          <coordinates>23.840600 92.619700</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in India -->
+        <name>Ajmer (Kishangarh)</name>
+        <coordinates>26.452100 74.638670</coordinates>
+        <location>
+          <name>Kishangarh Airport, Ajmer</name>
+          <code>VIKG</code>
+          <coordinates>26.591170 74.816170</coordinates>
+        </location>
+      </city>
+      <city>
         <!-- A city in India
 	     the local name in Hindi is "इलाहाबाद"-->
         <name>Allahabad</name>
@@ -3652,6 +5554,16 @@
           <name>Allahabad Airport</name>
           <code>VIAL</code>
           <coordinates>25.44000 81.733889</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in India -->
+        <name>Amravati</name>
+        <coordinates>20.933330 77.750000</coordinates>
+        <location>
+          <name>Amravati (Belora) Airstrip</name>
+          <code>VAAM</code>
+          <coordinates>20.814608 77.717765</coordinates>
         </location>
       </city>
       <city>
@@ -3664,6 +5576,16 @@
           <name>Raja Sansi International Airport</name>
           <code>VIAR</code>
           <coordinates>31.707778 74.799167</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in India -->
+        <name>Arkonam</name>
+        <coordinates>13.084490 79.670530</coordinates>
+        <location>
+          <name>Arkonam Airport</name>
+          <code>VOAR</code>
+          <coordinates>13.071200 79.691200</coordinates>
         </location>
       </city>
       <city>
@@ -3717,6 +5639,16 @@
         </location>
       </city>
       <city>
+        <!-- A city in India -->
+        <name>Belgaum</name>
+        <coordinates>15.852120 74.504470</coordinates>
+        <location>
+          <name>Belagavi Airport</name>
+          <code>VOBM</code>
+          <coordinates>15.859300 74.618301</coordinates>
+        </location>
+      </city>
+      <city>
         <!-- A city in India.
              "Benares" is the traditional English name.
              The local name is "Varanasi".
@@ -3765,6 +5697,36 @@
         </location>
       </city>
       <city>
+        <!-- A city in India -->
+        <name>Bhuntar</name>
+        <coordinates>31.860000 77.150000</coordinates>
+        <location>
+          <name>Kullu Manali Airport</name>
+          <code>VIBR</code>
+          <coordinates>31.876700 77.154400</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in India -->
+        <name>Bilaspur</name>
+        <coordinates>22.080050 82.155430</coordinates>
+        <location>
+          <name>Bilaspur Airport</name>
+          <code>VEBU</code>
+          <coordinates>21.988400 82.111000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in India -->
+        <name>Calicut</name>
+        <coordinates>11.248020 75.780400</coordinates>
+        <location>
+          <name>Calicut International Airport</name>
+          <code>VOCL</code>
+          <coordinates>11.136800 75.955300</coordinates>
+        </location>
+      </city>
+      <city>
       <!-- A union territory in India.
 	    The local name in Hindi is "चण्डीगढ़ / चंडीगढ़"
 	    The local name in Punjabi is "ਚੰਡੀਗੜ੍ਹ"-->
@@ -3790,6 +5752,26 @@
         </location>
       </city>
       <city>
+        <!-- A city in India -->
+        <name>Chipi</name>
+        <coordinates>16.002552 73.529846</coordinates>
+        <location>
+          <name>Sindhudurg Airport</name>
+          <code>VOSR</code>
+          <coordinates>16.002552 73.529846</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in India -->
+        <name>Chitrakoot</name>
+        <coordinates>25.214730 80.916450</coordinates>
+        <location>
+          <name>Chitrakoot Airport</name>
+          <code>VECT</code>
+          <coordinates>25.167694 80.935800</coordinates>
+        </location>
+      </city>
+      <city>
         <!-- A city in India.
              The local name in Tamil is "கோயம்புத்தூர்".
           -->
@@ -3802,6 +5784,26 @@
         </location>
       </city>
       <city>
+        <!-- A city in India -->
+        <name>Cooch Behar</name>
+        <coordinates>26.325390 89.445080</coordinates>
+        <location>
+          <name>Cooch Behar Airport</name>
+          <code>VECO</code>
+          <coordinates>26.330500 89.467200</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in India -->
+        <name>Daman</name>
+        <coordinates>20.414310 72.832360</coordinates>
+        <location>
+          <name>Daman Airport</name>
+          <code>VADN</code>
+          <coordinates>20.434400 72.843200</coordinates>
+        </location>
+      </city>
+      <city>
         <!-- A city in India
 	     also known as Dehra Doon
 	     the local name in Hindi is "देहरादून"-->
@@ -3811,6 +5813,16 @@
           <name>Jolly Grant Airport</name>
           <code>VIDN</code>
           <coordinates>30.189722 78.180278</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in India -->
+        <name>Deoghar</name>
+        <coordinates>24.489830 86.699020</coordinates>
+        <location>
+          <name>Deoghar Airport</name>
+          <code>VEDO</code>
+          <coordinates>24.445670 86.707000</coordinates>
         </location>
       </city>
       <city>
@@ -3836,12 +5848,137 @@
       </city>
       <city>
         <!-- A city in India -->
+        <name>Diu</name>
+        <coordinates>20.714050 70.982240</coordinates>
+        <location>
+          <name>Diu Airport</name>
+          <code>VADU</code>
+          <coordinates>20.714185 70.921855</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in India -->
+        <name>Durgapur</name>
+        <coordinates>23.515830 87.308010</coordinates>
+        <location>
+          <name>Kazi Nazrul Islam Airport</name>
+          <code>VEDG</code>
+          <coordinates>23.622500 87.243000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in India -->
+        <name>Faizabad</name>
+        <coordinates>26.775490 82.150180</coordinates>
+        <location>
+          <name>Maharishi Valmiki International Airport</name>
+          <code>VEAY</code>
+          <coordinates>26.748030 82.150780</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in India -->
+        <name>Gaya</name>
+        <coordinates>24.796860 85.003850</coordinates>
+        <location>
+          <name>Gaya Airport</name>
+          <code>VEGY</code>
+          <coordinates>24.744300 84.951200</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in India -->
+        <name>Gondia</name>
+        <coordinates>21.460260 80.192050</coordinates>
+        <location>
+          <name>Gondia Airport</name>
+          <code>VAGD</code>
+          <coordinates>21.526817 80.290347</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in India -->
+        <name>Guwahati</name>
+        <coordinates>26.184400 91.745800</coordinates>
+        <location>
+          <name>Lokpriya Gopinath Bordoloi International Airport</name>
+          <code>VEGT</code>
+          <coordinates>26.106100 91.585900</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in India -->
+        <name>Hubballi</name>
+        <coordinates>15.347760 75.133780</coordinates>
+        <location>
+          <name>Hubballi Airport</name>
+          <code>VOHB</code>
+          <coordinates>15.361084 75.082096</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in India -->
         <name>Hyderabad</name>
         <coordinates>17.375278 78.474444</coordinates>
         <location>
           <name>Hyderabad Airport</name>
           <code>VOHY</code>
           <coordinates>17.450000 78.466667</coordinates>
+        </location>
+        <location>
+          <name>Rajiv Gandhi International Airport Shamshabad</name>
+          <code>VOHS</code>
+          <coordinates>17.231320 78.429860</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in India -->
+        <name>Imphal</name>
+        <coordinates>24.808050 93.944200</coordinates>
+        <location>
+          <name>Imphal Airport</name>
+          <code>VEIM</code>
+          <coordinates>24.760000 93.896700</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in India -->
+        <name>Indore</name>
+        <coordinates>22.717920 75.833300</coordinates>
+        <location>
+          <name>Devi Ahilyabai Holkar Airport</name>
+          <code>VAID</code>
+          <coordinates>22.721800 75.801100</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in India -->
+        <name>Itanagar</name>
+        <coordinates>27.086940 93.609870</coordinates>
+        <location>
+          <name>Donyi Polo Airport</name>
+          <code>VEHO</code>
+          <coordinates>26.971841 93.642308</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in India -->
+        <name>Jabalpur</name>
+        <coordinates>23.166970 79.950060</coordinates>
+        <location>
+          <name>Jabalpur Airport</name>
+          <code>VAJB</code>
+          <coordinates>23.177800 80.052000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in India -->
+        <name>Jagdalpur</name>
+        <coordinates>19.081360 82.021310</coordinates>
+        <location>
+          <name>Jagdalpur Airport</name>
+          <code>VEJR</code>
+          <coordinates>19.074301 82.036797</coordinates>
         </location>
       </city>
       <city>
@@ -3852,6 +5989,16 @@
           <name>Jaipur / Sanganer</name>
           <code>VIJP</code>
           <coordinates>26.816667 75.800000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in India -->
+        <name>Jalgaon</name>
+        <coordinates>21.002920 75.566020</coordinates>
+        <location>
+          <name>Jalgaon Airport</name>
+          <code>VAJL</code>
+          <coordinates>20.962678 75.627492</coordinates>
         </location>
       </city>
       <city>
@@ -3866,6 +6013,76 @@
       </location>
       </city>
       <city>
+        <!-- A city in India -->
+        <name>Jamshedpur</name>
+        <coordinates>22.802780 86.185450</coordinates>
+        <location>
+          <name>Jamshedpur Airport</name>
+          <code>VEJS</code>
+          <coordinates>22.813200 86.168800</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in India -->
+        <name>Kadapa</name>
+        <coordinates>14.479950 78.823460</coordinates>
+        <location>
+          <name>Cuddapah Airport</name>
+          <code>VOCP</code>
+          <coordinates>14.510000 78.772800</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in India -->
+        <name>Kakadi</name>
+        <coordinates>19.689211 74.373655</coordinates>
+        <location>
+          <name>Shirdi International Airport</name>
+          <code>VASD</code>
+          <coordinates>19.689211 74.373655</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in India -->
+        <name>Kalaburagi</name>
+        <coordinates>17.335830 76.837570</coordinates>
+        <location>
+          <name>Kalaburagi</name>
+          <code>VOGB</code>
+          <coordinates>17.307780 76.958060</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in India -->
+        <name>Kangra</name>
+        <coordinates>32.091350 76.262670</coordinates>
+        <location>
+          <name>Kangra Airport</name>
+          <code>VIGG</code>
+          <coordinates>32.165100 76.263400</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in India -->
+        <name>Kannur</name>
+        <coordinates>11.867520 75.357630</coordinates>
+        <location>
+          <name>Kannur International Airport</name>
+          <code>VOKN</code>
+          <coordinates>11.915830 75.545830</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in India -->
+        <name>Keshod</name>
+        <coordinates>21.303280 70.248610</coordinates>
+        <location>
+          <name>Keshod Airport</name>
+          <code>VAKS</code>
+          <coordinates>21.317100 70.270400</coordinates>
+        </location>
+      </city>
+      <city>
         <!-- A city in India.
              The old name is "Cochin" -->
         <name>Kochi</name>
@@ -3875,7 +6092,22 @@
           <code>VOCI</code>
           <coordinates>10.155556 76.391389</coordinates>
        </location>
+        <location>
+          <name>Willingdon Island Air Base</name>
+          <code>VOCC</code>
+          <coordinates>9.947390 76.273100</coordinates>
+        </location>
      </city>
+      <city>
+        <!-- A city in India -->
+        <name>Kolhapur</name>
+        <coordinates>16.695630 74.231670</coordinates>
+        <location>
+          <name>Kolhapur Airport</name>
+          <code>VAKP</code>
+          <coordinates>16.664700 74.289400</coordinates>
+        </location>
+      </city>
       <city>
         <!-- A city in India.
              "Calcutta" is the traditional English name.
@@ -3890,6 +6122,16 @@
         </location>
       </city>
      <city>
+       <!-- A city in India -->
+       <name>Kushinagar</name>
+       <coordinates>26.741340 83.886890</coordinates>
+       <location>
+         <name>Kushinagar Airport</name>
+         <code>VEKI</code>
+         <coordinates>26.772670 83.895330</coordinates>
+       </location>
+     </city>
+     <city>
      <!-- A city in India. 
           The local name in Hindi is "लेह" -->
      <name>Leh</name>
@@ -3899,6 +6141,16 @@
        <code>VILH</code>
        <coordinates>34.135833 77.546389</coordinates>
      </location>
+     </city>
+     <city>
+       <!-- A city in India -->
+       <name>Lilabari</name>
+       <coordinates>27.295500 94.097600</coordinates>
+       <location>
+         <name>North Lakhimpur Airport</name>
+         <code>VELR</code>
+         <coordinates>27.295500 94.097600</coordinates>
+       </location>
      </city>
      <city>
        <!-- A city in India.
@@ -3913,6 +6165,66 @@
         </location>
       </city>
       <city>
+        <!-- A city in India -->
+        <name>Ludhiana</name>
+        <coordinates>30.912040 75.853790</coordinates>
+        <location>
+          <name>Ludhiana Airport</name>
+          <code>VILD</code>
+          <coordinates>30.855833 75.950556</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in India -->
+        <name>Madhurapudi</name>
+        <coordinates>17.110400 81.818200</coordinates>
+        <location>
+          <name>Rajahmundry Airport</name>
+          <code>VORY</code>
+          <coordinates>17.110400 81.818200</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in India -->
+        <name>Madurai</name>
+        <coordinates>9.919000 78.119530</coordinates>
+        <location>
+          <name>Madurai Airport</name>
+          <code>VOMD</code>
+          <coordinates>9.834510 78.093400</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in India -->
+        <name>Mana-Camp</name>
+        <coordinates>21.193950 81.717020</coordinates>
+        <location>
+          <name>Swami Vivekananda</name>
+          <code>VERP</code>
+          <coordinates>21.183000 81.733000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in India -->
+        <name>Mangaluru</name>
+        <coordinates>12.917230 74.856030</coordinates>
+        <location>
+          <name>Mangalore International Airport</name>
+          <code>VOML</code>
+          <coordinates>12.961300 74.890100</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in India -->
+        <name>Mopa</name>
+        <coordinates>15.732200 73.868000</coordinates>
+        <location>
+          <name>Manohar International Airport</name>
+          <code>VOGA</code>
+          <coordinates>15.732200 73.868000</coordinates>
+        </location>
+      </city>
+      <city>
         <!-- A city in India.
              "Bombay" is the traditional English name.
              The local name in Marathi is "Mumbai /  मुंबई".
@@ -3924,6 +6236,21 @@
           <code>VABB</code>
           <coordinates>19.116667 72.850000</coordinates>
         </location>
+        <location>
+          <name>Juhu Aerodrome</name>
+          <code>VAJJ</code>
+          <coordinates>19.098100 72.834200</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in India -->
+        <name>Mysore</name>
+        <coordinates>12.297910 76.639250</coordinates>
+        <location>
+          <name>Mysore Airport</name>
+          <code>VOMY</code>
+          <coordinates>12.307200 76.649700</coordinates>
+        </location>
       </city>
       <city>
         <!-- A city in India -->
@@ -3933,6 +6260,26 @@
           <name>Nagpur Sonegaon</name>
           <code>VANP</code>
           <coordinates>21.100000 79.050000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in India -->
+        <name>Nashik</name>
+        <coordinates>19.997270 73.790960</coordinates>
+        <location>
+          <name>Ozar Airport</name>
+          <code>VAOZ</code>
+          <coordinates>20.119100 73.912900</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in India -->
+        <name>Navi Mumbai</name>
+        <coordinates>19.036810 73.015820</coordinates>
+        <location>
+          <name>Navi Mumbai International Airport</name>
+          <code>VANM</code>
+          <coordinates>18.593978 73.041295</coordinates>
         </location>
       </city>
       <city>
@@ -3948,6 +6295,41 @@
           <code>VIDP</code>
           <coordinates>28.566667 77.116667</coordinates>
         </location>
+        <location>
+          <name>Safdarjung Airport</name>
+          <code>VIDD</code>
+          <coordinates>28.584500 77.205800</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in India -->
+        <name>Orvakal</name>
+        <coordinates>15.713681 78.161561</coordinates>
+        <location>
+          <name>Kurnool Airport</name>
+          <code>VOKU</code>
+          <coordinates>15.713681 78.161561</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in India -->
+        <name>Pakyong</name>
+        <coordinates>27.232500 88.588333</coordinates>
+        <location>
+          <name>Pakyong Airport</name>
+          <code>VEPY</code>
+          <coordinates>27.232500 88.588333</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in India -->
+        <name>Pantnagar</name>
+        <coordinates>29.033400 79.473700</coordinates>
+        <location>
+          <name>Pantnagar Airport</name>
+          <code>VIPT</code>
+          <coordinates>29.033400 79.473700</coordinates>
+        </location>
       </city>
       <city>
         <!-- A city in India -->
@@ -3960,6 +6342,36 @@
         </location>
       </city>
       <city>
+        <!-- A city in India -->
+        <name>Porbandar</name>
+        <coordinates>21.642190 69.609290</coordinates>
+        <location>
+          <name>Porbandar Airport</name>
+          <code>VAPR</code>
+          <coordinates>21.648700 69.657200</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in India -->
+        <name>Port Blair</name>
+        <coordinates>11.666130 92.746350</coordinates>
+        <location>
+          <name>Vir Savarkar International Airport</name>
+          <code>VOPB</code>
+          <coordinates>11.641200 92.729700</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in India -->
+        <name>Puducherry (Pondicherry)</name>
+        <coordinates>11.933810 79.829790</coordinates>
+        <location>
+          <name>Pondicherry Airport</name>
+          <code>VOPC</code>
+          <coordinates>11.968700 79.810100</coordinates>
+        </location>
+      </city>
+      <city>
       <!-- A city in India -->
         <name>Pune</name>
         <coordinates>18.53 73.85</coordinates>
@@ -3967,6 +6379,66 @@
           <name>Pune International Airport</name>
 	  <code>VAPO</code>
 	  <coordinates>18.3456 073.5511</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in India -->
+        <name>Rajkot</name>
+        <coordinates>22.291610 70.793220</coordinates>
+        <location>
+          <name>Rajkot International Airport</name>
+          <code>VAHS</code>
+          <coordinates>22.381915 71.031681</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in India -->
+        <name>Ranchi</name>
+        <coordinates>23.343160 85.309400</coordinates>
+        <location>
+          <name>Birsa Munda Airport</name>
+          <code>VERC</code>
+          <coordinates>23.314300 85.321700</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in India -->
+        <name>Rourkela</name>
+        <coordinates>22.224960 84.864140</coordinates>
+        <location>
+          <name>Rourkela Airport</name>
+          <code>VERK</code>
+          <coordinates>22.256700 84.814600</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in India -->
+        <name>Rupsi</name>
+        <coordinates>26.139700 89.910000</coordinates>
+        <location>
+          <name>Rupsi India Airport</name>
+          <code>VERU</code>
+          <coordinates>26.139700 89.910000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in India -->
+        <name>Salem</name>
+        <coordinates>11.653760 78.155380</coordinates>
+        <location>
+          <name>Salem Airport</name>
+          <code>VOSM</code>
+          <coordinates>11.783300 78.065600</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in India -->
+        <name>Shillong</name>
+        <coordinates>25.568920 91.883130</coordinates>
+        <location>
+          <name>Shillong Airport</name>
+          <code>VEBI</code>
+          <coordinates>25.703600 91.978700</coordinates>
         </location>
       </city>
       <city>
@@ -3981,6 +6453,26 @@
         </location>
       </city>
       <city>
+        <!-- A city in India -->
+        <name>Shimoga</name>
+        <coordinates>13.931570 75.567910</coordinates>
+        <location>
+          <name>Shivamogga Airport</name>
+          <code>VOSH</code>
+          <coordinates>13.854722 75.610556</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in India -->
+        <name>Solapur</name>
+        <coordinates>17.671520 75.910440</coordinates>
+        <location>
+          <name>Solapur Airport</name>
+          <code>VASL</code>
+          <coordinates>17.628000 75.934800</coordinates>
+        </location>
+      </city>
+      <city>
       <!-- A city in India.
            The local name in Dogri is "श्रीनगर"
            The local name in Urdu is "شرینگر"-->
@@ -3990,6 +6482,26 @@
           <name>Srinagar Airport</name>
           <code>VISR</code>
           <coordinates>33.987139 74.77425</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in India -->
+        <name>Surat</name>
+        <coordinates>21.195940 72.830230</coordinates>
+        <location>
+          <name>Surat Airport</name>
+          <code>VASU</code>
+          <coordinates>21.114100 72.741800</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in India -->
+        <name>Tezu</name>
+        <coordinates>27.912560 96.128820</coordinates>
+        <location>
+          <name>Tezu Airport</name>
+          <code>VETJ</code>
+          <coordinates>27.941200 96.134400</coordinates>
         </location>
       </city>
       <city>
@@ -4016,13 +6528,113 @@
           <coordinates>10.766667 78.716667</coordinates>
         </location>
       </city>
+      <city>
+        <!-- A city in India -->
+        <name>Tirupati</name>
+        <coordinates>13.635510 79.419890</coordinates>
+        <location>
+          <name>Tirupati Airport</name>
+          <code>VOTP</code>
+          <coordinates>13.632500 79.543300</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in India -->
+        <name>Toranagallu</name>
+        <coordinates>15.174970 76.634950</coordinates>
+        <location>
+          <name>Vijayanagar Aerodrome (JSW)</name>
+          <code>VOJV</code>
+          <coordinates>15.174970 76.634950</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in India -->
+        <name>Udaipur</name>
+        <coordinates>24.585840 73.713460</coordinates>
+        <location>
+          <name>Maharana Pratap Airport</name>
+          <code>VAUD</code>
+          <coordinates>24.617700 73.896100</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in India -->
+        <name>Vadodara</name>
+        <coordinates>22.299410 73.208120</coordinates>
+        <location>
+          <name>Vadodara Airport</name>
+          <code>VABO</code>
+          <coordinates>22.336200 73.226300</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in India -->
+        <name>Vagaikulam</name>
+        <coordinates>8.722330 78.026170</coordinates>
+        <location>
+          <name>Tuticorin Southwest Airport</name>
+          <code>VOTK</code>
+          <coordinates>8.722330 78.026170</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in India -->
+        <name>Varanasi</name>
+        <coordinates>25.316680 83.010410</coordinates>
+        <location>
+          <name>Lal Bahadur Shastri Airport</name>
+          <code>VEBN</code>
+          <coordinates>25.451170 82.858670</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in India -->
+        <name>Vasco da Gama</name>
+        <coordinates>15.395850 73.815680</coordinates>
+        <location>
+          <name>Dabolim Airport</name>
+          <code>VOGO</code>
+          <coordinates>15.380800 73.831400</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in India -->
+        <name>Veer Surendra Sai</name>
+        <coordinates>21.914830 84.048670</coordinates>
+        <location>
+          <name>Jharsuguda Airport</name>
+          <code>VEJH</code>
+          <coordinates>21.914830 84.048670</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in India -->
+        <name>Vijayawada</name>
+        <coordinates>16.507450 80.646600</coordinates>
+        <location>
+          <name>Vijayawada Airport</name>
+          <code>VOBZ</code>
+          <coordinates>16.530400 80.796800</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in India -->
+        <name>Visakhapatnam</name>
+        <coordinates>17.680090 83.201610</coordinates>
+        <location>
+          <name>Vishakhapatnam Airport</name>
+          <code>VOVZ</code>
+          <coordinates>17.721200 83.224500</coordinates>
+        </location>
+      </city>
     </country>
     <country>
       <!-- ID - Indonesia -->
       <name>Indonesia</name>
       <!-- Could not find information about the following stations,
            which may be in Indonesia:
-           WADD WALL WARR WARS WIDD WIPT
+           WARS WIPT
         -->
       <iso-code>ID</iso-code>
       <fips-code>ID</fips-code>
@@ -4049,6 +6661,80 @@
       </timezones>
       <tz-hint>Asia/Jakarta</tz-hint>
       <city>
+        <!-- A city in Indonesia -->
+        <name>Ambon</name>
+        <coordinates>-3.695830 128.183330</coordinates>
+        <location>
+          <name>Pattimura Airport Ambon</name>
+          <code>WAPP</code>
+          <tz-hint>Asia/Jayapura</tz-hint>
+          <coordinates>-3.710260 128.089000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Indonesia -->
+        <name>Balikpapan</name>
+        <coordinates>-1.267530 116.828870</coordinates>
+        <location>
+          <name>Sepinggan International Airport</name>
+          <code>WALL</code>
+          <tz-hint>Asia/Makassar</tz-hint>
+          <coordinates>-1.268270 116.894000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Indonesia -->
+        <name>Banda Aceh</name>
+        <coordinates>5.541670 95.333330</coordinates>
+        <location>
+          <name>Sultan Iskandarmuda Airport</name>
+          <code>WITT</code>
+          <coordinates>5.523520 95.420400</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Indonesia -->
+        <name>Bandar Lampung</name>
+        <coordinates>-5.429170 105.261110</coordinates>
+        <location>
+          <name>Radin Inten II International Airport</name>
+          <code>WILL</code>
+          <coordinates>-5.246803 105.182531</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Indonesia -->
+        <name>Banjarbaru</name>
+        <coordinates>-3.440600 114.836500</coordinates>
+        <location>
+          <name>Syamsudin Noor Airport</name>
+          <code>WAOO</code>
+          <tz-hint>Asia/Makassar</tz-hint>
+          <coordinates>-3.442360 114.763000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Indonesia -->
+        <name>Batam</name>
+        <coordinates>1.149370 104.024910</coordinates>
+        <location>
+          <name>Hang Nadim Airport</name>
+          <code>WIDD</code>
+          <coordinates>1.121030 104.119000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Indonesia -->
+        <name>Biak</name>
+        <coordinates>-1.176700 136.082000</coordinates>
+        <location>
+          <name>Frans Kaisiepo Airport</name>
+          <code>WABB</code>
+          <tz-hint>Asia/Jayapura</tz-hint>
+          <coordinates>-1.190020 136.108000</coordinates>
+        </location>
+      </city>
+      <city>
         <!-- The capital of Indonesia -->
         <name>Jakarta</name>
         <coordinates>-6.174444 106.829444</coordinates>
@@ -4056,6 +6742,33 @@
           <name>Soekarno-Hatta Airport</name>
           <code>WIII</code>
           <coordinates>-6.116667 106.650000</coordinates>
+        </location>
+        <location>
+          <name>Halim Perdanakusuma International Airport</name>
+          <code>WIHH</code>
+          <coordinates>-6.266610 106.891000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Indonesia -->
+        <name>Kupang</name>
+        <coordinates>-10.170830 123.606940</coordinates>
+        <location>
+          <name>El Tari Airport</name>
+          <code>WATT</code>
+          <tz-hint>Asia/Makassar</tz-hint>
+          <coordinates>-10.171600 123.671000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Indonesia -->
+        <name>Kuta, Badung</name>
+        <coordinates>-8.723320 115.172340</coordinates>
+        <location>
+          <name>Ngurah Rai (Bali) International Airport</name>
+          <code>WADD</code>
+          <tz-hint>Asia/Makassar</tz-hint>
+          <coordinates>-8.748170 115.167000</coordinates>
         </location>
       </city>
       <city>
@@ -4071,12 +6784,44 @@
       </city>
       <city>
         <!-- A city in Indonesia -->
+        <name>Manado</name>
+        <coordinates>1.482180 124.848920</coordinates>
+        <location>
+          <name>Sam Ratulangi Airport</name>
+          <code>WAMM</code>
+          <tz-hint>Asia/Makassar</tz-hint>
+          <coordinates>1.549260 124.926000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Indonesia -->
+        <name>Mataram (Pujut, Lombok Tengah)</name>
+        <coordinates>-8.583330 116.116670</coordinates>
+        <location>
+          <name>Bandara International Lombok Airport</name>
+          <code>WADL</code>
+          <tz-hint>Asia/Makassar</tz-hint>
+          <coordinates>-8.757320 116.276670</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Indonesia -->
         <name>Medan</name>
         <coordinates>3.583333 98.666667</coordinates>
         <location>
           <name>Polonia Airport</name>
           <code>WIMM</code>
           <coordinates>3.566667 98.683333</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Indonesia -->
+        <name>Padang (Katapiang)</name>
+        <coordinates>-0.949240 100.354270</coordinates>
+        <location>
+          <name>Minangkabau Airport</name>
+          <code>WIEE</code>
+          <coordinates>-0.786920 100.281000</coordinates>
         </location>
       </city>
       <city>
@@ -4101,6 +6846,89 @@
       </city>
       <city>
         <!-- A city in Indonesia -->
+        <name>Pontianak</name>
+        <coordinates>-0.031940 109.325000</coordinates>
+        <location>
+          <name>Supadio Airport</name>
+          <code>WIOO</code>
+          <tz-hint>Asia/Pontianak</tz-hint>
+          <coordinates>-0.150710 109.404000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Indonesia -->
+        <name>Rogojampi, Banyuwangi</name>
+        <coordinates>-8.310150 114.340100</coordinates>
+        <location>
+          <name>Banyuwangi Airport</name>
+          <code>WADY</code>
+          <coordinates>-8.310150 114.340100</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Indonesia -->
+        <name>Semarang</name>
+        <coordinates>-6.993060 110.420830</coordinates>
+        <location>
+          <name>Jenderal Ahmad Yani Airport</name>
+          <code>WAHS</code>
+          <coordinates>-6.970732 110.373244</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Indonesia -->
+        <name>Sentani</name>
+        <coordinates>-2.569100 140.512700</coordinates>
+        <location>
+          <name>Sentani International Airport</name>
+          <code>WAJJ</code>
+          <tz-hint>Asia/Jayapura</tz-hint>
+          <coordinates>-2.576950 140.516010</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Indonesia -->
+        <name>Siborong-Borong</name>
+        <coordinates>2.212510 98.972910</coordinates>
+        <location>
+          <name>Silangit Airport</name>
+          <code>WIMN</code>
+          <coordinates>2.259730 98.991900</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Indonesia -->
+        <name>Surabaya</name>
+        <coordinates>-7.249170 112.750830</coordinates>
+        <location>
+          <name>Juanda International Airport</name>
+          <code>WARR</code>
+          <coordinates>-7.379830 112.787000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Indonesia -->
+        <name>Tanjung Pinang-Bintan Island</name>
+        <coordinates>0.916670 104.458330</coordinates>
+        <location>
+          <name>Kijang Airport</name>
+          <code>WIDN</code>
+          <coordinates>0.922680 104.532000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Indonesia -->
+        <name>Tarakan</name>
+        <coordinates>3.313320 117.591520</coordinates>
+        <location>
+          <name>Tarakan/Juwata</name>
+          <code>WAQQ</code>
+          <tz-hint>Asia/Makassar</tz-hint>
+          <coordinates>3.333000 117.567000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Indonesia -->
         <name>Yogyakarta</name>
         <coordinates>-7.803164 110.3398254</coordinates>
         <location>
@@ -4108,15 +6936,16 @@
           <code>WAHH</code>
           <coordinates>-7.7876785 110.4295726</coordinates>
         </location>
+        <location>
+          <name>Yogyakarta International Airport</name>
+          <code>WAHI</code>
+          <coordinates>-7.904170 110.057500</coordinates>
+        </location>
       </city>
     </country>
     <country>
       <!-- JP - Japan -->
       <name>Japan</name>
-      <!-- Could not find information about the following stations,
-           which may be in Japan:
-           RJBE RJNW 
-        -->
       <iso-code>JP</iso-code>
       <fips-code>JA</fips-code>
       <timezones>
@@ -4125,12 +6954,32 @@
       <tz-hint>Asia/Tokyo</tz-hint>
       <city>
         <!-- A city in Japan -->
+        <name>Akeno</name>
+        <coordinates>34.533300 136.672000</coordinates>
+        <location>
+          <name>Akeno Airport</name>
+          <code>RJOE</code>
+          <coordinates>34.533300 136.672000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Japan -->
         <name>Akita</name>
         <coordinates>39.716667 140.066667</coordinates>
         <location>
           <name>Akita Airport</name>
           <code>RJSK</code>
           <coordinates>39.616667 140.216667</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Japan -->
+        <name>Amagi</name>
+        <coordinates>27.816670 128.900000</coordinates>
+        <location>
+          <name>Tokunoshima Airport</name>
+          <code>RJKN</code>
+          <coordinates>27.836400 128.881000</coordinates>
         </location>
       </city>
       <city>
@@ -4162,6 +7011,11 @@
           <code>RJEC</code>
           <coordinates>43.666667 142.450000</coordinates>
         </location>
+        <location>
+          <name>Asahikawa Airport</name>
+          <code>RJCA</code>
+          <coordinates>43.795200 142.363010</coordinates>
+        </location>
       </city>
       <city>
         <!-- A city in Japan -->
@@ -4171,6 +7025,16 @@
           <name>Ashiya Air Base</name>
           <code>RJFA</code>
           <coordinates>33.883333 130.650000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Japan -->
+        <name>Bōjo</name>
+        <coordinates>33.320070 130.422220</coordinates>
+        <location>
+          <name>Metabaru (JASDF)</name>
+          <code>RJDM</code>
+          <coordinates>33.317000 130.417000</coordinates>
         </location>
       </city>
       <city>
@@ -4250,6 +7114,16 @@
       </city>
       <city>
         <!-- A city in Japan -->
+        <name>Hachinohe</name>
+        <coordinates>40.500000 141.500000</coordinates>
+        <location>
+          <name>Hachinohe Airport</name>
+          <code>RJSH</code>
+          <coordinates>40.556400 141.466000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Japan -->
         <name>Hakodate</name>
         <coordinates>41.775833 140.736667</coordinates>
         <location>
@@ -4311,6 +7185,26 @@
           <name>Hofu Air Base</name>
           <code>RJOF</code>
           <coordinates>34.033333 131.550000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Japan -->
+        <name>Ichigaya-honmurachō</name>
+        <coordinates>35.694370 139.728570</coordinates>
+        <location>
+          <name>Ichigaya</name>
+          <code>RJAI</code>
+          <coordinates>35.680000 139.720000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Japan -->
+        <name>Iki</name>
+        <coordinates>33.782860 129.720900</coordinates>
+        <location>
+          <name>Iki Airport</name>
+          <code>RJDB</code>
+          <coordinates>33.749000 129.785000</coordinates>
         </location>
       </city>
       <city>
@@ -4405,12 +7299,52 @@
       </city>
       <city>
         <!-- A city in Japan -->
+        <name>Kikai</name>
+        <coordinates>28.316670 129.933330</coordinates>
+        <location>
+          <name>Kikai Airport</name>
+          <code>RJKI</code>
+          <coordinates>28.321300 129.927990</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Japan -->
+        <name>Kisarazu</name>
+        <coordinates>35.383290 139.932540</coordinates>
+        <location>
+          <name>Kisarazu Airport</name>
+          <code>RJTK</code>
+          <coordinates>35.398300 139.910000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Japan -->
+        <name>Kitadaitōjima</name>
+        <coordinates>25.944700 131.327000</coordinates>
+        <location>
+          <name>Kitadaito Airport</name>
+          <code>RORK</code>
+          <coordinates>25.944700 131.327000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Japan -->
         <name>Kitakyushu</name>
         <coordinates>33.833333 130.833333</coordinates>
         <location>
           <name>Kitakyushu Airport</name>
           <code>RJFR</code>
           <coordinates>33.833333 130.950000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Japan -->
+        <name>Kobe</name>
+        <coordinates>34.691300 135.183000</coordinates>
+        <location>
+          <name>Kobe Airport</name>
+          <code>RJBE</code>
+          <coordinates>34.632800 135.224000</coordinates>
         </location>
       </city>
       <city>
@@ -4461,6 +7395,16 @@
           <name>Kushiro Airport</name>
           <code>RJCK</code>
           <coordinates>43.033333 144.200000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Japan -->
+        <name>Makinohara / Shimada</name>
+        <coordinates>34.774370 138.148310</coordinates>
+        <location>
+          <name>Mt. Fuji Shizuoka Airport</name>
+          <code>RJNS</code>
+          <coordinates>34.796040 138.187750</coordinates>
         </location>
       </city>
       <city>
@@ -4535,6 +7479,16 @@
       </city>
       <city>
         <!-- A city in Japan -->
+        <name>Minamidaito</name>
+        <coordinates>25.829870 131.232340</coordinates>
+        <location>
+          <name>Minami Daito Airport</name>
+          <code>ROMD</code>
+          <coordinates>25.846500 131.263000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Japan -->
         <name>Misawa</name>
         <coordinates>40.683611 141.359722</coordinates>
         <location>
@@ -4571,6 +7525,16 @@
           <name>Mombetsu Airport</name>
           <code>RJEB</code>
           <coordinates>44.250000 143.533333</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Japan -->
+        <name>Motobu</name>
+        <coordinates>26.659010 127.906670</coordinates>
+        <location>
+          <name>Ie Shima Auxiliary Air Base</name>
+          <code>RODE</code>
+          <coordinates>26.729000 127.762000</coordinates>
         </location>
       </city>
       <city>
@@ -4730,6 +7694,16 @@
       </city>
       <city>
         <!-- A city in Japan -->
+        <name>Ominato</name>
+        <coordinates>41.233000 141.133000</coordinates>
+        <location>
+          <name>JASDF Airport</name>
+          <code>RJSO</code>
+          <coordinates>41.233000 141.133000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Japan -->
         <name>Osaka</name>
         <coordinates>34.666667 135.500000</coordinates>
         <location>
@@ -4766,6 +7740,16 @@
           <name>New Tokyo International Airport</name>
           <code>RJAA</code>
           <coordinates>35.766667 140.383333</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Japan -->
+        <name>Sapporo</name>
+        <coordinates>43.066670 141.350000</coordinates>
+        <location>
+          <name>Okadama Airport</name>
+          <code>RJCO</code>
+          <coordinates>43.116100 141.380000</coordinates>
         </location>
       </city>
       <city>
@@ -4825,12 +7809,32 @@
       </city>
       <city>
         <!-- A city in Japan -->
+        <name>Tarama</name>
+        <coordinates>24.668510 124.702590</coordinates>
+        <location>
+          <name>Tarama Airport</name>
+          <code>RORT</code>
+          <coordinates>24.653900 124.675000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Japan -->
         <name>Tateyama</name>
         <coordinates>34.983333 139.866667</coordinates>
         <location>
           <name>Tateyama Air Base</name>
           <code>RJTE</code>
           <coordinates>34.983333 139.833333</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Japan -->
+        <name>Tokushima</name>
+        <coordinates>34.066670 134.566670</coordinates>
+        <location>
+          <name>Tokushima Airport</name>
+          <code>RJOS</code>
+          <coordinates>34.132800 134.606990</coordinates>
         </location>
       </city>
       <city>
@@ -4846,6 +7850,11 @@
           <name>Tokyo International Airport</name>
           <code>RJTT</code>
           <coordinates>35.550000 139.783333</coordinates>
+        </location>
+        <location>
+          <name>Tachikawa Airfield</name>
+          <code>RJTC</code>
+          <coordinates>35.710800 139.403000</coordinates>
         </location>
       </city>
       <city>
@@ -4900,12 +7909,52 @@
       </city>
       <city>
         <!-- A city in Japan -->
+        <name>Utsunomiya</name>
+        <coordinates>36.566670 139.883330</coordinates>
+        <location>
+          <name>Utsunomiya Airport</name>
+          <code>RJTU</code>
+          <coordinates>36.514500 139.871000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Japan -->
+        <name>Wadomari</name>
+        <coordinates>27.383330 128.650000</coordinates>
+        <location>
+          <name>Okierabu Airport</name>
+          <code>RJKB</code>
+          <coordinates>27.425500 128.701000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Japan -->
+        <name>Wajima</name>
+        <coordinates>37.404580 136.899120</coordinates>
+        <location>
+          <name>Noto Airport</name>
+          <code>RJNW</code>
+          <coordinates>37.293100 136.962010</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Japan -->
         <name>Wakkanai</name>
         <coordinates>45.409444 141.673889</coordinates>
         <location>
           <name>Wakkanai Airport</name>
           <code>RJCW</code>
           <coordinates>45.400000 141.800000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Japan -->
+        <name>Yakushima</name>
+        <coordinates>30.387960 130.649240</coordinates>
+        <location>
+          <name>Yakushima Airport</name>
+          <code>RJFC</code>
+          <coordinates>30.385600 130.659000</coordinates>
         </location>
       </city>
       <city>
@@ -4950,12 +7999,42 @@
       </city>
       <city>
         <!-- A city in Japan -->
+        <name>Yonaguni</name>
+        <coordinates>24.466670 123.000000</coordinates>
+        <location>
+          <name>Yonaguni Airport</name>
+          <code>ROYN</code>
+          <coordinates>24.466900 122.978000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Japan -->
+        <name>Yoron</name>
+        <coordinates>27.048730 128.418200</coordinates>
+        <location>
+          <name>Yoron Airport</name>
+          <code>RORY</code>
+          <coordinates>27.044000 128.401990</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Japan -->
         <name>Yoshinaga</name>
         <coordinates>34.800000 138.300000</coordinates>
         <location>
           <name>Shizuhama Air Base</name>
           <code>RJNY</code>
           <coordinates>34.816667 138.300000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Japan -->
+        <name>Zama</name>
+        <coordinates>35.487900 139.391010</coordinates>
+        <location>
+          <name>Kastner Army Air Field / Camp Zama</name>
+          <code>RJTR</code>
+          <coordinates>35.514000 139.394000</coordinates>
         </location>
       </city>
     </country>
@@ -5156,12 +8235,42 @@
       </city>
       <city>
         <!-- A city in Kazakhstan -->
+        <name>Taldy Kurgan</name>
+        <coordinates>45.126200 78.447000</coordinates>
+        <location>
+          <name>Taldykorgan Airport</name>
+          <code>UAAT</code>
+          <coordinates>45.126200 78.447000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Kazakhstan -->
         <name>Taraz</name>
         <coordinates>42.901070 71.378531</coordinates>
         <location>
           <name>Taraz Airport</name>
           <code>UADD</code>
           <coordinates>42.866460 71.293308</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Kazakhstan -->
+        <name>Turkıstan</name>
+        <coordinates>43.306670 68.550170</coordinates>
+        <location>
+          <name>Turkistan International Airport</name>
+          <code>UAIT</code>
+          <coordinates>43.306670 68.550170</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Kazakhstan -->
+        <name>Zhezkazgan</name>
+        <coordinates>47.794110 67.706280</coordinates>
+        <location>
+          <name>Zhezkazgan Airport</name>
+          <code>UAKD</code>
+          <coordinates>47.708300 67.733300</coordinates>
         </location>
       </city>
     </country>
@@ -5187,6 +8296,31 @@
           <code>UAFM</code>
           <coordinates>42.850000 74.583333</coordinates>
         </location>
+        <location>
+          <name>Manas International Airport</name>
+          <code>UCFM</code>
+          <coordinates>43.061300 74.477600</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Kyrgyzstan -->
+        <name>Osh</name>
+        <coordinates>40.528280 72.798500</coordinates>
+        <location>
+          <name>Osh Airport</name>
+          <code>UCFO</code>
+          <coordinates>40.609000 72.793300</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Kyrgyzstan -->
+        <name>Tamchy</name>
+        <coordinates>42.588300 76.713300</coordinates>
+        <location>
+          <name>Issyk-Kul International Airport</name>
+          <code>UCFL</code>
+          <coordinates>42.588300 76.713300</coordinates>
+        </location>
       </city>
     </country>
     <country>
@@ -5202,6 +8336,46 @@
         <timezone id="Asia/Vientiane" />
       </timezones>
       <tz-hint>Asia/Vientiane</tz-hint>
+      <city>
+        <!-- A city in Laos -->
+        <name>Luang Namtha</name>
+        <coordinates>20.948600 101.401880</coordinates>
+        <location>
+          <name>Luang Namtha Airport</name>
+          <code>VLLN</code>
+          <coordinates>20.967000 101.400000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Laos -->
+        <name>Luang Phabang</name>
+        <coordinates>19.897300 102.161000</coordinates>
+        <location>
+          <name>Luang Phabang International Airport</name>
+          <code>VLLB</code>
+          <coordinates>19.897300 102.161000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Laos -->
+        <name>Pakse</name>
+        <coordinates>15.120220 105.798980</coordinates>
+        <location>
+          <name>Pakse International Airport</name>
+          <code>VLPS</code>
+          <coordinates>15.132100 105.781000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Laos -->
+        <name>Savannakhet</name>
+        <coordinates>16.570300 104.762200</coordinates>
+        <location>
+          <name>Savannakhet Airport</name>
+          <code>VLSK</code>
+          <coordinates>16.556600 104.760000</coordinates>
+        </location>
+      </city>
       <city>
         <!-- The capital of Laos.
              "Vientiane" is the traditional English name.
@@ -5257,10 +8431,6 @@
     <country>
       <!-- MY - Malaysia -->
       <name>Malaysia</name>
-      <!-- Could not find information about the following stations,
-           which may be in Malaysia:
-           WBGY WMAU WMKA WMKB WMKI WMKN 
-        -->
       <iso-code>MY</iso-code>
       <fips-code>MY</fips-code>
       <timezones>
@@ -5271,12 +8441,32 @@
       <tz-hint>Asia/Kuala_Lumpur</tz-hint>
       <city>
         <!-- A city in Malaysia -->
+        <name>Alor Satar</name>
+        <coordinates>6.189670 100.398000</coordinates>
+        <location>
+          <name>Sultan Abdul Halim Airport</name>
+          <code>WMKA</code>
+          <coordinates>6.189670 100.398000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Malaysia -->
         <name>Bintulu</name>
         <coordinates>3.166667 113.033333</coordinates>
         <location>
           <name>Bintulu</name>
           <code>WBGB</code>
           <coordinates>3.200000 113.033333</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Malaysia -->
+        <name>Butterworth</name>
+        <coordinates>5.399100 100.363820</coordinates>
+        <location>
+          <name>Butterworth Airport</name>
+          <code>WMKB</code>
+          <coordinates>5.465920 100.391000</coordinates>
         </location>
       </city>
       <city>
@@ -5291,12 +8481,32 @@
       </city>
       <city>
         <!-- A city in Malaysia -->
+        <name>Ipoh</name>
+        <coordinates>4.584100 101.082900</coordinates>
+        <location>
+          <name>Sultan Azlan Shah Airport</name>
+          <code>WMKI</code>
+          <coordinates>4.567970 101.092000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Malaysia -->
         <name>Johor Bahru</name>
         <coordinates>1.466667 103.750000</coordinates>
         <location>
           <name>Senai Airport</name>
           <code>WMKJ</code>
           <coordinates>1.633333 103.666667</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Malaysia -->
+        <name>Kerteh</name>
+        <coordinates>4.514100 103.448300</coordinates>
+        <location>
+          <name>Kerteh Airport</name>
+          <code>WMKE</code>
+          <coordinates>4.537220 103.427000</coordinates>
         </location>
       </city>
       <city>
@@ -5351,6 +8561,16 @@
       </city>
       <city>
         <!-- A city in Malaysia -->
+        <name>Kuala Terengganu</name>
+        <coordinates>5.330200 103.140800</coordinates>
+        <location>
+          <name>Sultan Mahmud Airport</name>
+          <code>WMKN</code>
+          <coordinates>5.382640 103.103000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Malaysia -->
         <name>Kuantan</name>
         <coordinates>3.800000 103.333333</coordinates>
         <location>
@@ -5387,6 +8607,16 @@
           <name>Melaka</name>
           <code>WMKM</code>
           <coordinates>2.266667 102.250000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Malaysia -->
+        <name>Mersing</name>
+        <coordinates>2.431200 103.840500</coordinates>
+        <location>
+          <name>Mersing Airport</name>
+          <code>WMAU</code>
+          <coordinates>2.383000 103.867000</coordinates>
         </location>
       </city>
       <city>
@@ -5431,6 +8661,17 @@
       </city>
       <city>
         <!-- A city in Malaysia -->
+        <name>Simanggang</name>
+        <coordinates>1.247220 111.452780</coordinates>
+        <location>
+          <name>Simanggang Airport</name>
+          <code>WBGY</code>
+          <tz-hint>Asia/Kuching</tz-hint>
+          <coordinates>1.217000 111.450000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Malaysia -->
         <name>Sitiawan</name>
         <coordinates>4.216667 100.700000</coordinates>
         <location>
@@ -5469,6 +8710,46 @@
         <timezone id="Indian/Maldives" />
       </timezones>
       <tz-hint>Indian/Maldives</tz-hint>
+      <city>
+        <!-- A city in Maldives -->
+        <name>Gan</name>
+        <coordinates>-0.693330 73.155560</coordinates>
+        <location>
+          <name>Gan International Airport</name>
+          <code>VRMG</code>
+          <coordinates>-0.693330 73.155560</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Maldives -->
+        <name>Haa Dhaalu Atoll</name>
+        <coordinates>6.746110 73.168330</coordinates>
+        <location>
+          <name>Hanimaadhoo International Airport</name>
+          <code>VRMH</code>
+          <coordinates>6.746110 73.168330</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Maldives -->
+        <name>Huvadhu Atoll</name>
+        <coordinates>0.488330 72.996110</coordinates>
+        <location>
+          <name>Kaadedhdhoo Airport</name>
+          <code>VRMT</code>
+          <coordinates>0.488330 72.996110</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Maldives -->
+        <name>Kadhdhoo</name>
+        <coordinates>1.858330 73.519720</coordinates>
+        <location>
+          <name>Kadhdhoo Airport</name>
+          <code>VRMK</code>
+          <coordinates>1.858330 73.519720</coordinates>
+        </location>
+      </city>
       <city>
         <!-- The capital of the Maldives.
              "Male" is the traditional English name.
@@ -5521,6 +8802,16 @@
           <coordinates>47.850000 106.766667</coordinates>
         </location>
       </city>
+      <city>
+        <!-- A city in Mongolia -->
+        <name>Ulaanbaatar (Sergelen)</name>
+        <coordinates>47.907710 106.883240</coordinates>
+        <location>
+          <name>Chinggis Khaan International Airport</name>
+          <code>ZMCK</code>
+          <coordinates>47.646670 106.820000</coordinates>
+        </location>
+      </city>
     </country>
     <country>
       <!-- MM - Myanmar (also known as Burma, but "Myanmar" is
@@ -5528,16 +8819,22 @@
            more Google hits in English)
         -->
       <name>Myanmar</name>
-      <!-- Could not find information about the following stations,
-           which may be in Myanmar:
-           VYMD 
-        -->
       <iso-code>MM</iso-code>
       <fips-code>BM</fips-code>
       <timezones>
         <timezone id="Asia/Yangon" />
       </timezones>
       <tz-hint>Asia/Yangon</tz-hint>
+      <city>
+        <!-- A city in Myanmar -->
+        <name>Mandalay</name>
+        <coordinates>21.974730 96.083590</coordinates>
+        <location>
+          <name>Mandalay International Airport</name>
+          <code>VYMD</code>
+          <coordinates>21.702200 95.977900</coordinates>
+        </location>
+      </city>
       <city>
         <!-- The capital of Myanmar.
              "Rangoon" is the traditional English name.
@@ -5579,16 +8876,22 @@
            Korea
         -->
       <name>North Korea</name>
-      <!-- Could not find weather stations for the following major
-           cities:
-           Pyongyang
-        -->
       <iso-code>KP</iso-code>
       <fips-code>KN</fips-code>
       <timezones>
         <timezone id="Asia/Pyongyang" />
       </timezones>
       <tz-hint>Asia/Pyongyang</tz-hint>
+      <city>
+        <!-- A city in North Korea -->
+        <name>Pyongyang</name>
+        <coordinates>39.033850 125.754320</coordinates>
+        <location>
+          <name>Pyongyang International Airport</name>
+          <code>ZKPY</code>
+          <coordinates>39.224100 125.670000</coordinates>
+        </location>
+      </city>
     </country>
     <country>
       <!-- PK - Pakistan -->
@@ -5599,6 +8902,36 @@
         <timezone id="Asia/Karachi" />
       </timezones>
       <tz-hint>Asia/Karachi</tz-hint>
+      <city>
+        <!-- A city in Pakistan -->
+        <name>Attock</name>
+        <coordinates>33.766710 72.359770</coordinates>
+        <location>
+          <name>Islamabad International Airport</name>
+          <code>OPIS</code>
+          <coordinates>33.549080 72.825650</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Pakistan -->
+        <name>Faisalabad</name>
+        <coordinates>31.415540 73.089690</coordinates>
+        <location>
+          <name>Faisalabad International Airport</name>
+          <code>OPFA</code>
+          <coordinates>31.365000 72.994800</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Pakistan -->
+        <name>Gurandani</name>
+        <coordinates>25.296733 62.498822</coordinates>
+        <location>
+          <name>New Gwadar International Airport</name>
+          <code>OPGW</code>
+          <coordinates>25.296733 62.498822</coordinates>
+        </location>
+      </city>
       <city>
         <!-- The capital of Pakistan -->
         <name>Islamabad</name>
@@ -5631,12 +8964,42 @@
       </city>
       <city>
         <!-- A city in Pakistan -->
+        <name>Multan</name>
+        <coordinates>30.196790 71.478240</coordinates>
+        <location>
+          <name>Multan International Airport</name>
+          <code>OPMT</code>
+          <coordinates>30.203200 71.419100</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Pakistan -->
         <name>Nawabshah</name>
         <coordinates>26.250000 68.416667</coordinates>
         <location>
           <name>Nawabshah</name>
           <code>OPNH</code>
           <coordinates>26.250000 68.366667</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Pakistan -->
+        <name>Peshawar</name>
+        <coordinates>34.008000 71.578490</coordinates>
+        <location>
+          <name>Peshawar International Airport</name>
+          <code>OPPS</code>
+          <coordinates>33.993900 71.514600</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Pakistan -->
+        <name>Sialkot</name>
+        <coordinates>32.492680 74.531340</coordinates>
+        <location>
+          <name>Sialkot Airport</name>
+          <code>OPST</code>
+          <coordinates>32.535560 74.363890</coordinates>
         </location>
       </city>
     </country>
@@ -5667,6 +9030,36 @@
           <name>Davao Airport</name>
           <code>RPMD</code>
           <coordinates>7.116667 125.650000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Philippines -->
+        <name>Dumaguete City</name>
+        <coordinates>9.306460 123.307690</coordinates>
+        <location>
+          <name>Sibulan Airport</name>
+          <code>RPVD</code>
+          <coordinates>9.333710 123.300000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Philippines -->
+        <name>General Santos</name>
+        <coordinates>6.112780 125.171670</coordinates>
+        <location>
+          <name>General Santos International Airport</name>
+          <code>RPMR</code>
+          <coordinates>6.058000 125.096000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Philippines -->
+        <name>Kalibo</name>
+        <coordinates>11.706110 122.364440</coordinates>
+        <location>
+          <name>Kalibo International Airport</name>
+          <code>RPVK</code>
+          <coordinates>11.679400 122.376000</coordinates>
         </location>
       </city>
       <city>
@@ -5710,6 +9103,16 @@
         </location>
       </city>
       <city>
+        <!-- A city in Philippines -->
+        <name>Puerto Princesa</name>
+        <coordinates>9.739170 118.735280</coordinates>
+        <location>
+          <name>Puerto Princesa Airport</name>
+          <code>RPVP</code>
+          <coordinates>9.742120 118.759000</coordinates>
+        </location>
+      </city>
+      <city>
         <!-- A city in the Philippines -->
         <name>Subic</name>
         <coordinates>14.879722 120.233333</coordinates>
@@ -5733,16 +9136,22 @@
     <country>
       <!-- SG - Singapore -->
       <name msgctxt="Country">Singapore</name>
-      <!-- Could not find information about the following stations,
-           which may be in Singapore:
-           WSSL 
-        -->
       <iso-code>SG</iso-code>
       <fips-code>SN</fips-code>
       <timezones>
         <timezone id="Asia/Singapore" />
       </timezones>
       <tz-hint>Asia/Singapore</tz-hint>
+      <city>
+        <!-- A city in Singapore -->
+        <name>Seletar</name>
+        <coordinates>1.416950 103.868000</coordinates>
+        <location>
+          <name>Seletar Airport</name>
+          <code>WSSL</code>
+          <coordinates>1.416950 103.868000</coordinates>
+        </location>
+      </city>
       <city>
         <!-- The capital of Singapore -->
         <name msgctxt="City in Singapore">Singapore</name>
@@ -5762,16 +9171,34 @@
     <country>
       <!-- KR - The Republic of Korea, aka South Korea -->
       <name>South Korea</name>
-      <!-- Could not find information about the following stations,
-           which may be in South Korea:
-           RKJB RKNY 
-        -->
       <iso-code>KR</iso-code>
       <fips-code>KS</fips-code>
       <timezones>
         <timezone id="Asia/Seoul" />
       </timezones>
       <tz-hint>Asia/Seoul</tz-hint>
+      <city>
+        <!-- A city in South Korea -->
+        <name>Baengnyeongdo</name>
+        <coordinates>37.951390 124.673200</coordinates>
+        <location>
+          <name>Baengnyeongdo Air Base</name>
+          <code>RKSP</code>
+          <tz-hint>Asia/Seoul</tz-hint>
+          <coordinates>37.933000 124.667000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in South Korea -->
+        <name>Boryeong</name>
+        <coordinates>36.349310 126.597720</coordinates>
+        <location>
+          <name>Woong Cheon</name>
+          <code>RKTW</code>
+          <tz-hint>Asia/Seoul</tz-hint>
+          <coordinates>36.200000 126.550000</coordinates>
+        </location>
+      </city>
       <city>
         <!-- A city in South Korea -->
         <name>Ch'ongju</name>
@@ -5794,6 +9221,75 @@
       </city>
       <city>
         <!-- A city in South Korea -->
+        <name>Daejeon</name>
+        <coordinates>36.349130 127.384930</coordinates>
+        <location>
+          <name>Taejon</name>
+          <code>RKTF</code>
+          <tz-hint>Asia/Seoul</tz-hint>
+          <coordinates>36.300000 127.400000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in South Korea -->
+        <name>Ganghwa-gun</name>
+        <coordinates>37.747220 126.485560</coordinates>
+        <location>
+          <name>Pyoripsan</name>
+          <code>RKSV</code>
+          <tz-hint>Asia/Seoul</tz-hint>
+          <coordinates>37.783000 126.367000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in South Korea -->
+        <name>Gangneung</name>
+        <coordinates>37.752660 128.872390</coordinates>
+        <location>
+          <name>Gangneung Airport</name>
+          <code>RKNN</code>
+          <coordinates>37.753600 128.944000</coordinates>
+        </location>
+        <location>
+          <name>Whang Ryeong</name>
+          <code>RKNF</code>
+          <tz-hint>Asia/Seoul</tz-hint>
+          <coordinates>37.750000 128.667000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in South Korea -->
+        <name>Gimseang-ro</name>
+        <coordinates>37.030000 127.885000</coordinates>
+        <location>
+          <name>Jungwon Air Base</name>
+          <code>RKTI</code>
+          <coordinates>37.030000 127.885000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in South Korea -->
+        <name>Gonghang-ro</name>
+        <coordinates>38.061300 128.669010</coordinates>
+        <location>
+          <name>Yangyang International Airport</name>
+          <code>RKNY</code>
+          <coordinates>38.061300 128.669010</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in South Korea -->
+        <name>Gwangmyeong</name>
+        <coordinates>37.477220 126.866390</coordinates>
+        <location>
+          <name>Korean AF HQ</name>
+          <code>RKSF</code>
+          <tz-hint>Asia/Seoul</tz-hint>
+          <coordinates>37.500000 126.917000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in South Korea -->
         <name>Inch'on</name>
         <coordinates>37.453611 126.731667</coordinates>
         <location>
@@ -5804,12 +9300,33 @@
       </city>
       <city>
         <!-- A city in South Korea -->
+        <name>Kangnyŏng</name>
+        <coordinates>37.700000 125.700000</coordinates>
+        <location>
+          <name>Yeonpyeungdo</name>
+          <code>RKSQ</code>
+          <tz-hint>Asia/Seoul</tz-hint>
+          <coordinates>37.700000 125.700000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in South Korea -->
         <name>Kunsan</name>
         <coordinates>35.978611 126.711389</coordinates>
         <location>
           <name>Kunsan Air Base</name>
           <code>RKJK</code>
           <coordinates>35.916667 126.616667</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in South Korea -->
+        <name>Muan (Piseo-ri)</name>
+        <coordinates>34.990140 126.478990</coordinates>
+        <location>
+          <name>Muan International Airport</name>
+          <code>RKJB</code>
+          <coordinates>34.991410 126.382810</coordinates>
         </location>
       </city>
       <city>
@@ -5845,6 +9362,37 @@
         </location>
       </city>
       <city>
+        <!-- A city in South Korea -->
+        <name>Seogwipo</name>
+        <coordinates>33.253330 126.561810</coordinates>
+        <location>
+          <name>Mosulpo (KOR-AFB)</name>
+          <code>RKPM</code>
+          <tz-hint>Asia/Seoul</tz-hint>
+          <coordinates>33.200000 126.267000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in South Korea -->
+        <name>Seongmu</name>
+        <coordinates>36.568200 127.500000</coordinates>
+        <location>
+          <name>Seongmu Airport</name>
+          <code>RKTE</code>
+          <coordinates>36.568200 127.500000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in South Korea -->
+        <name>Seosan</name>
+        <coordinates>36.781670 126.452220</coordinates>
+        <location>
+          <name>Seosan Air Base</name>
+          <code>RKTP</code>
+          <coordinates>36.704000 126.486000</coordinates>
+        </location>
+      </city>
+      <city>
         <!-- The capital of South Korea.
              "Seoul" is the traditional English name.
              The local name in Korean is "Soul".
@@ -5856,6 +9404,22 @@
           <code>RKSS</code>
           <coordinates>37.550000 126.800000</coordinates>
         </location>
+        <location>
+          <name>Seoul Air Base</name>
+          <code>RKSM</code>
+          <tz-hint>Asia/Seoul</tz-hint>
+          <coordinates>37.446000 127.114000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in South Korea -->
+        <name>Suwon</name>
+        <coordinates>37.291110 127.008890</coordinates>
+        <location>
+          <name>Suwon Airport</name>
+          <code>RKSW</code>
+          <coordinates>37.239400 127.007000</coordinates>
+        </location>
       </city>
       <city>
         <!-- A city in South Korea -->
@@ -5865,6 +9429,59 @@
           <name>Taegu Air Base</name>
           <code>RKTN</code>
           <coordinates>35.900000 128.650000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in South Korea -->
+        <name>Taesal-li</name>
+        <coordinates>36.971400 126.454200</coordinates>
+        <location>
+          <name>Paekado</name>
+          <code>RKTB</code>
+          <tz-hint>Asia/Seoul</tz-hint>
+          <coordinates>37.017000 126.050000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in South Korea -->
+        <name>T’aebaek</name>
+        <coordinates>37.175900 128.988900</coordinates>
+        <location>
+          <name>Kotar Range</name>
+          <code>RKNR</code>
+          <tz-hint>Asia/Seoul</tz-hint>
+          <coordinates>37.100000 128.900000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in South Korea -->
+        <name>Wonju</name>
+        <coordinates>37.351390 127.945280</coordinates>
+        <location>
+          <name>Wonju Airport</name>
+          <code>RKNW</code>
+          <coordinates>37.438100 127.960000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in South Korea -->
+        <name>Yangp'yŏng</name>
+        <coordinates>37.489720 127.490560</coordinates>
+        <location>
+          <name>Yeoju Range</name>
+          <code>RKSU</code>
+          <tz-hint>Asia/Seoul</tz-hint>
+          <coordinates>37.433000 127.633000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in South Korea -->
+        <name>Yecheon-ri</name>
+        <coordinates>36.657400 128.455140</coordinates>
+        <location>
+          <name>Yecheon Airport</name>
+          <code>RKTY</code>
+          <coordinates>36.631900 128.355000</coordinates>
         </location>
       </city>
     </country>
@@ -5886,6 +9503,21 @@
           <code>VCBI</code>
           <coordinates>7.166667 79.883333</coordinates>
         </location>
+        <location>
+          <name>Colombo Int Arpt Ratmalana Airport</name>
+          <code>VCCC</code>
+          <coordinates>6.821990 79.886200</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Sri Lanka -->
+        <name>Jaffna</name>
+        <coordinates>9.668450 80.007420</coordinates>
+        <location>
+          <name>Jaffna International Airport</name>
+          <code>VCCJ</code>
+          <coordinates>9.792330 80.070100</coordinates>
+        </location>
       </city>
       <city>
         <!-- A city in Sri Lanka -->
@@ -5895,6 +9527,16 @@
           <name>Katunayaka</name>
           <code>VCBI</code>
           <coordinates>7.166667 79.883333</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Sri Lanka -->
+        <name>Mattala</name>
+        <coordinates>6.284500 81.124170</coordinates>
+        <location>
+          <name>Mattala Rajapaksa International Airport</name>
+          <code>VCRI</code>
+          <coordinates>6.284500 81.124170</coordinates>
         </location>
       </city>
       <city>
@@ -5920,6 +9562,16 @@
       </timezones>
       <tz-hint>Asia/Taipei</tz-hint>
       <city>
+        <!-- A city in Taiwan -->
+        <name>Huxi</name>
+        <coordinates>23.568700 119.628000</coordinates>
+        <location>
+          <name>Makung Airport</name>
+          <code>RCQC</code>
+          <coordinates>23.568700 119.628000</coordinates>
+        </location>
+      </city>
+      <city>
         <!-- A city in Taiwan.
              The name is also written "高雄".
           -->
@@ -5932,6 +9584,16 @@
         </location>
       </city>
       <city>
+        <!-- A city in Taiwan -->
+        <name>Taitung City</name>
+        <coordinates>22.755000 121.102000</coordinates>
+        <location>
+          <name>Taitung Airport</name>
+          <code>RCFN</code>
+          <coordinates>22.755000 121.102000</coordinates>
+        </location>
+      </city>
+      <city>
         <!-- A city in Taiwan.
              The name is also written "埔頂".
           -->
@@ -5941,6 +9603,26 @@
           <name>Taoyuan International Airport</name>
           <code>RCTP</code>
           <coordinates>25.083333 121.216667</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Taiwan -->
+        <name>Taichung (Qingshui)</name>
+        <coordinates>24.146900 120.683900</coordinates>
+        <location>
+          <name>Taichung Ching Chuang Kang Airport</name>
+          <code>RCMQ</code>
+          <coordinates>24.264700 120.621000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Taiwan -->
+        <name>Tainan (Rende)</name>
+        <coordinates>22.990830 120.213330</coordinates>
+        <location>
+          <name>Tainan Airport</name>
+          <code>RCNN</code>
+          <coordinates>22.950400 120.206000</coordinates>
         </location>
       </city>
       <city>
@@ -5975,6 +9657,36 @@
           <coordinates>38.550000 68.783333</coordinates>
         </location>
       </city>
+      <city>
+        <!-- A city in Tajikistan -->
+        <name>Khujand</name>
+        <coordinates>40.282560 69.622160</coordinates>
+        <location>
+          <name>Khudzhand Airport</name>
+          <code>UTDL</code>
+          <coordinates>40.215400 69.694700</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Tajikistan -->
+        <name>Kulyab</name>
+        <coordinates>37.914590 69.784540</coordinates>
+        <location>
+          <name>Kulob Airport</name>
+          <code>UTDK</code>
+          <coordinates>37.988100 69.805000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Tajikistan -->
+        <name>Kurgan-Tyube</name>
+        <coordinates>37.836540 68.777620</coordinates>
+        <location>
+          <name>Qurghonteppa International Airport</name>
+          <code>UTDT</code>
+          <coordinates>37.866400 68.864700</coordinates>
+        </location>
+      </city>
     </country>
     <country>
       <!-- TH - Thailand -->
@@ -5996,6 +9708,17 @@
           <name>Bangkok</name>
           <code>VTBD</code>
           <coordinates>13.916667 100.600000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Thailand -->
+        <name>Betong</name>
+        <coordinates>5.774340 101.072310</coordinates>
+        <location>
+          <name>Betong International Airport</name>
+          <code>VTSY</code>
+          <tz-hint>Asia/Bangkok</tz-hint>
+          <coordinates>5.790000 101.150000</coordinates>
         </location>
       </city>
       <city>
@@ -6100,6 +9823,16 @@
       </city>
       <city>
         <!-- A city in Thailand -->
+        <name>Laem Ngop</name>
+        <coordinates>12.171690 102.394890</coordinates>
+        <location>
+          <name>Trat Airport</name>
+          <code>VTBO</code>
+          <coordinates>12.274600 102.319000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Thailand -->
         <name>Lampang</name>
         <coordinates>18.298333 99.507222</coordinates>
         <location>
@@ -6159,6 +9892,7 @@
         </location>
       </city>
       <city>
+        <!-- A city in Thailand -->
         <name>Nakhon Si Thammarat</name>
         <coordinates>8.546117 99.939499</coordinates>
         <location>
@@ -6259,6 +9993,16 @@
       </city>
       <city>
         <!-- A city in Thailand -->
+        <name>Sakon Nakhon</name>
+        <coordinates>17.161160 104.147250</coordinates>
+        <location>
+          <name>Sakon Nakhon Airport</name>
+          <code>VTUI</code>
+          <coordinates>17.195100 104.119000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Thailand -->
         <name>Sukhothai</name>
         <coordinates>17.232695 99.820653</coordinates>
         <location>
@@ -6330,13 +10074,73 @@
           <coordinates>37.983333 58.366667</coordinates>
         </location>
       </city>
+      <city>
+        <!-- A city in Turkmenistan -->
+        <name>Daşoguz</name>
+        <coordinates>41.836250 59.966610</coordinates>
+        <location>
+          <name>Dashoguz Airport</name>
+          <code>UTAT</code>
+          <coordinates>41.761100 59.826700</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Turkmenistan -->
+        <name>Jebel</name>
+        <coordinates>39.634150 54.230530</coordinates>
+        <location>
+          <name>Balkanabat International Airport</name>
+          <code>UTAN</code>
+          <coordinates>39.680500 54.204667</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Turkmenistan -->
+        <name>Kerki</name>
+        <coordinates>37.835730 65.210580</coordinates>
+        <location>
+          <name>Kerki International Airport</name>
+          <code>UTAE</code>
+          <coordinates>37.808889 65.212500</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Turkmenistan -->
+        <name>Mary</name>
+        <coordinates>37.593780 61.830310</coordinates>
+        <location>
+          <name>Mary Airport</name>
+          <code>UTAM</code>
+          <coordinates>37.619400 61.896700</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Turkmenistan -->
+        <name>Turkmenbashi</name>
+        <coordinates>40.022160 52.955170</coordinates>
+        <location>
+          <name>Turkmenbashi Airport</name>
+          <code>UTAK</code>
+          <coordinates>40.063300 53.007200</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Turkmenistan -->
+        <name>Türkmenabat</name>
+        <coordinates>39.073280 63.578610</coordinates>
+        <location>
+          <name>Turkmenabat International Airport</name>
+          <code>UTAV</code>
+          <coordinates>39.083300 63.613300</coordinates>
+        </location>
+      </city>
     </country>
     <country>
       <!-- UZ - Uzbekistan -->
       <name>Uzbekistan</name>
       <!-- Could not find information about the following stations,
            which may be in Uzbekistan:
-           UTAK UTAM UTAT UTAV UTDL UTFN UTSB UTSH UTSK 
+           UTFN UTSB UTSH UTSK
         -->
       <iso-code>UZ</iso-code>
       <fips-code>UZ</fips-code>
@@ -6348,11 +10152,77 @@
       <tz-hint>Asia/Tashkent</tz-hint>
       <city>
         <!-- A city in Uzbekistan -->
+        <name>Andijan</name>
+        <coordinates>40.783380 72.350670</coordinates>
+        <location>
+          <name>Andijan International Airport</name>
+          <code>UZFA</code>
+          <tz-hint>Asia/Tashkent</tz-hint>
+          <coordinates>40.727699 72.293999</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Uzbekistan -->
+        <name>Bukhara</name>
+        <coordinates>39.770260 64.430690</coordinates>
+        <location>
+          <name>Bukhara Airport</name>
+          <code>UZSB</code>
+          <tz-hint>Asia/Samarkand</tz-hint>
+          <coordinates>39.775000 64.483300</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Uzbekistan -->
+        <name>Fergana</name>
+        <coordinates>40.384210 71.784320</coordinates>
+        <location>
+          <name>Fergana International Airport</name>
+          <code>UZFF</code>
+          <tz-hint>Asia/Tashkent</tz-hint>
+          <coordinates>40.358799 71.745003</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Uzbekistan -->
+        <name>Karshi</name>
+        <coordinates>38.860560 65.789050</coordinates>
+        <location>
+          <name>Karshi Airport</name>
+          <code>UZSK</code>
+          <tz-hint>Asia/Samarkand</tz-hint>
+          <coordinates>38.802500 65.773060</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Uzbekistan -->
+        <name>Namangan</name>
+        <coordinates>40.998300 71.672570</coordinates>
+        <location>
+          <name>Namangan International Airport</name>
+          <code>UZFN</code>
+          <tz-hint>Asia/Tashkent</tz-hint>
+          <coordinates>40.984622 71.557800</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Uzbekistan -->
+        <name>Navoi</name>
+        <coordinates>40.084440 65.379170</coordinates>
+        <location>
+          <name>Navoi Airport</name>
+          <code>UZSA</code>
+          <tz-hint>Asia/Samarkand</tz-hint>
+          <coordinates>40.117200 65.170800</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Uzbekistan -->
         <name>Nukus</name>
         <coordinates>42.453056 59.610278</coordinates>
         <location>
           <name>Nukus / Karakalpakstan</name>
-          <code>UTNN</code>
+          <code>UZNN</code>
           <coordinates>42.480000 59.630000</coordinates>
         </location>
       </city>
@@ -6362,7 +10232,7 @@
         <coordinates>39.654167 66.959722</coordinates>
         <location>
           <name>Samarqand</name>
-          <code>UTSS</code>
+          <code>UZSS</code>
           <coordinates>39.566667 66.950000</coordinates>
         </location>
       </city>
@@ -6375,7 +10245,7 @@
         <coordinates>41.316667 69.250000</coordinates>
         <location>
           <name>Tashkent</name>
-          <code>UTTT</code>
+          <code>UZTT</code>
           <coordinates>41.266667 69.266667</coordinates>
         </location>
       </city>
@@ -6385,7 +10255,7 @@
         <coordinates>37.224167 67.278333</coordinates>
         <location>
           <name>Termiz</name>
-          <code>UTST</code>
+          <code>UZST</code>
           <coordinates>37.233333 67.266667</coordinates>
         </location>
       </city>
@@ -6395,7 +10265,7 @@
         <coordinates>41.550000 60.633333</coordinates>
         <location>
           <name>Urganch</name>
-          <code>UTNU</code>
+          <code>UZNU</code>
           <coordinates>41.583333 60.645000</coordinates>
         </location>
       </city>
@@ -6414,12 +10284,32 @@
       <tz-hint>Asia/Ho_Chi_Minh</tz-hint>
       <city>
         <!-- A city in Viet Nam -->
+        <name>Can Tho</name>
+        <coordinates>10.037110 105.788250</coordinates>
+        <location>
+          <name>Tra Noc Airport</name>
+          <code>VVCT</code>
+          <coordinates>10.085100 105.712000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Viet Nam -->
         <name>Da Nang</name>
         <coordinates>16.067778 108.220833</coordinates>
         <location>
           <name>Da Nang</name>
           <code>VVDN</code>
           <coordinates>16.033333 108.183333</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Viet Nam -->
+        <name>Haiphong (Hai An)</name>
+        <coordinates>20.864810 106.683450</coordinates>
+        <location>
+          <name>Cat Bi International Airport</name>
+          <code>VVCI</code>
+          <coordinates>20.819400 106.725000</coordinates>
         </location>
       </city>
       <city>
@@ -6446,6 +10336,46 @@
           <name>Ho Chi Minh</name>
           <code>VVTS</code>
           <coordinates>10.816667 106.666667</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Viet Nam -->
+        <name>Huế</name>
+        <coordinates>16.461900 107.595460</coordinates>
+        <location>
+          <name>Phu Bai Airport</name>
+          <code>VVPB</code>
+          <coordinates>16.401500 107.703000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Viet Nam -->
+        <name>Nha Trang/nha Trang aiurportCam Ranh</name>
+        <coordinates>12.245070 109.194320</coordinates>
+        <location>
+          <name>Cam Ranh Airport</name>
+          <code>VVCR</code>
+          <coordinates>11.998200 109.219000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Viet Nam -->
+        <name>Phu Quoc Island</name>
+        <coordinates>10.227000 103.967000</coordinates>
+        <location>
+          <name>Phu Quoc Airport</name>
+          <code>VVPQ</code>
+          <coordinates>10.227000 103.967000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Viet Nam -->
+        <name>Van Don</name>
+        <coordinates>21.118000 107.414170</coordinates>
+        <location>
+          <name>Van Don International Airport</name>
+          <code>VVVD</code>
+          <coordinates>21.118000 107.414170</coordinates>
         </location>
       </city>
     </country>
@@ -6482,6 +10412,17 @@
         <timezone id="America/Antigua" />
       </timezones>
       <tz-hint>America/Antigua</tz-hint>
+      <city>
+        <!-- A city in Antigua and Barbuda -->
+        <name>Codrington</name>
+        <coordinates>17.639400 -61.824370</coordinates>
+        <location>
+          <name>Burton-Nibbs International Airport</name>
+          <code>TAPB</code>
+          <tz-hint>America/Antigua</tz-hint>
+          <coordinates>17.621194 -61.798347</coordinates>
+        </location>
+      </city>
       <city>
         <!-- A city in Antigua and Barbuda -->
         <name>Fitches Creek</name>
@@ -6734,7 +10675,6 @@
            * Culebra:  TJCP
            * Fajardo:  TJFA
            * Mayagüez: TJMZ
-           * Ponce:    TJPS
            * Vieques:  TJVQ
         -->
       <name>Puerto Rico</name>
@@ -6792,6 +10732,17 @@
       </city>
       <city>
         <!-- A municipality of Puerto Rico -->
+        <name>Ponce</name>
+        <coordinates>18.008778 -66.564528</coordinates>
+        <location>
+          <name>Mercedita Airport</name>
+          <code>TJPS</code>
+          <zone>PRZ007</zone>
+          <coordinates>18.008778 -66.564528</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A municipality of Puerto Rico -->
         <name>San Juan</name>
         <coordinates>18.466334 -66.105722</coordinates>
         <location>
@@ -6814,14 +10765,20 @@
         <timezone id="America/St_Barthelemy" />
       </timezones>
       <tz-hint>America/St_Barthelemy</tz-hint>
+      <city>
+        <!-- A city in Saint Barthélemy -->
+        <name>Gustavia</name>
+        <coordinates>17.896180 -62.849780</coordinates>
+        <location>
+          <name>Gustaf III Airport</name>
+          <code>TFFJ</code>
+          <coordinates>17.904400 -62.843600</coordinates>
+        </location>
+      </city>
     </country>
     <country>
       <!-- SH - Saint Helena, a British territory in the South Atlantic -->
       <name>Saint Helena</name>
-      <!-- Could not find weather stations for the following major
-           cities:
-           Jamestown
-        -->
       <iso-code>SH</iso-code>
       <fips-code>SH</fips-code>
       <timezones>
@@ -6942,10 +10899,6 @@
     <country>
       <!-- AU - Australia -->
       <name>Australia</name>
-      <!-- Could not find information about the following stations,
-           which may be in Australia:
-           YBHM 
-        -->
       <iso-code>AU</iso-code>
       <fips-code>AS</fips-code>
       <timezones>
@@ -7371,21 +11324,193 @@
           </location>
         </city>
       </state>
+      <city>
+        <!-- A city in Australia -->
+        <name>Brassall</name>
+        <coordinates>-27.597530 152.747550</coordinates>
+        <location>
+          <name>Amberley</name>
+          <code>YAMB</code>
+          <tz-hint>Australia/Brisbane</tz-hint>
+          <coordinates>-27.641000 152.712000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Australia -->
+        <name>Busselton</name>
+        <coordinates>-33.652490 115.345500</coordinates>
+        <location>
+          <name>Busselton Regional Airport</name>
+          <code>YBLN</code>
+          <tz-hint>Australia/Perth</tz-hint>
+          <coordinates>-33.688420 115.401600</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Australia -->
+        <name>Coffs Harbour</name>
+        <coordinates>-30.296260 153.113510</coordinates>
+        <location>
+          <name>Coffs Harbour Airport</name>
+          <code>YCFS</code>
+          <tz-hint>Australia/Sydney</tz-hint>
+          <coordinates>-30.320601 153.115997</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Australia -->
+        <name>Derby</name>
+        <coordinates>-17.302950 123.628640</coordinates>
+        <location>
+          <name>RAAF Base Curtin</name>
+          <code>YCIN</code>
+          <tz-hint>Australia/Perth</tz-hint>
+          <coordinates>-17.581400 123.828000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Australia -->
+        <name>Forrest</name>
+        <coordinates>-30.838100 128.115010</coordinates>
+        <location>
+          <name>Forrest Airport</name>
+          <code>YFRT</code>
+          <tz-hint>Australia/Perth</tz-hint>
+          <coordinates>-30.838100 128.115010</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Australia -->
+        <name>Gladstone</name>
+        <coordinates>-23.848520 151.257750</coordinates>
+        <location>
+          <name>Gladstone Airport</name>
+          <code>YGLA</code>
+          <tz-hint>Australia/Brisbane</tz-hint>
+          <coordinates>-23.869700 151.223010</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Australia -->
+        <name>Hamilton Island</name>
+        <coordinates>-20.358100 148.952000</coordinates>
+        <location>
+          <name>Hamilton Island Airport</name>
+          <code>YBHM</code>
+          <tz-hint>Australia/Lindeman</tz-hint>
+          <coordinates>-20.358100 148.952000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Australia -->
+        <name>Horn</name>
+        <coordinates>-10.606480 142.281590</coordinates>
+        <location>
+          <name>Horn Island Airport</name>
+          <code>YHID</code>
+          <tz-hint>Australia/Brisbane</tz-hint>
+          <coordinates>-10.586400 142.289990</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Australia -->
+        <name>Lord Howe Island</name>
+        <coordinates>-31.538300 159.077000</coordinates>
+        <location>
+          <name>Lord Howe Island Airport</name>
+          <code>YLHI</code>
+          <tz-hint>Australia/Lord_Howe</tz-hint>
+          <coordinates>-31.538300 159.077000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Australia -->
+        <name>Maroochydore</name>
+        <coordinates>-26.660080 153.099530</coordinates>
+        <location>
+          <name>Sunshine Coast Airport</name>
+          <code>YBSU</code>
+          <tz-hint>Australia/Brisbane</tz-hint>
+          <coordinates>-26.593324 153.083190</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Australia -->
+        <name>Moonyoonooka</name>
+        <coordinates>-28.796100 114.707000</coordinates>
+        <location>
+          <name>Geraldton Airport</name>
+          <code>YGEL</code>
+          <tz-hint>Australia/Perth</tz-hint>
+          <coordinates>-28.796100 114.707000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Australia -->
+        <name>Nhulunbuy</name>
+        <coordinates>-12.181650 136.778410</coordinates>
+        <location>
+          <name>Gove Airport</name>
+          <code>YPGV</code>
+          <tz-hint>Australia/Darwin</tz-hint>
+          <coordinates>-12.269400 136.817990</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Australia -->
+        <name>Perth</name>
+        <coordinates>-31.952240 115.861400</coordinates>
+        <location>
+          <name>Perth Jandakot Airport</name>
+          <code>YPJT</code>
+          <tz-hint>Australia/Perth</tz-hint>
+          <coordinates>-32.097500 115.881000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Australia -->
+        <name>Toowoomba</name>
+        <coordinates>-27.560560 151.953860</coordinates>
+        <location>
+          <name>Toowoomba Wellcamp Airport</name>
+          <code>YBWW</code>
+          <tz-hint>Australia/Brisbane</tz-hint>
+          <coordinates>-27.558330 151.793330</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Australia -->
+        <name>Williamtown</name>
+        <coordinates>-32.806380 151.843610</coordinates>
+        <location>
+          <name>Newcastle Airport</name>
+          <code>YWLM</code>
+          <tz-hint>Australia/Sydney</tz-hint>
+          <coordinates>-32.795000 151.834000</coordinates>
+        </location>
+      </city>
     </country>
     <country>
       <!-- IO - British Indian Ocean Territory, which is exactly what
            it sounds like.
         -->
       <name>British Indian Ocean Territory</name>
-      <!-- Could not find cities for the following weather stations:
-           FJDG - Diego Garcia (-7.300000 72.400000)
-        -->
       <iso-code>IO</iso-code>
       <fips-code>IO</fips-code>
       <timezones>
         <timezone id="Indian/Chagos" />
       </timezones>
       <tz-hint>Indian/Chagos</tz-hint>
+      <city>
+        <!-- A city in British Indian Ocean Territory -->
+        <name>Diego Garcia</name>
+        <coordinates>-7.262290 72.376760</coordinates>
+        <location>
+          <name>Diego Garcia Naval Support Facility</name>
+          <code>FJDG</code>
+          <coordinates>-7.313270 72.411100</coordinates>
+        </location>
+      </city>
     </country>
     <country>
       <!-- CX - Christmas Island, a territory of Australia in the
@@ -7393,10 +11518,6 @@
            of the same name.
         -->
       <name>Christmas Island</name>
-      <!-- Could not find information about the following stations,
-           which may be in Christmas Island:
-           YPGV 
-        -->
       <iso-code>CX</iso-code>
       <fips-code>KT</fips-code>
       <timezones>
@@ -7458,6 +11579,26 @@
       </timezones>
       <tz-hint>Pacific/Rarotonga</tz-hint>
       <city>
+        <!-- A city in Cook Islands -->
+        <name>Aitutaki</name>
+        <coordinates>-18.830900 -159.764010</coordinates>
+        <location>
+          <name>Aitutaki Airport</name>
+          <code>NCAI</code>
+          <coordinates>-18.830900 -159.764010</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Cook Islands -->
+        <name>Atiu Island</name>
+        <coordinates>-19.967800 -158.119000</coordinates>
+        <location>
+          <name>Enua Airport</name>
+          <code>NCAT</code>
+          <coordinates>-19.967800 -158.119000</coordinates>
+        </location>
+      </city>
+      <city>
         <!-- The capital of the Cook Islands -->
         <name>Avarua</name>
         <coordinates>-21.207778 -159.775000</coordinates>
@@ -7465,6 +11606,56 @@
           <name>Rarotonga</name>
           <code>NCRG</code>
           <coordinates>-21.200000 -159.816667</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Cook Islands -->
+        <name>Mangaia Island</name>
+        <coordinates>-21.895990 -157.906660</coordinates>
+        <location>
+          <name>Mangaia Island Airport</name>
+          <code>NCMG</code>
+          <coordinates>-21.895990 -157.906660</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Cook Islands -->
+        <name>Manihiki Island</name>
+        <coordinates>-10.376700 -161.002000</coordinates>
+        <location>
+          <name>Manihiki Island Airport</name>
+          <code>NCMH</code>
+          <coordinates>-10.376700 -161.002000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Cook Islands -->
+        <name>Mauke Island</name>
+        <coordinates>-20.136100 -157.345000</coordinates>
+        <location>
+          <name>Mauke Airport</name>
+          <code>NCMK</code>
+          <coordinates>-20.136100 -157.345000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Cook Islands -->
+        <name>Mitiaro Island</name>
+        <coordinates>-19.842500 -157.703000</coordinates>
+        <location>
+          <name>Mitiaro Island Airport</name>
+          <code>NCMR</code>
+          <coordinates>-19.842500 -157.703000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Cook Islands -->
+        <name>Penrhyn Island</name>
+        <coordinates>-9.014370 -158.032410</coordinates>
+        <location>
+          <name>Tongareva Airport</name>
+          <code>NCPY</code>
+          <coordinates>-9.014370 -158.032410</coordinates>
         </location>
       </city>
     </country>
@@ -7481,6 +11672,76 @@
         <timezone id="Pacific/Fiji" />
       </timezones>
       <tz-hint>Pacific/Fiji</tz-hint>
+      <city>
+        <!-- A city in Fiji -->
+        <name>Labasa</name>
+        <coordinates>-16.433200 179.364510</coordinates>
+        <location>
+          <name>Labasa Airport</name>
+          <code>NFNL</code>
+          <coordinates>-16.466700 179.340000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Fiji -->
+        <name>Matei</name>
+        <coordinates>-16.690600 -179.877000</coordinates>
+        <location>
+          <name>Matei Airport</name>
+          <code>NFNM</code>
+          <coordinates>-16.690600 -179.877000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Fiji -->
+        <name>Nadi</name>
+        <coordinates>-17.803090 177.416170</coordinates>
+        <location>
+          <name>Nadi International Airport</name>
+          <code>NFFN</code>
+          <coordinates>-17.755400 177.442990</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Fiji -->
+        <name>Nausori</name>
+        <coordinates>-18.043300 178.559010</coordinates>
+        <location>
+          <name>Nausori International Airport</name>
+          <code>NFNA</code>
+          <coordinates>-18.043300 178.559010</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Fiji -->
+        <name>Rotuma</name>
+        <coordinates>-12.482500 177.071000</coordinates>
+        <location>
+          <name>Rotuma Airport</name>
+          <code>NFNR</code>
+          <coordinates>-12.482500 177.071000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Fiji -->
+        <name>Savusavu</name>
+        <coordinates>-16.779420 179.335640</coordinates>
+        <location>
+          <name>Savusavu Airport</name>
+          <code>NFNS</code>
+          <coordinates>-16.802800 179.341000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Fiji -->
+        <name>Vunisea</name>
+        <coordinates>-19.058100 178.157000</coordinates>
+        <location>
+          <name>Vunisea Airport</name>
+          <code>NFKD</code>
+          <coordinates>-19.058100 178.157000</coordinates>
+        </location>
+      </city>
     </country>
     <country>
       <!-- PF - French Polynesia, a French territory in the South
@@ -7515,6 +11776,26 @@
       </timezones>
       <tz-hint>Pacific/Tahiti</tz-hint>
       <city>
+        <!-- A city in French Polynesia -->
+        <name>Motu Mute</name>
+        <coordinates>-16.444400 -151.751010</coordinates>
+        <location>
+          <name>Bora Bora Airport</name>
+          <code>NTTB</code>
+          <coordinates>-16.444400 -151.751010</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in French Polynesia -->
+        <name>Otepa</name>
+        <coordinates>-18.106160 -140.905900</coordinates>
+        <location>
+          <name>Hao Airport</name>
+          <code>NTTO</code>
+          <coordinates>-18.074800 -140.946000</coordinates>
+        </location>
+      </city>
+      <city>
         <!-- The capital of French Polynesia -->
         <name>Papeete</name>
         <coordinates>-17.533333 -149.566667</coordinates>
@@ -7524,16 +11805,22 @@
           <coordinates>-17.550000 -149.616667</coordinates>
         </location>
       </city>
+      <city>
+        <!-- A city in French Polynesia -->
+        <name>Tubuai</name>
+        <coordinates>-23.365400 -149.524000</coordinates>
+        <location>
+          <name>Tubuai Airport</name>
+          <code>NTAT</code>
+          <coordinates>-23.365400 -149.524000</coordinates>
+        </location>
+      </city>
     </country>
     <country>
       <!-- GU - Guam, a territory of the United States in the South
            Pacific.
         -->
       <name>Guam</name>
-      <!-- Could not find information about the following stations,
-           which may be in Guam:
-           PGRO 
-        -->
       <iso-code>GU</iso-code>
       <fips-code>US66</fips-code>
       <timezones>
@@ -7604,13 +11891,22 @@
           <coordinates>1.983333 -157.483333</coordinates>
         </location>
       </city>
+      <city>
+        <!-- A city in Kiribati -->
+        <name>South Tarawa</name>
+        <coordinates>1.327800 172.976960</coordinates>
+        <location>
+          <name>Bonriki International Airport</name>
+          <code>NGTA</code>
+          <coordinates>1.381640 173.147000</coordinates>
+        </location>
+      </city>
     </country>
     <country>
       <!-- MH - Marshall Islands -->
       <name>Marshall Islands</name>
       <!-- Could not find cities for the following weather stations:
-           PKWA - Kwajalein, Bucholz AAF, Kwajalein KMR ATOL Airport
-           (8.716667 167.733333)
+           ATOL
         -->
       <iso-code>MH</iso-code>
       <fips-code>RM</fips-code>
@@ -7621,6 +11917,17 @@
         </timezone>
       </timezones>
       <tz-hint>Pacific/Majuro</tz-hint>
+      <city>
+        <!-- A city in Marshall Islands -->
+        <name>Kwajalein</name>
+        <coordinates>8.720124 167.731674</coordinates>
+        <location>
+          <name>Bucholz Army Air Field (Kwajalein) Airport</name>
+          <code>PKWA</code>
+          <tz-hint>Pacific/Kwajalein</tz-hint>
+          <coordinates>8.720124 167.731674</coordinates>
+        </location>
+      </city>
       <city>
         <!-- The capital of the Marshall Islands -->
         <name>Majuro</name>
@@ -7640,10 +11947,6 @@
     <country>
       <!-- FM - Federated States of Micronesia -->
       <name>Micronesia, Federated States of</name>
-      <!-- Could not find information about the following stations,
-           which may be in Micronesia, Federated States of:
-           PTKK PTPN PTSA PTYA 
-        -->
       <iso-code>FM</iso-code>
       <fips-code>FM</fips-code>
       <fips-code>US64</fips-code>
@@ -7669,6 +11972,17 @@
         </timezone>
       </timezones>
       <city>
+        <!-- A city in Micronesia, Federated States of -->
+        <name>Okat</name>
+        <coordinates>5.356972 162.958389</coordinates>
+        <location>
+          <name>Kosrae Airport</name>
+          <code>PTSA</code>
+          <tz-hint>Pacific/Kosrae</tz-hint>
+          <coordinates>5.356972 162.958389</coordinates>
+        </location>
+      </city>
+      <city>
         <!-- The capital of the Federated States of Micronesia -->
         <name>Palikir</name>
         <coordinates>6.916667 158.150000</coordinates>
@@ -7677,6 +11991,39 @@
           <code>PTTP</code>
           <tz-hint>Pacific/Pohnpei</tz-hint>
           <coordinates>6.966667 158.216667</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Micronesia, Federated States of -->
+        <name>Pohnpei Island</name>
+        <coordinates>6.985083 158.209806</coordinates>
+        <location>
+          <name>Pohnpei International Airport</name>
+          <code>PTPN</code>
+          <tz-hint>Pacific/Pohnpei</tz-hint>
+          <coordinates>6.985083 158.209806</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Micronesia, Federated States of -->
+        <name>Weno Island</name>
+        <coordinates>7.461891 151.843017</coordinates>
+        <location>
+          <name>Chuuk International Airport</name>
+          <code>PTKK</code>
+          <tz-hint>Pacific/Chuuk</tz-hint>
+          <coordinates>7.461891 151.843017</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Micronesia, Federated States of -->
+        <name>Yap Island</name>
+        <coordinates>9.498911 138.082484</coordinates>
+        <location>
+          <name>Yap International Airport</name>
+          <code>PTYA</code>
+          <tz-hint>Pacific/Chuuk</tz-hint>
+          <coordinates>9.498911 138.082484</coordinates>
         </location>
       </city>
     </country>
@@ -7777,6 +12124,36 @@
         </location>
       </city>
       <city>
+        <!-- A city in New Zealand -->
+        <name>Hamilton</name>
+        <coordinates>-37.783330 175.283330</coordinates>
+        <location>
+          <name>Hamilton International Airport</name>
+          <code>NZHN</code>
+          <coordinates>-37.866700 175.332000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in New Zealand -->
+        <name>Marton</name>
+        <coordinates>-40.069200 175.378230</coordinates>
+        <location>
+          <name>Ohakea</name>
+          <code>NZOH</code>
+          <coordinates>-40.206000 175.388000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in New Zealand -->
+        <name>Queenstown</name>
+        <coordinates>-45.030230 168.662710</coordinates>
+        <location>
+          <name>Queenstown International Airport</name>
+          <code>NZQN</code>
+          <coordinates>-45.021100 168.739000</coordinates>
+        </location>
+      </city>
+      <city>
         <!-- The capital of New Zealand -->
         <name>Wellington</name>
         <coordinates>-41.300000 174.783333</coordinates>
@@ -7854,6 +12231,16 @@
           <coordinates>14.983333 145.616667</coordinates>
         </location>
       </city>
+      <city>
+        <!-- A city in Northern Mariana Islands -->
+        <name>Rota Island</name>
+        <coordinates>14.174349 145.241119</coordinates>
+        <location>
+          <name>Benjamin Taisacan Manglona International Airport</name>
+          <code>PGRO</code>
+          <coordinates>14.174349 145.241119</coordinates>
+        </location>
+      </city>
     </country>
     <country>
       <!-- PW - Palau -->
@@ -7904,6 +12291,26 @@
       </timezones>
       <tz-hint>Pacific/Port_Moresby</tz-hint>
       <city>
+        <!-- A city in Papua New Guinea -->
+        <name>Lae</name>
+        <coordinates>-6.723330 146.996110</coordinates>
+        <location>
+          <name>Lae Nadzab Airport</name>
+          <code>AYNZ</code>
+          <coordinates>-6.569830 146.726000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Papua New Guinea -->
+        <name>Mount Hagen</name>
+        <coordinates>-5.857460 144.230580</coordinates>
+        <location>
+          <name>Mount Hagen Kagamuga Airport</name>
+          <code>AYMH</code>
+          <coordinates>-5.826790 144.296010</coordinates>
+        </location>
+      </city>
+      <city>
         <!-- The capital of Papua New Guinea -->
         <name>Port Moresby</name>
         <coordinates>-9.464722 147.192500</coordinates>
@@ -7911,6 +12318,16 @@
           <name>Moresby</name>
           <code>AYPY</code>
           <coordinates>-9.433333 147.216667</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Papua New Guinea -->
+        <name>Wewak</name>
+        <coordinates>-3.549640 143.632290</coordinates>
+        <location>
+          <name>Wewak International Airport</name>
+          <code>AYWK</code>
+          <coordinates>-3.583830 143.669010</coordinates>
         </location>
       </city>
     </country>
@@ -7979,6 +12396,16 @@
         <timezone id="Asia/Dili" />
       </timezones>
       <tz-hint>Asia/Dili</tz-hint>
+      <city>
+        <!-- A city in Timor-Leste -->
+        <name>Suai</name>
+        <coordinates>-9.312860 125.256480</coordinates>
+        <location>
+          <name>Suai Airport</name>
+          <code>WPDB</code>
+          <coordinates>-9.303310 125.287000</coordinates>
+        </location>
+      </city>
     </country>
     <country>
       <!-- TK - Tokelau, a territory of New Zealand -->
@@ -8010,6 +12437,16 @@
         </location>
       </city>
       <city>
+        <!-- A city in Tonga -->
+        <name>Lifuka</name>
+        <coordinates>-19.777000 -174.341000</coordinates>
+        <location>
+          <name>Lifuka Island Airport</name>
+          <code>NFTL</code>
+          <coordinates>-19.777000 -174.341000</coordinates>
+        </location>
+      </city>
+      <city>
         <!-- The capital of Tonga -->
         <name>Nuku'alofa</name>
         <coordinates>-21.133333 -175.200000</coordinates>
@@ -8017,6 +12454,16 @@
           <name>Fua'amotu</name>
           <code>NFTF</code>
           <coordinates>-21.233333 -175.150000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Tonga -->
+        <name>Vava'u Island</name>
+        <coordinates>-18.585300 -173.962010</coordinates>
+        <location>
+          <name>Vava'u International Airport</name>
+          <code>NFTV</code>
+          <coordinates>-18.585300 -173.962010</coordinates>
         </location>
       </city>
     </country>
@@ -8078,6 +12525,17 @@
         </timezone>
       </timezones>
       <city>
+        <!-- A city in United States Minor Outlying Islands -->
+        <name>Sand Island</name>
+        <coordinates>28.201484 -177.381309</coordinates>
+        <location>
+          <name>Henderson Field</name>
+          <code>PMDY</code>
+          <tz-hint>Pacific/Midway</tz-hint>
+          <coordinates>28.201484 -177.381309</coordinates>
+        </location>
+      </city>
+      <city>
         <!-- A city in the United States Minor Outlying Islands -->
         <name>Wake Island, Wake Island Army Airfield Airport</name>
         <coordinates>19.283333 166.650000</coordinates>
@@ -8101,6 +12559,66 @@
         <timezone id="Pacific/Efate" />
       </timezones>
       <tz-hint>Pacific/Efate</tz-hint>
+      <city>
+        <!-- A city in Vanuatu -->
+        <name>Anatom Island</name>
+        <coordinates>-20.249200 169.771000</coordinates>
+        <location>
+          <name>Anelghowhat Airport</name>
+          <code>NVVA</code>
+          <coordinates>-20.249200 169.771000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Vanuatu -->
+        <name>Longana</name>
+        <coordinates>-15.306700 167.967000</coordinates>
+        <location>
+          <name>Longana Airport</name>
+          <code>NVSG</code>
+          <coordinates>-15.306700 167.967000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Vanuatu -->
+        <name>Luganville</name>
+        <coordinates>-15.519890 167.162350</coordinates>
+        <location>
+          <name>Santo Pekoa International Airport</name>
+          <code>NVSS</code>
+          <coordinates>-15.505000 167.220000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Vanuatu -->
+        <name>Port Vila</name>
+        <coordinates>-17.736480 168.313660</coordinates>
+        <location>
+          <name>Port Vila Bauerfield Airport</name>
+          <code>NVVV</code>
+          <coordinates>-17.699300 168.320010</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Vanuatu -->
+        <name>Sola</name>
+        <coordinates>-13.876110 167.551670</coordinates>
+        <location>
+          <name>Sola Airport</name>
+          <code>NVSC</code>
+          <coordinates>-13.851700 167.537000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Vanuatu -->
+        <name>Tanna Island</name>
+        <coordinates>-19.455100 169.224000</coordinates>
+        <location>
+          <name>Tanna Airport</name>
+          <code>NVVW</code>
+          <coordinates>-19.455100 169.224000</coordinates>
+        </location>
+      </city>
     </country>
     <country>
       <!-- WF - Wallis and Futuna, a French territory in the South
@@ -8147,6 +12665,16 @@
       </timezones>
       <tz-hint>America/Argentina/Buenos_Aires</tz-hint>
       <city>
+        <!-- A city in Argentina -->
+        <name>Bahía Blanca</name>
+        <coordinates>-38.717600 -62.265450</coordinates>
+        <location>
+          <name>Comandante Espora Airport</name>
+          <code>SAZB</code>
+          <coordinates>-38.725000 -62.169300</coordinates>
+        </location>
+      </city>
+      <city>
         <!-- The capital of Argentina -->
         <name>Buenos Aires</name>
         <coordinates>-34.587500 -58.672500</coordinates>
@@ -8158,12 +12686,45 @@
       </city>
       <city>
         <!-- A city in Argentina -->
+        <name>Catamarca</name>
+        <coordinates>-28.469570 -65.785240</coordinates>
+        <location>
+          <name>Catamarca Airport</name>
+          <code>SANC</code>
+          <tz-hint>America/Argentina/Catamarca</tz-hint>
+          <coordinates>-28.595600 -65.751700</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Argentina -->
+        <name>Chapelco/San Martin de los Andes</name>
+        <coordinates>-40.075400 -71.137300</coordinates>
+        <location>
+          <name>Aviador C. Campos Airport</name>
+          <code>SAZY</code>
+          <tz-hint>America/Argentina/Ushuaia</tz-hint>
+          <coordinates>-40.075400 -71.137300</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Argentina -->
         <name>Comodoro Rivadavia</name>
         <coordinates>-45.866667 -67.500000</coordinates>
         <location>
           <name>Comodoro Rivadavia Airport</name>
           <code>SAVC</code>
           <coordinates>-45.783333 -67.500000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Argentina -->
+        <name>Concordia</name>
+        <coordinates>-31.391950 -58.017060</coordinates>
+        <location>
+          <name>Comodoro Pierrestegui Airport</name>
+          <code>SAAC</code>
+          <tz-hint>America/Argentina/Cordoba</tz-hint>
+          <coordinates>-31.296900 -57.996600</coordinates>
         </location>
       </city>
       <city>
@@ -8188,12 +12749,34 @@
       </city>
       <city>
         <!-- A city in Argentina -->
+        <name>El Calafate</name>
+        <coordinates>-50.340750 -72.276820</coordinates>
+        <location>
+          <name>El Calafate Airport</name>
+          <code>SAWC</code>
+          <tz-hint>America/Argentina/Rio_Gallegos</tz-hint>
+          <coordinates>-50.280300 -72.053100</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Argentina -->
         <name>El Palomar</name>
         <coordinates>-34.541667 -58.615278</coordinates>
         <location>
           <name>El Palomar Airport</name>
           <code>SADP</code>
           <coordinates>-34.600000 -58.600000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Argentina -->
+        <name>Esquel</name>
+        <coordinates>-42.911470 -71.319470</coordinates>
+        <location>
+          <name>Brigadier Antonio Parodi Airport</name>
+          <code>SAVE</code>
+          <tz-hint>America/Argentina/Catamarca</tz-hint>
+          <coordinates>-42.908000 -71.139500</coordinates>
         </location>
       </city>
       <city>
@@ -8218,6 +12801,70 @@
       </city>
       <city>
         <!-- A city in Argentina -->
+        <name>General Pico</name>
+        <coordinates>-35.659300 -63.757870</coordinates>
+        <location>
+          <name>General Pico Airport</name>
+          <code>SAZG</code>
+          <tz-hint>America/Argentina/Ushuaia</tz-hint>
+          <coordinates>-35.696200 -63.758300</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Argentina -->
+        <name>General Sarmiento</name>
+        <coordinates>-34.560600 -58.789600</coordinates>
+        <location>
+          <name>Mariano Moreno Airport</name>
+          <code>SADJ</code>
+          <coordinates>-34.560600 -58.789600</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Argentina -->
+        <name>Gualeguaychu</name>
+        <coordinates>-33.007770 -58.518360</coordinates>
+        <location>
+          <name>Gualeguaychu Airport</name>
+          <code>SAAG</code>
+          <tz-hint>America/Argentina/Cordoba</tz-hint>
+          <coordinates>-33.010300 -58.613100</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Argentina -->
+        <name>La Plata</name>
+        <coordinates>-34.921260 -57.954420</coordinates>
+        <location>
+          <name>La Plata Airport</name>
+          <code>SADL</code>
+          <coordinates>-34.972200 -57.894700</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Argentina -->
+        <name>La Rioja</name>
+        <coordinates>-29.413280 -66.856370</coordinates>
+        <location>
+          <name>Capitan V A Almonacid Airport</name>
+          <code>SANL</code>
+          <tz-hint>America/Argentina/La_Rioja</tz-hint>
+          <coordinates>-29.381600 -66.795800</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Argentina -->
+        <name>Malargue</name>
+        <coordinates>-35.477910 -69.585210</coordinates>
+        <location>
+          <name>Comodoro D.R. Salomon Airport</name>
+          <code>SAMM</code>
+          <tz-hint>America/Argentina/Mendoza</tz-hint>
+          <coordinates>-35.493600 -69.574300</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Argentina -->
         <name>Mar del Plata</name>
         <coordinates>-38.000000 -57.550000</coordinates>
         <location>
@@ -8238,12 +12885,55 @@
       </city>
       <city>
         <!-- A city in Argentina -->
+        <name>Merlo</name>
+        <coordinates>-32.342880 -65.013960</coordinates>
+        <location>
+          <name>Valle Del Conlara International Airport</name>
+          <code>SAOS</code>
+          <tz-hint>America/Argentina/San_Luis</tz-hint>
+          <coordinates>-32.384700 -65.186500</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Argentina -->
+        <name>Moron</name>
+        <coordinates>-34.651180 -58.622050</coordinates>
+        <location>
+          <name>Moron Airport</name>
+          <code>SADM</code>
+          <coordinates>-34.676300 -58.642800</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Argentina -->
         <name>Neuquén</name>
         <coordinates>-38.950000 -68.066667</coordinates>
         <location>
           <name>Neuquén Airport</name>
           <code>SAZN</code>
           <coordinates>-38.950000 -68.133333</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Argentina -->
+        <name>Parana</name>
+        <coordinates>-31.732710 -60.528970</coordinates>
+        <location>
+          <name>General Urquiza Airport</name>
+          <code>SAAP</code>
+          <tz-hint>America/Argentina/Cordoba</tz-hint>
+          <coordinates>-31.794800 -60.480400</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Argentina -->
+        <name>Paso de los Libres</name>
+        <coordinates>-29.712510 -57.087710</coordinates>
+        <location>
+          <name>Paso De Los Libres Airport</name>
+          <code>SARL</code>
+          <tz-hint>America/Argentina/Cordoba</tz-hint>
+          <coordinates>-29.689400 -57.152100</coordinates>
         </location>
       </city>
       <city>
@@ -8268,6 +12958,28 @@
       </city>
       <city>
         <!-- A city in Argentina -->
+        <name>Puerto Madryn</name>
+        <coordinates>-42.768480 -65.038270</coordinates>
+        <location>
+          <name>El Tehuelche Airport</name>
+          <code>SAVY</code>
+          <tz-hint>America/Argentina/Catamarca</tz-hint>
+          <coordinates>-42.759200 -65.102700</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Argentina -->
+        <name>Rawson</name>
+        <coordinates>-43.300310 -65.105640</coordinates>
+        <location>
+          <name>Almirante Marco Andres Zar Airport</name>
+          <code>SAVT</code>
+          <tz-hint>America/Argentina/Catamarca</tz-hint>
+          <coordinates>-43.210500 -65.270300</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Argentina -->
         <name>Reconquista</name>
         <coordinates>-29.150000 -59.650000</coordinates>
         <location>
@@ -8284,6 +12996,17 @@
           <name>Resistencia Airport</name>
           <code>SARE</code>
           <coordinates>-27.450000 -59.050000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Argentina -->
+        <name>Rio Cuarto</name>
+        <coordinates>-33.130440 -64.352720</coordinates>
+        <location>
+          <name>Area De Material Airport</name>
+          <code>SAOC</code>
+          <tz-hint>America/Argentina/Cordoba</tz-hint>
+          <coordinates>-33.085100 -64.261300</coordinates>
         </location>
       </city>
       <city>
@@ -8348,12 +13071,45 @@
       </city>
       <city>
         <!-- A city in Argentina -->
+        <name>San Rafael</name>
+        <coordinates>-34.615310 -68.332380</coordinates>
+        <location>
+          <name>Suboficial Ay Santiago Germano Airport</name>
+          <code>SAMR</code>
+          <tz-hint>America/Argentina/Mendoza</tz-hint>
+          <coordinates>-34.588300 -68.403900</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Argentina -->
         <name>San Salvador de Jujuy</name>
         <coordinates>-24.183333 -65.300000</coordinates>
         <location>
           <name>San Salvador de Jujuy Airport</name>
           <code>SASJ</code>
           <coordinates>-24.383333 -65.083333</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Argentina -->
+        <name>San Juan</name>
+        <coordinates>-31.537260 -68.525680</coordinates>
+        <location>
+          <name>Domingo Faustino Sarmiento Airport</name>
+          <code>SANU</code>
+          <tz-hint>America/Argentina/San_Juan</tz-hint>
+          <coordinates>-31.571500 -68.418200</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Argentina -->
+        <name>San Luis</name>
+        <coordinates>-33.291400 -66.324670</coordinates>
+        <location>
+          <name>Brigadier Mayor D Cesar Raul Ojeda Airport</name>
+          <code>SAOU</code>
+          <tz-hint>America/Argentina/San_Luis</tz-hint>
+          <coordinates>-33.273200 -66.356400</coordinates>
         </location>
       </city>
       <city>
@@ -8368,12 +13124,88 @@
       </city>
       <city>
         <!-- A city in Argentina -->
+        <name>Santa Fe</name>
+        <coordinates>-31.648810 -60.708680</coordinates>
+        <location>
+          <name>Sauce Viejo Airport</name>
+          <code>SAAV</code>
+          <tz-hint>America/Argentina/Cordoba</tz-hint>
+          <coordinates>-31.711700 -60.811700</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Argentina -->
+        <name>Santa Rosa</name>
+        <coordinates>-36.616170 -64.289910</coordinates>
+        <location>
+          <name>Santa Rosa Airport</name>
+          <code>SAZR</code>
+          <tz-hint>America/Argentina/Ushuaia</tz-hint>
+          <coordinates>-36.588300 -64.275700</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Argentina -->
+        <name>Santiago del Estero</name>
+        <coordinates>-27.800470 -64.262850</coordinates>
+        <location>
+          <name>Vicecomodoro Angel D. La Paz Aragones Airport</name>
+          <code>SANE</code>
+          <tz-hint>America/Argentina/Cordoba</tz-hint>
+          <coordinates>-27.765560 -64.310000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Argentina -->
+        <name>Tandil</name>
+        <coordinates>-37.328700 -59.136900</coordinates>
+        <location>
+          <name>Heroes De Malvinas Airport</name>
+          <code>SAZT</code>
+          <coordinates>-37.237400 -59.227900</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Argentina -->
+        <name>Termas de Río Hondo</name>
+        <coordinates>-27.493620 -64.859720</coordinates>
+        <location>
+          <name>Termas de Río Hondo international Airport</name>
+          <code>SANR</code>
+          <tz-hint>America/Argentina/Ushuaia</tz-hint>
+          <coordinates>-27.496600 -64.935950</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Argentina -->
         <name>Ushuaia</name>
         <coordinates>-54.800000 -68.300000</coordinates>
         <location>
           <name>Ushuaia Airport</name>
           <code>SAWH</code>
           <coordinates>-54.800000 -68.316667</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Argentina -->
+        <name>Viedma / Carmen de Patagones</name>
+        <coordinates>-40.815190 -63.000400</coordinates>
+        <location>
+          <name>Gobernador Castello Airport</name>
+          <code>SAVV</code>
+          <tz-hint>America/Argentina/Ushuaia</tz-hint>
+          <coordinates>-40.869200 -63.000400</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Argentina -->
+        <name>Villa Mercedes</name>
+        <coordinates>-33.675710 -65.457830</coordinates>
+        <location>
+          <name>Villa Reynolds Airport</name>
+          <code>SAOR</code>
+          <tz-hint>America/Argentina/San_Luis</tz-hint>
+          <coordinates>-33.729900 -65.387400</coordinates>
         </location>
       </city>
     </country>
@@ -8419,6 +13251,16 @@
       </timezones>
       <tz-hint>America/Nassau</tz-hint>
       <city>
+        <!-- A city in Bahamas -->
+        <name>Andros Town</name>
+        <coordinates>24.705020 -77.769120</coordinates>
+        <location>
+          <name>Andros Town Airport</name>
+          <code>MYAF</code>
+          <coordinates>24.697900 -77.795600</coordinates>
+        </location>
+      </city>
+      <city>
         <!-- A city in the Bahamas -->
         <name msgctxt="City in Bahamas">Freeport</name>
         <coordinates>26.533333 -78.700000</coordinates>
@@ -8446,6 +13288,16 @@
           <name>Nassau Airport</name>
           <code>MYNN</code>
           <coordinates>25.050000 -77.466667</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Bahamas -->
+        <name>San Salvador</name>
+        <coordinates>24.063300 -74.524000</coordinates>
+        <location>
+          <name>San Salvador Airport</name>
+          <code>MYSM</code>
+          <coordinates>24.063300 -74.524000</coordinates>
         </location>
       </city>
     </country>
@@ -8484,6 +13336,36 @@
       <tz-hint>America/La_Paz</tz-hint>
       <city>
         <!-- A city in Bolivia -->
+        <name>Apolo</name>
+        <coordinates>-14.735600 -68.411900</coordinates>
+        <location>
+          <name>Apolo Airport</name>
+          <code>SLAP</code>
+          <coordinates>-14.735600 -68.411900</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Bolivia -->
+        <name>Ascensión de Guarayos</name>
+        <coordinates>-15.930300 -63.156700</coordinates>
+        <location>
+          <name>Ascencion De Guarayos Airport</name>
+          <code>SLAS</code>
+          <coordinates>-15.930300 -63.156700</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Bolivia -->
+        <name>Bermejo</name>
+        <coordinates>-22.732060 -64.337240</coordinates>
+        <location>
+          <name>Bermejo Airport</name>
+          <code>SLBJ</code>
+          <coordinates>-22.773300 -64.312900</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Bolivia -->
         <name>Camiri</name>
         <coordinates>-20.050000 -63.516667</coordinates>
         <location>
@@ -8520,6 +13402,26 @@
           <name>Concepción</name>
           <code>SLCP</code>
           <coordinates>-16.150000 -62.016667</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Bolivia -->
+        <name>Copacabana</name>
+        <coordinates>-16.169900 -69.079190</coordinates>
+        <location>
+          <name>Copacabana Airport</name>
+          <code>SLCC</code>
+          <coordinates>-16.191100 -69.095600</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Bolivia -->
+        <name>Guayaramerín</name>
+        <coordinates>-10.825800 -65.358100</coordinates>
+        <location>
+          <name>Guayaramerin International</name>
+          <code>SLGM</code>
+          <coordinates>-10.889000 -65.381000</coordinates>
         </location>
       </city>
       <city>
@@ -8574,6 +13476,16 @@
       </city>
       <city>
         <!-- A city in Bolivia -->
+        <name>Quijarro</name>
+        <coordinates>-20.446300 -66.848400</coordinates>
+        <location>
+          <name>Uyuni Airport</name>
+          <code>SLUY</code>
+          <coordinates>-20.446300 -66.848400</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Bolivia -->
         <name>Reyes</name>
         <coordinates>-14.316667 -67.383333</coordinates>
         <location>
@@ -8624,12 +13536,32 @@
       </city>
       <city>
         <!-- A city in Bolivia -->
+        <name>San Ignacio de Moxos</name>
+        <coordinates>-14.000000 -65.633900</coordinates>
+        <location>
+          <name>San Ignacio de Moxos Airport</name>
+          <code>SLSM</code>
+          <coordinates>-14.000000 -65.633900</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Bolivia -->
         <name>San Ignacio de Velasco</name>
         <coordinates>-16.366667 -60.950000</coordinates>
         <location>
           <name>San Ignacio de Velasco</name>
           <code>SLSI</code>
           <coordinates>-16.383333 -60.966667</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Bolivia -->
+        <name>San Javier</name>
+        <coordinates>-16.270800 -62.470300</coordinates>
+        <location>
+          <name>San Javier Airport</name>
+          <code>SLJV</code>
+          <coordinates>-16.270800 -62.470300</coordinates>
         </location>
       </city>
       <city>
@@ -8656,6 +13588,26 @@
       </city>
       <city>
         <!-- A city in Bolivia -->
+        <name>San Matías</name>
+        <coordinates>-16.359700 -58.400390</coordinates>
+        <location>
+          <name>San Matias Airport</name>
+          <code>SLTI</code>
+          <coordinates>-16.339200 -58.401900</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Bolivia -->
+        <name>San Ramón / Mamoré</name>
+        <coordinates>-13.266470 -64.615150</coordinates>
+        <location>
+          <name>San Ramon Airport</name>
+          <code>SLRA</code>
+          <coordinates>-13.263900 -64.603900</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Bolivia -->
         <name>Santa Ana de Yacuma</name>
         <coordinates>-13.750000 -65.433333</coordinates>
         <location>
@@ -8675,6 +13627,16 @@
         </location>
       </city>
       <city>
+        <!-- A city in Bolivia -->
+        <name>Santa Rosa</name>
+        <coordinates>-14.077190 -66.793490</coordinates>
+        <location>
+          <name>Santa Rosa De Yacuma Airport</name>
+          <code>SLSR</code>
+          <coordinates>-14.066200 -66.786800</coordinates>
+        </location>
+      </city>
+      <city>
         <!-- The capital of Bolivia -->
         <name>Sucre</name>
         <coordinates>-19.043056 -65.259167</coordinates>
@@ -8682,6 +13644,11 @@
           <name>Sucre</name>
           <code>SLSU</code>
           <coordinates>-19.016667 -65.300000</coordinates>
+        </location>
+        <location>
+          <name>Alcantarí International Airport</name>
+          <code>SLAL</code>
+          <coordinates>-19.238670 -65.148000</coordinates>
         </location>
       </city>
       <city>
@@ -8702,6 +13669,16 @@
           <name>Trinidad</name>
           <code>SLTR</code>
           <coordinates>-14.816667 -64.916667</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Bolivia -->
+        <name>Vallegrande</name>
+        <coordinates>-18.488870 -64.108270</coordinates>
+        <location>
+          <name>Capitan Av. Vidal Villagomez Toledo Airport</name>
+          <code>SLVG</code>
+          <coordinates>-18.482500 -64.099400</coordinates>
         </location>
       </city>
       <city>
@@ -8738,13 +13715,6 @@
     <country>
       <!-- BR - Brazil -->
       <name>Brazil</name>
-      <!-- Could not find cities for the following weather stations:
-           SBCJ - Carajas, Maraba Airport (-6.116667 -50.000000)
-        -->
-      <!-- Could not find information about the following stations,
-           which may be in Brazil:
-           SBCH SBNF SBPJ SBTA 
-        -->
       <iso-code>BR</iso-code>
       <fips-code>BR</fips-code>
       <timezones>
@@ -9955,6 +14925,275 @@
         <name>Tocantins</name>
         <fips-code>BR31</fips-code>
       </state>
+      <city>
+        <!-- A city in Brazil -->
+        <name>Araxá</name>
+        <coordinates>-19.593330 -46.940560</coordinates>
+        <location>
+          <name>Araxa Airport</name>
+          <code>SBAX</code>
+          <coordinates>-19.563200 -46.960400</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Brazil -->
+        <name>Araçatuba</name>
+        <coordinates>-21.208890 -50.432780</coordinates>
+        <location>
+          <name>Aracatuba Airport</name>
+          <code>SBAU</code>
+          <coordinates>-21.141300 -50.424700</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Brazil -->
+        <name>Bagé</name>
+        <coordinates>-31.331390 -54.106940</coordinates>
+        <location>
+          <name>Comandante Gustavo Kraemer Airport</name>
+          <code>SBBG</code>
+          <coordinates>-31.390500 -54.112200</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Brazil -->
+        <name>Cabo Frio</name>
+        <coordinates>-22.887170 -42.026220</coordinates>
+        <location>
+          <name>Cabo Frio Airport</name>
+          <code>SBCB</code>
+          <coordinates>-22.921700 -42.074300</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Brazil -->
+        <name>Cascavel</name>
+        <coordinates>-24.955830 -53.455280</coordinates>
+        <location>
+          <name>Cascavel Airport</name>
+          <code>SBCA</code>
+          <coordinates>-25.000300 -53.500800</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Brazil -->
+        <name>Caxias Do Sul</name>
+        <coordinates>-29.168060 -51.179440</coordinates>
+        <location>
+          <name>Campo dos Bugres Airport</name>
+          <code>SBCX</code>
+          <coordinates>-29.197100 -51.187500</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Brazil -->
+        <name>Chapecó</name>
+        <coordinates>-27.096390 -52.618330</coordinates>
+        <location>
+          <name>Chapeco Airport</name>
+          <code>SBCH</code>
+          <coordinates>-27.134200 -52.656600</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Brazil -->
+        <name>Cruz</name>
+        <coordinates>-2.921100 -40.175890</coordinates>
+        <location>
+          <name>Comandante Ariston Pessoa Airport</name>
+          <code>SBJE</code>
+          <tz-hint>America/Fortaleza</tz-hint>
+          <coordinates>-2.906670 -40.358000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Brazil -->
+        <name>Guajará-Mirim</name>
+        <coordinates>-10.783560 -65.335520</coordinates>
+        <location>
+          <name>Guajara-Mirim Airport</name>
+          <code>SBGM</code>
+          <tz-hint>America/Boa_Vista</tz-hint>
+          <coordinates>-10.786400 -65.284800</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Brazil -->
+        <name>Ipatinga</name>
+        <coordinates>-19.468330 -42.536670</coordinates>
+        <location>
+          <name>Usiminas Airport</name>
+          <code>SBIP</code>
+          <coordinates>-19.470700 -42.487600</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Brazil -->
+        <name>Juazeiro do Norte</name>
+        <coordinates>-7.213060 -39.315280</coordinates>
+        <location>
+          <name>Orlando Bezerra de Menezes Airport</name>
+          <code>SBJU</code>
+          <tz-hint>America/Fortaleza</tz-hint>
+          <coordinates>-7.218960 -39.270100</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Brazil -->
+        <name>Lagoa Santa</name>
+        <coordinates>-19.630060 -43.900900</coordinates>
+        <location>
+          <name>Lagoa Santa Airport</name>
+          <code>SBLS</code>
+          <coordinates>-19.661600 -43.896400</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Brazil -->
+        <name>Lençóis</name>
+        <coordinates>-12.563060 -41.390000</coordinates>
+        <location>
+          <name>Chapada Diamantina Airport</name>
+          <code>SBLE</code>
+          <tz-hint>America/Bahia</tz-hint>
+          <coordinates>-12.482300 -41.277000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Brazil -->
+        <name>Macaé</name>
+        <coordinates>-22.384840 -41.783240</coordinates>
+        <location>
+          <name>Macae Airport</name>
+          <code>SBME</code>
+          <coordinates>-22.343000 -41.766000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Brazil -->
+        <name>Marília</name>
+        <coordinates>-22.213890 -49.945830</coordinates>
+        <location>
+          <name>Marilia Airport</name>
+          <code>SBML</code>
+          <coordinates>-22.196900 -49.926400</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Brazil -->
+        <name>Navegantes</name>
+        <coordinates>-26.898890 -48.654170</coordinates>
+        <location>
+          <name>Ministro Victor Konder International Airport</name>
+          <code>SBNF</code>
+          <coordinates>-26.880000 -48.651400</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Brazil -->
+        <name>Palmas</name>
+        <coordinates>-10.167450 -48.327660</coordinates>
+        <location>
+          <name>Brigadeiro Lysias Rodrigues Airport</name>
+          <code>SBPJ</code>
+          <tz-hint>America/Araguaina</tz-hint>
+          <coordinates>-10.291500 -48.357000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Brazil -->
+        <name>Parauapebas</name>
+        <coordinates>-6.067500 -49.902220</coordinates>
+        <location>
+          <name>Carajas Airport</name>
+          <code>SBCJ</code>
+          <tz-hint>America/Araguaina</tz-hint>
+          <coordinates>-6.115280 -50.001390</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Brazil -->
+        <name>Passo Fundo</name>
+        <coordinates>-28.262780 -52.406670</coordinates>
+        <location>
+          <name>Lauro Kurtz Airport</name>
+          <code>SBPF</code>
+          <coordinates>-28.244000 -52.326600</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Brazil -->
+        <name>Santo Ângelo</name>
+        <coordinates>-28.299170 -54.263060</coordinates>
+        <location>
+          <name>Santo Angelo Airport</name>
+          <code>SBNM</code>
+          <coordinates>-28.281700 -54.169100</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Brazil -->
+        <name>Sao Valerio</name>
+        <coordinates>-11.633330 -48.233330</coordinates>
+        <location>
+          <name>Fazenda Pirassununga Airport</name>
+          <code>SWVI</code>
+          <tz-hint>America/Araguaina</tz-hint>
+          <coordinates>-11.517780 -48.311110</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Brazil -->
+        <name>São Gonçalo do Amarante</name>
+        <coordinates>-5.793330 -35.329440</coordinates>
+        <location>
+          <name>Greater Natal International Airport</name>
+          <code>SBSG</code>
+          <tz-hint>America/Recife</tz-hint>
+          <coordinates>-5.768833 -35.366333</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Brazil -->
+        <name>São José do Rio Preto</name>
+        <coordinates>-20.819720 -49.379440</coordinates>
+        <location>
+          <name>Sao Jose do Rio Preto Airport</name>
+          <code>SBSR</code>
+          <coordinates>-20.816600 -49.406500</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Brazil -->
+        <name>Taubate</name>
+        <coordinates>-23.026390 -45.555280</coordinates>
+        <location>
+          <name>Base de Aviacao de Taubate Airport</name>
+          <code>SBTA</code>
+          <coordinates>-23.040100 -45.516000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Brazil -->
+        <name>Toledo</name>
+        <coordinates>-24.713610 -53.743060</coordinates>
+        <location>
+          <name>Toledo Airport</name>
+          <code>SBTD</code>
+          <coordinates>-24.686300 -53.697500</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Brazil -->
+        <name>Una</name>
+        <coordinates>-15.293330 -39.075280</coordinates>
+        <location>
+          <name>Hotel Transamerica Airport</name>
+          <code>SBTC</code>
+          <tz-hint>America/Bahia</tz-hint>
+          <coordinates>-15.355200 -38.999000</coordinates>
+        </location>
+      </city>
     </country>
     <country>
       <!-- VG - British Virgin Islands, a British territory in the
@@ -10031,10 +15270,6 @@
     <country>
       <!-- CL - Chile -->
       <name>Chile</name>
-      <!-- Could not find information about the following stations,
-           which may be in Chile:
-           SCAT SCCF SCJO 
-        -->
       <iso-code>CL</iso-code>
       <fips-code>CI</fips-code>
       <timezones>
@@ -10051,6 +15286,7 @@
             -->
           <name>Easter Island</name>
         </timezone>
+        <timezone id="America/Punta_Arenas" />
       </timezones>
       <tz-hint>America/Santiago</tz-hint>
       <city>
@@ -10085,12 +15321,82 @@
       </city>
       <city>
         <!-- A city in Chile -->
+        <name>Calama</name>
+        <coordinates>-22.456670 -68.923710</coordinates>
+        <location>
+          <name>El Loa Airport</name>
+          <code>SCCF</code>
+          <coordinates>-22.498200 -68.903600</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Chile -->
+        <name>Chaitén</name>
+        <coordinates>-42.915960 -72.706320</coordinates>
+        <location>
+          <name>Chaiten Airport</name>
+          <code>SCTN</code>
+          <coordinates>-42.932800 -72.699100</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Chile -->
+        <name>Chillan</name>
+        <coordinates>-36.606640 -72.103440</coordinates>
+        <location>
+          <name>Gral. Bernardo O´Higgins Airport</name>
+          <code>SCCH</code>
+          <coordinates>-36.582500 -72.031400</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Chile -->
         <name msgctxt="City in Chile">Concepción</name>
         <coordinates>-36.833333 -73.050000</coordinates>
         <location>
           <name>Concepción</name>
           <code>SCIE</code>
           <coordinates>-36.766667 -73.050000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Chile -->
+        <name>Copiapo</name>
+        <coordinates>-27.367370 -70.332190</coordinates>
+        <location>
+          <name>Desierto de Atacama Airport</name>
+          <code>SCAT</code>
+          <coordinates>-27.261200 -70.779200</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Chile -->
+        <name>Curico</name>
+        <coordinates>-34.982790 -71.239430</coordinates>
+        <location>
+          <name>General Freire Airport</name>
+          <code>SCIC</code>
+          <coordinates>-34.966670 -71.216390</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Chile -->
+        <name>Dalcahue</name>
+        <coordinates>-42.378450 -73.650110</coordinates>
+        <location>
+          <name>Mocopulli Airport</name>
+          <code>SCPQ</code>
+          <coordinates>-42.340280 -73.715560</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Chile -->
+        <name>Futaleufu</name>
+        <coordinates>-43.184920 -71.867220</coordinates>
+        <location>
+          <name>Futaleufu Airport</name>
+          <code>SCFT</code>
+          <coordinates>-43.189200 -71.851100</coordinates>
         </location>
       </city>
       <city>
@@ -10115,12 +15421,53 @@
       </city>
       <city>
         <!-- A city in Chile -->
+        <name>Isla Robinson Crusoe</name>
+        <coordinates>-33.665000 -78.929700</coordinates>
+        <location>
+          <name>Robinson Crusoe Airport</name>
+          <code>SCIR</code>
+          <coordinates>-33.665000 -78.929700</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Chile -->
         <name>La Serena</name>
         <coordinates>-29.907778 -71.254167</coordinates>
         <location>
           <name>La Serena</name>
           <code>SCSE</code>
           <coordinates>-29.900000 -71.200000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Chile -->
+        <name>Los Angeles</name>
+        <coordinates>-37.469730 -72.353660</coordinates>
+        <location>
+          <name>Maria Dolores Airport</name>
+          <code>SCGE</code>
+          <coordinates>-37.401700 -72.425400</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Chile -->
+        <name>Osorno</name>
+        <coordinates>-40.573950 -73.133480</coordinates>
+        <location>
+          <name>Canal Bajo Carlos - Hott Siebert Airport</name>
+          <code>SCJO</code>
+          <coordinates>-40.611200 -73.061000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Chile -->
+        <name>Porvenir</name>
+        <coordinates>-53.296000 -70.366290</coordinates>
+        <location>
+          <name>Capitan Fuentes Martinez Airport Airport</name>
+          <code>SCFM</code>
+          <tz-hint>America/Punta_Arenas</tz-hint>
+          <coordinates>-53.253700 -70.319200</coordinates>
         </location>
       </city>
       <city>
@@ -10135,12 +15482,44 @@
       </city>
       <city>
         <!-- A city in Chile -->
+        <name>Puerto Natales</name>
+        <coordinates>-51.729870 -72.506030</coordinates>
+        <location>
+          <name>Tte. Julio Gallardo Airport</name>
+          <code>SCNT</code>
+          <tz-hint>America/Punta_Arenas</tz-hint>
+          <coordinates>-51.671500 -72.528400</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Chile -->
+        <name>Puerto Williams</name>
+        <coordinates>-54.933550 -67.609630</coordinates>
+        <location>
+          <name>Guardiamarina Zanartu Airport</name>
+          <code>SCGZ</code>
+          <tz-hint>America/Punta_Arenas</tz-hint>
+          <coordinates>-54.931100 -67.626300</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Chile -->
         <name>Punta Arenas</name>
         <coordinates>-53.150000 -70.916667</coordinates>
         <location>
           <name>Punta Arenas</name>
           <code>SCCI</code>
           <coordinates>-53.000000 -70.850000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Chile -->
+        <name>Rancagua</name>
+        <coordinates>-34.169100 -70.740530</coordinates>
+        <location>
+          <name>De La Independencia Airport</name>
+          <code>SCRG</code>
+          <coordinates>-34.173700 -70.775700</coordinates>
         </location>
       </city>
       <city>
@@ -10162,6 +15541,21 @@
           <code>SCEL</code>
           <coordinates>-33.383333 -70.783333</coordinates>
         </location>
+        <location>
+          <name>Eulogio Sanchez Airport</name>
+          <code>SCTB</code>
+          <coordinates>-33.456300 -70.546700</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Chile -->
+        <name>Santo Domingo</name>
+        <coordinates>-33.656400 -71.614400</coordinates>
+        <location>
+          <name>Santo Domingo Airport</name>
+          <code>SCSN</code>
+          <coordinates>-33.656400 -71.614400</coordinates>
+        </location>
       </city>
       <city>
         <!-- A city in Chile -->
@@ -10171,6 +15565,36 @@
           <name>Temuco</name>
           <code>SCTC</code>
           <coordinates>-38.750000 -72.633333</coordinates>
+        </location>
+        <location>
+          <name>La Araucanía Airport (Temuco)</name>
+          <code>SCQP</code>
+          <coordinates>-38.925833 -72.651667</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Chile -->
+        <name>Valdivia</name>
+        <coordinates>-39.814220 -73.245890</coordinates>
+        <location>
+          <name>Pichoy Airport</name>
+          <code>SCVD</code>
+          <coordinates>-39.650000 -73.086100</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Chile -->
+        <name>Viña Del Mar</name>
+        <coordinates>-33.024570 -71.551830</coordinates>
+        <location>
+          <name>Rodelillo Airport</name>
+          <code>SCRD</code>
+          <coordinates>-33.068100 -71.557500</coordinates>
+        </location>
+        <location>
+          <name>Vina del mar Airport</name>
+          <code>SCVM</code>
+          <coordinates>-32.949600 -71.478600</coordinates>
         </location>
       </city>
     </country>
@@ -10185,12 +15609,42 @@
       <tz-hint>America/Bogota</tz-hint>
       <city>
         <!-- A city in Colombia -->
+        <name>Arauca</name>
+        <coordinates>7.084710 -70.759080</coordinates>
+        <location>
+          <name>Santiago Perez Airport</name>
+          <code>SKUC</code>
+          <coordinates>7.068880 -70.736900</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Colombia -->
         <name>Armenia</name>
         <coordinates>4.528740 -75.704292</coordinates>
         <location>
           <name>El Eden Airport</name>
           <code>SKAR</code>
           <coordinates>4.500000 -75.716667</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Colombia -->
+        <name>Bahía Solano</name>
+        <coordinates>6.226220 -77.404390</coordinates>
+        <location>
+          <name>Jose Celestino Mutis Airport</name>
+          <code>SKBS</code>
+          <coordinates>6.202920 -77.394700</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Colombia -->
+        <name>Barrancabermeja</name>
+        <coordinates>7.065280 -73.854720</coordinates>
+        <location>
+          <name>Yariguies Airport</name>
+          <code>SKEJ</code>
+          <coordinates>7.024330 -73.806800</coordinates>
         </location>
       </city>
       <city>
@@ -10225,12 +15679,32 @@
       </city>
       <city>
         <!-- A city in Colombia -->
+        <name>Buenaventura</name>
+        <coordinates>3.880100 -77.031160</coordinates>
+        <location>
+          <name>Gerardo Tobar Lopez Airport</name>
+          <code>SKBU</code>
+          <coordinates>3.819630 -76.989800</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Colombia -->
         <name>Cali</name>
         <coordinates>3.437222 -76.522500</coordinates>
         <location>
           <name>Alfonso Bonillaaragon Airport</name>
           <code>SKCL</code>
           <coordinates>3.550000 -76.383333</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Colombia -->
+        <name>Carepa</name>
+        <coordinates>7.758490 -76.652550</coordinates>
+        <location>
+          <name>Antonio Roldan Betancourt Airport</name>
+          <code>SKLC</code>
+          <coordinates>7.811960 -76.716400</coordinates>
         </location>
       </city>
       <city>
@@ -10245,12 +15719,72 @@
       </city>
       <city>
         <!-- A city in Colombia -->
+        <name>Cartago</name>
+        <coordinates>4.746390 -75.911670</coordinates>
+        <location>
+          <name>Santa Ana Airport</name>
+          <code>SKGO</code>
+          <coordinates>4.758180 -75.955700</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Colombia -->
+        <name>Chia</name>
+        <coordinates>4.858760 -74.058660</coordinates>
+        <location>
+          <name>Guaymaral Airport</name>
+          <code>SKGY</code>
+          <coordinates>4.812330 -74.064900</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Colombia -->
+        <name>Corozal</name>
+        <coordinates>9.318470 -75.293300</coordinates>
+        <location>
+          <name>Las Brujas Airport</name>
+          <code>SKCZ</code>
+          <coordinates>9.332740 -75.285600</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Colombia -->
         <name>Cúcuta</name>
         <coordinates>7.883333 -72.505278</coordinates>
         <location>
           <name>Camilo Daza Airport</name>
           <code>SKCC</code>
           <coordinates>7.933333 -72.516667</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Colombia -->
+        <name>Florencia</name>
+        <coordinates>1.615490 -75.604120</coordinates>
+        <location>
+          <name>Gustavo Artunduaga Paredes Airport</name>
+          <code>SKFL</code>
+          <coordinates>1.589190 -75.564400</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Colombia -->
+        <name>Girardot</name>
+        <coordinates>4.300790 -74.807540</coordinates>
+        <location>
+          <name>Santiago Vila Airport</name>
+          <code>SKGI</code>
+          <coordinates>4.276240 -74.796700</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Colombia -->
+        <name>Guapi</name>
+        <coordinates>2.570820 -77.885420</coordinates>
+        <location>
+          <name>Juan Casiano Airport</name>
+          <code>SKGP</code>
+          <coordinates>2.570130 -77.898600</coordinates>
         </location>
       </city>
       <city>
@@ -10285,6 +15819,26 @@
       </city>
       <city>
         <!-- A city in Colombia -->
+        <name>Manizales</name>
+        <coordinates>5.066800 -75.506840</coordinates>
+        <location>
+          <name>La Nubia Airport</name>
+          <code>SKMZ</code>
+          <coordinates>5.029600 -75.464700</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Colombia -->
+        <name>Mariquita</name>
+        <coordinates>5.198890 -74.892950</coordinates>
+        <location>
+          <name>Jose Celestino Mutis Airport</name>
+          <code>SKQU</code>
+          <coordinates>5.212560 -74.883600</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Colombia -->
         <name>Medellín</name>
         <coordinates>6.251290 -75.575974</coordinates>
         <location>
@@ -10295,12 +15849,32 @@
       </city>
       <city>
         <!-- A city in Colombia -->
+        <name>Mitú</name>
+        <coordinates>1.257440 -70.235510</coordinates>
+        <location>
+          <name>Fabio Alberto Leon Bentley Airport</name>
+          <code>SKMU</code>
+          <coordinates>1.253660 -70.233900</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Colombia -->
         <name>Monteria</name>
         <coordinates>8.759794 -75.887344</coordinates>
         <location>
           <name>Los Garzones Airport</name>
           <code>SKMR</code>
           <coordinates>8.823889 -75.825554</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Colombia -->
+        <name>Neiva</name>
+        <coordinates>2.930010 -75.279730</coordinates>
+        <location>
+          <name>Benito Salas Airport</name>
+          <code>SKNV</code>
+          <coordinates>2.950150 -75.294000</coordinates>
         </location>
       </city>
       <city>
@@ -10331,6 +15905,46 @@
           <name>Guillermo Leon Valencia Airport</name>
           <code>SKPP</code>
           <coordinates>2.456333 -76.613724</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Colombia -->
+        <name>Providencia</name>
+        <coordinates>13.356900 -81.358300</coordinates>
+        <location>
+          <name>El Embrujo Airport</name>
+          <code>SKPV</code>
+          <coordinates>13.356900 -81.358300</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Colombia -->
+        <name>Puerto Asís</name>
+        <coordinates>0.505140 -76.495710</coordinates>
+        <location>
+          <name>Tres De Mayo Airport</name>
+          <code>SKAS</code>
+          <coordinates>0.505230 -76.500800</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Colombia -->
+        <name>Puerto Carreño</name>
+        <coordinates>6.190410 -67.483910</coordinates>
+        <location>
+          <name>German Olano Airport</name>
+          <code>SKPC</code>
+          <coordinates>6.184720 -67.493200</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Colombia -->
+        <name>Puerto Inírida</name>
+        <coordinates>3.865280 -67.923890</coordinates>
+        <location>
+          <name>Obando Airport</name>
+          <code>SKPD</code>
+          <coordinates>3.853530 -67.906200</coordinates>
         </location>
       </city>
       <city>
@@ -10375,6 +15989,16 @@
       </city>
       <city>
         <!-- A city in Colombia -->
+        <name>San José Del Guaviare</name>
+        <coordinates>2.567990 -72.639720</coordinates>
+        <location>
+          <name>Jorge E. Gonzalez Torres Airport</name>
+          <code>SKSJ</code>
+          <coordinates>2.579690 -72.639400</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Colombia -->
         <name>Santa Marta</name>
         <coordinates>11.248362 -74.204849</coordinates>
         <location>
@@ -10385,12 +16009,82 @@
       </city>
       <city>
         <!-- A city in Colombia -->
+        <name>Santiago de Tolú</name>
+        <coordinates>9.523920 -75.581390</coordinates>
+        <location>
+          <name>Tolu Airport</name>
+          <code>SKTL</code>
+          <coordinates>9.509450 -75.585400</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Colombia -->
+        <name>Saravena</name>
+        <coordinates>6.963190 -71.882300</coordinates>
+        <location>
+          <name>Los Colonizadores Airport</name>
+          <code>SKSA</code>
+          <coordinates>6.950330 -71.856170</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Colombia -->
+        <name>Tame</name>
+        <coordinates>6.460650 -71.736180</coordinates>
+        <location>
+          <name>Gustavo Vargas Airport</name>
+          <code>SKTM</code>
+          <coordinates>6.451080 -71.760300</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Colombia -->
+        <name>Tumaco</name>
+        <coordinates>1.791120 -78.792750</coordinates>
+        <location>
+          <name>La Florida Airport</name>
+          <code>SKCO</code>
+          <coordinates>1.814420 -78.749200</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Colombia -->
+        <name>Valledupar</name>
+        <coordinates>10.465380 -73.253100</coordinates>
+        <location>
+          <name>Alfonso Lopez Pumarejo Airport</name>
+          <code>SKVP</code>
+          <coordinates>10.435000 -73.249500</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Colombia -->
+        <name>Villa Garzón</name>
+        <coordinates>0.978770 -76.605600</coordinates>
+        <location>
+          <name>Villagarzon Airport</name>
+          <code>SKVG</code>
+          <coordinates>0.978770 -76.605600</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Colombia -->
         <name>Villavicencio</name>
         <coordinates>4.157307 -73.637428</coordinates>
         <location>
           <name>Vanguardia Airport</name>
           <code>SKVV</code>
           <coordinates>4.168334 -73.615555</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Colombia -->
+        <name>Yopal</name>
+        <coordinates>5.335730 -72.393900</coordinates>
+        <location>
+          <name>El Yopal Airport</name>
+          <code>SKYP</code>
+          <coordinates>5.319110 -72.384000</coordinates>
         </location>
       </city>
     </country>
@@ -10457,9 +16151,6 @@
     <country>
       <!-- CU - Cuba -->
       <name>Cuba</name>
-      <!-- Could not find cities for the following weather stations:
-           MUCL - Cayo Largo del Sur (21.616667 -81.550000)
-        -->
       <iso-code>CU</iso-code>
       <fips-code>CU</fips-code>
       <timezones>
@@ -10474,6 +16165,26 @@
           <name>Camagüey Airport</name>
           <code>MUCM</code>
           <coordinates>21.416667 -77.850000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Cuba -->
+        <name>Cayo Coco</name>
+        <coordinates>22.461000 -78.328400</coordinates>
+        <location>
+          <name>Jardines Del Rey Airport</name>
+          <code>MUCC</code>
+          <coordinates>22.461000 -78.328400</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Cuba -->
+        <name>Cayo Largo del Sur</name>
+        <coordinates>21.616500 -81.546000</coordinates>
+        <location>
+          <name>Vilo Acuna International Airport</name>
+          <code>MUCL</code>
+          <coordinates>21.616500 -81.546000</coordinates>
         </location>
       </city>
       <city>
@@ -10541,6 +16252,26 @@
       </city>
       <city>
         <!-- A city in Cuba -->
+        <name>Nueva Gerona</name>
+        <coordinates>21.887590 -82.806620</coordinates>
+        <location>
+          <name>Rafael Cabrera Airport</name>
+          <code>MUNG</code>
+          <coordinates>21.834700 -82.783800</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Cuba -->
+        <name>Santa Clara</name>
+        <coordinates>22.407110 -79.965810</coordinates>
+        <location>
+          <name>Abel Santamaria Airport</name>
+          <code>MUSC</code>
+          <coordinates>22.492200 -79.943600</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Cuba -->
         <name>Santiago de Cuba</name>
         <coordinates>20.024722 -75.821944</coordinates>
         <location>
@@ -10553,16 +16284,22 @@
     <country>
       <!-- DO - Dominican Republic -->
       <name>Dominican Republic</name>
-      <!-- Could not find information about the following stations,
-           which may be in Dominican Republic:
-           MDCY MDJB 
-        -->
       <iso-code>DO</iso-code>
       <fips-code>DR</fips-code>
       <timezones>
         <timezone id="America/Santo_Domingo" />
       </timezones>
       <tz-hint>America/Santo_Domingo</tz-hint>
+      <city>
+        <!-- A city in Dominican Republic -->
+        <name>Arroyo Barril</name>
+        <coordinates>19.198600 -69.429800</coordinates>
+        <location>
+          <name>Arroyo Barril Airport</name>
+          <code>MDAB</code>
+          <coordinates>19.198600 -69.429800</coordinates>
+        </location>
+      </city>
       <city>
         <!-- A city in the Dominican Republic -->
         <name>Barahona</name>
@@ -10571,6 +16308,16 @@
           <name>Barahona</name>
           <code>MDBH</code>
           <coordinates>18.200000 -71.100000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Dominican Republic -->
+        <name>La Isabela</name>
+        <coordinates>18.572500 -69.985600</coordinates>
+        <location>
+          <name>La Isabela International Airport</name>
+          <code>MDJB</code>
+          <coordinates>18.572500 -69.985600</coordinates>
         </location>
       </city>
       <city>
@@ -10611,6 +16358,16 @@
           <name>Puerto Plata International Airport</name>
           <code>MDPP</code>
           <coordinates>19.750000 -70.550000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Dominican Republic -->
+        <name>Samana</name>
+        <coordinates>19.204040 -69.334070</coordinates>
+        <location>
+          <name>Samana El Catey International Airport</name>
+          <code>MDCY</code>
+          <coordinates>19.267000 -69.742000</coordinates>
         </location>
       </city>
       <city>
@@ -10658,12 +16415,85 @@
       <tz-hint>America/Guayaquil</tz-hint>
       <city>
         <!-- A city in Ecuador -->
+        <name>Ahuano</name>
+        <coordinates>-1.058680 -77.545920</coordinates>
+        <location>
+          <name>Jumandy Airport</name>
+          <code>SEJD</code>
+          <tz-hint>America/Guayaquil</tz-hint>
+          <coordinates>-1.060185 -77.580525</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Ecuador -->
+        <name>Ambato</name>
+        <coordinates>-1.249080 -78.616750</coordinates>
+        <location>
+          <name>Chachoan Airport</name>
+          <code>SEAM</code>
+          <coordinates>-1.212070 -78.574600</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Ecuador -->
+        <name>Catamayo</name>
+        <coordinates>-3.986610 -79.357630</coordinates>
+        <location>
+          <name>Camilo Ponce Enriquez Airport / Ciudad de Catamayo</name>
+          <code>SECA</code>
+          <tz-hint>America/Guayaquil</tz-hint>
+          <coordinates>-4.000000 -79.367000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Ecuador -->
+        <name>Coca</name>
+        <coordinates>-0.449670 -76.997240</coordinates>
+        <location>
+          <name>Francisco De Orellana Airport</name>
+          <code>SECO</code>
+          <coordinates>-0.462890 -76.986800</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Ecuador -->
+        <name>Cuenca</name>
+        <coordinates>-2.895300 -78.996300</coordinates>
+        <location>
+          <name>Mariscal Lamar Airport</name>
+          <code>SECU</code>
+          <coordinates>-2.889470 -78.984400</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Ecuador -->
         <name>Guayaquil</name>
         <coordinates>-2.166667 -79.900000</coordinates>
         <location>
           <name>Simon Bolivar Airport</name>
           <code>SEGU</code>
           <coordinates>-2.150000 -79.883333</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Ecuador -->
+        <name>Isla Baltra</name>
+        <coordinates>-0.453760 -90.265900</coordinates>
+        <location>
+          <name>Seymour Airport</name>
+          <code>SEGS</code>
+          <tz-hint>Pacific/Galapagos</tz-hint>
+          <coordinates>-0.453760 -90.265900</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Ecuador -->
+        <name>Lago Agrio</name>
+        <coordinates>0.086000 -76.895280</coordinates>
+        <location>
+          <name>Nueva Loja Airport</name>
+          <code>SENL</code>
+          <coordinates>0.093060 -76.867500</coordinates>
         </location>
       </city>
       <city>
@@ -10678,12 +16508,33 @@
       </city>
       <city>
         <!-- A city in Ecuador -->
+        <name>Macas</name>
+        <coordinates>-2.307410 -78.120260</coordinates>
+        <location>
+          <name>Coronel E Carvajal Airport</name>
+          <code>SEMC</code>
+          <coordinates>-2.299170 -78.120800</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Ecuador -->
         <name>Manta</name>
         <coordinates>-0.950000 -80.733333</coordinates>
         <location>
           <name>Manta</name>
           <code>SEMT</code>
           <coordinates>-0.950000 -80.683333</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Ecuador -->
+        <name>Puerto Baquerizo Moreno</name>
+        <coordinates>-0.901720 -89.610210</coordinates>
+        <location>
+          <name>San Cristobal Airport</name>
+          <code>SEST</code>
+          <tz-hint>Pacific/Galapagos</tz-hint>
+          <coordinates>-0.910210 -89.617400</coordinates>
         </location>
       </city>
       <city>
@@ -10694,6 +16545,76 @@
           <name>Mariscal Sucre Airport</name>
           <code>SEQM</code>
           <coordinates>-0.120000 -78.350000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Ecuador -->
+        <name>Riobamba</name>
+        <coordinates>-1.665060 -78.658870</coordinates>
+        <location>
+          <name>Chimborazo Airport</name>
+          <code>SERB</code>
+          <coordinates>-1.653430 -78.656100</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Ecuador -->
+        <name>Salinas/La Libertad</name>
+        <coordinates>-2.214520 -80.951510</coordinates>
+        <location>
+          <name>General Ulpiano Paez Airport</name>
+          <code>SESA</code>
+          <coordinates>-2.204990 -80.988900</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Ecuador -->
+        <name>Santa Rosa</name>
+        <coordinates>-3.455710 -79.963700</coordinates>
+        <location>
+          <name>Coronel Artilleria Victor Larrea Airport</name>
+          <code>SERO</code>
+          <coordinates>-3.435160 -79.977800</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Ecuador -->
+        <name>Santiago</name>
+        <coordinates>-3.403520 -78.581480</coordinates>
+        <location>
+          <name>Gualaquiza Airport</name>
+          <code>SEGZ</code>
+          <coordinates>-3.423210 -78.567000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Ecuador -->
+        <name>Shell Mera</name>
+        <coordinates>-1.505380 -78.063320</coordinates>
+        <location>
+          <name>Rio Amazonas Airport</name>
+          <code>SESM</code>
+          <coordinates>-1.505240 -78.062700</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Ecuador -->
+        <name>Tachina</name>
+        <coordinates>0.978520 -79.626600</coordinates>
+        <location>
+          <name>General Rivadeneira Airport</name>
+          <code>SETN</code>
+          <coordinates>0.978520 -79.626600</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Ecuador -->
+        <name>Tulcán</name>
+        <coordinates>0.812400 -77.717090</coordinates>
+        <location>
+          <name>Teniente Coronel Luis a Mantilla Airport</name>
+          <code>SETU</code>
+          <coordinates>0.809510 -77.708100</coordinates>
         </location>
       </city>
     </country>
@@ -10727,6 +16648,21 @@
         </location>
       </city>
       <city>
+        <!-- A city in El Salvador -->
+        <name>San Miguel</name>
+        <coordinates>13.482610 -88.182110</coordinates>
+        <location>
+          <name>El Papalon Airport</name>
+          <code>MSSM</code>
+          <coordinates>13.444100 -88.127000</coordinates>
+        </location>
+        <location>
+          <name>La Aramuaca Airport</name>
+          <code>MSAC</code>
+          <coordinates>13.447990 -88.120110</coordinates>
+        </location>
+      </city>
+      <city>
         <!-- The capital of El Salvador -->
         <name>San Salvador</name>
         <coordinates>13.708611 -89.203056</coordinates>
@@ -10734,6 +16670,16 @@
           <name>San Salvador Airport, Ilopango</name>
           <code>MSSS</code>
           <coordinates>13.700000 -89.116667</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in El Salvador -->
+        <name>Santa Ana</name>
+        <coordinates>13.988270 -89.556850</coordinates>
+        <location>
+          <name>El Palmer Airport</name>
+          <code>MSSA</code>
+          <coordinates>14.067220 -89.632220</coordinates>
         </location>
       </city>
     </country>
@@ -10759,6 +16705,11 @@
           <name>Mount Pleasant Airport</name>
           <code>EGYP</code>
           <coordinates>-51.816667 -58.450000</coordinates>
+        </location>
+        <location>
+          <name>Stanley Airport</name>
+          <code>SFAL</code>
+          <coordinates>-51.685700 -57.777600</coordinates>
         </location>
       </city>
     </country>
@@ -10856,6 +16807,37 @@
       </timezones>
       <tz-hint>America/Guatemala</tz-hint>
       <city>
+        <!-- A city in Guatemala -->
+        <name>Champerico</name>
+        <coordinates>14.292060 -91.913390</coordinates>
+        <location>
+          <name>Champerico</name>
+          <code>MGCP</code>
+          <tz-hint>America/Guatemala</tz-hint>
+          <coordinates>14.300000 -91.900000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Guatemala -->
+        <name>Coban</name>
+        <coordinates>15.470250 -90.374550</coordinates>
+        <location>
+          <name>Coban Airport</name>
+          <code>MGCB</code>
+          <coordinates>15.469000 -90.406700</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Guatemala -->
+        <name>Esquipulas</name>
+        <coordinates>14.565710 -89.351660</coordinates>
+        <location>
+          <name>Esquipulas Airport</name>
+          <code>MGES</code>
+          <coordinates>14.566670 -89.350000</coordinates>
+        </location>
+      </city>
+      <city>
         <!-- The capital of Guatemala -->
         <name msgctxt="City in Guatemala">Guatemala</name>
         <coordinates>14.621111 -90.526944</coordinates>
@@ -10873,6 +16855,16 @@
           <name>Huehuetenango</name>
           <code>MGHT</code>
           <coordinates>15.316667 -91.466667</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Guatemala -->
+        <name>Melchor de Mencos</name>
+        <coordinates>17.066060 -89.152290</coordinates>
+        <location>
+          <name>Melchor de Mencos Airport</name>
+          <code>MGMM</code>
+          <coordinates>17.068610 -89.152220</coordinates>
         </location>
       </city>
       <city>
@@ -10897,6 +16889,16 @@
       </city>
       <city>
         <!-- A city in Guatemala -->
+        <name>Quezaltenango</name>
+        <coordinates>14.844620 -91.523160</coordinates>
+        <location>
+          <name>Quezaltenango Airport</name>
+          <code>MGQZ</code>
+          <coordinates>14.865600 -91.502000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Guatemala -->
         <name>Retalhuleu</name>
         <coordinates>14.533333 -91.683333</coordinates>
         <location>
@@ -10907,12 +16909,32 @@
       </city>
       <city>
         <!-- A city in Guatemala -->
+        <name>San Marcos</name>
+        <coordinates>14.964370 -91.794860</coordinates>
+        <location>
+          <name>San Marcos Airport</name>
+          <code>MGSM</code>
+          <coordinates>14.956300 -91.806300</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Guatemala -->
         <name>Tikal</name>
         <coordinates>17.225000 -89.613333</coordinates>
         <location>
           <name>Tikal</name>
           <code>MGTK</code>
           <coordinates>16.900000 -89.850000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Guatemala -->
+        <name>Zacapa</name>
+        <coordinates>14.968670 -89.527320</coordinates>
+        <location>
+          <name>Zacapa Airport</name>
+          <code>MGZA</code>
+          <coordinates>14.960300 -89.539200</coordinates>
         </location>
       </city>
     </country>
@@ -10934,6 +16956,32 @@
           <code>SYCJ</code>
           <coordinates>6.483333 -58.250000</coordinates>
         </location>
+        <location>
+          <name>Eugene F. Correia International</name>
+          <code>SYEC</code>
+          <tz-hint>America/Guyana</tz-hint>
+          <coordinates>6.817000 -58.117000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Guyana -->
+        <name>Lethem</name>
+        <coordinates>3.372600 -59.799670</coordinates>
+        <location>
+          <name>Lethem Airport</name>
+          <code>SYLT</code>
+          <coordinates>3.372760 -59.789400</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Guyana -->
+        <name>Mabaruma</name>
+        <coordinates>8.203770 -59.781170</coordinates>
+        <location>
+          <name>Mabaruma Airport</name>
+          <code>SYMB</code>
+          <coordinates>8.200000 -59.783300</coordinates>
+        </location>
       </city>
     </country>
     <country>
@@ -10945,6 +16993,16 @@
         <timezone id="America/Port-au-Prince" />
       </timezones>
       <tz-hint>America/Port-au-Prince</tz-hint>
+      <city>
+        <!-- A city in Haiti -->
+        <name>Cap Haitien</name>
+        <coordinates>19.759380 -72.198150</coordinates>
+        <location>
+          <name>Cap Haitien International Airport</name>
+          <code>MTCH</code>
+          <coordinates>19.733000 -72.194700</coordinates>
+        </location>
+      </city>
       <city>
         <!-- Capital of Haiti -->
         <name>Port-au-Prince</name>
@@ -10959,10 +17017,6 @@
     <country>
       <!-- HN - Honduras -->
       <name>Honduras</name>
-      <!-- Could not find information about the following stations,
-           which may be in Honduras:
-           MHTR 
-        -->
       <iso-code>HN</iso-code>
       <fips-code>HO</fips-code>
       <timezones>
@@ -11011,6 +17065,16 @@
       </city>
       <city>
         <!-- A city in Honduras -->
+        <name>El Molino</name>
+        <coordinates>14.596670 -88.594170</coordinates>
+        <location>
+          <name>Gracias Airport</name>
+          <code>MHGS</code>
+          <coordinates>14.596670 -88.594170</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Honduras -->
         <name>Guanaja</name>
         <coordinates>16.400000 -85.900000</coordinates>
         <location>
@@ -11047,6 +17111,16 @@
           <name>La Mesa San Pedro Sula</name>
           <code>MHLM</code>
           <coordinates>15.450000 -87.933333</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Honduras -->
+        <name>Palmerola</name>
+        <coordinates>14.382330 -87.621170</coordinates>
+        <location>
+          <name>Comayagua-Palmerola International Airport</name>
+          <code>MHPR</code>
+          <coordinates>14.382330 -87.621170</coordinates>
         </location>
       </city>
       <city>
@@ -11097,6 +17171,17 @@
           <name>Tela</name>
           <code>MHTE</code>
           <coordinates>15.716667 -87.483333</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Honduras -->
+        <name>Trujillo</name>
+        <coordinates>15.917410 -85.952630</coordinates>
+        <location>
+          <name>Trujillo Airport</name>
+          <code>MHTR</code>
+          <tz-hint>America/Tegucigalpa</tz-hint>
+          <coordinates>15.930000 -85.930000</coordinates>
         </location>
       </city>
       <city>
@@ -11175,16 +17260,22 @@
     <country>
       <!-- MS - Montserrat, a British territory in the Caribbean. -->
       <name>Montserrat</name>
-      <!-- Could not find weather stations for the following major
-           cities:
-           Plymouth
-        -->
       <iso-code>MS</iso-code>
       <fips-code>MH</fips-code>
       <timezones>
         <timezone id="America/Montserrat" />
       </timezones>
       <tz-hint>America/Montserrat</tz-hint>
+      <city>
+        <!-- A city in Montserrat -->
+        <name>Gerald's Park</name>
+        <coordinates>16.791400 -62.193300</coordinates>
+        <location>
+          <name>John A. Osborne Airport</name>
+          <code>TRPG</code>
+          <coordinates>16.791400 -62.193300</coordinates>
+        </location>
+      </city>
     </country>
     <country>
       <!-- AN - Netherlands Antilles, a group of Caribbean islands; one
@@ -11332,6 +17423,16 @@
       <tz-hint>America/Panama</tz-hint>
       <city>
         <!-- A city in Panama -->
+        <name>Albrook</name>
+        <coordinates>8.973340 -79.555600</coordinates>
+        <location>
+          <name>Marcos A. Gelabert International Airport</name>
+          <code>MPMG</code>
+          <coordinates>8.973340 -79.555600</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Panama -->
         <name>David</name>
         <coordinates>8.433333 -82.433333</coordinates>
         <location>
@@ -11351,6 +17452,26 @@
         </location>
       </city>
       <city>
+        <!-- A city in Panama -->
+        <name>Isla Colón</name>
+        <coordinates>9.340850 -82.250800</coordinates>
+        <location>
+          <name>Bocas Del Toro International Airport</name>
+          <code>MPBO</code>
+          <coordinates>9.340850 -82.250800</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Panama -->
+        <name>Panama City</name>
+        <coordinates>8.993600 -79.519730</coordinates>
+        <location>
+          <name>Howard/Panama Pacifico International Airport</name>
+          <code>MPPA</code>
+          <coordinates>8.914790 -79.599600</coordinates>
+        </location>
+      </city>
+      <city>
         <!-- The capital of Panama -->
         <name>Panamá</name>
         <coordinates>8.966667 -79.533333</coordinates>
@@ -11358,6 +17479,16 @@
           <name>Howard Air Force Base</name>
           <code>MPHO</code>
           <coordinates>8.916667 -79.600000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Panama -->
+        <name>Río Hato</name>
+        <coordinates>8.379400 -80.166210</coordinates>
+        <location>
+          <name>Cap Scarlet R. Martínez L. Airport</name>
+          <code>MPSM</code>
+          <coordinates>8.380000 -80.129670</coordinates>
         </location>
       </city>
       <city>
@@ -11400,6 +17531,96 @@
           <coordinates>-25.450000 -54.850000</coordinates>
         </location>
       </city>
+      <city>
+        <!-- A city in Paraguay -->
+        <name>Concepción</name>
+        <coordinates>-23.399850 -57.432360</coordinates>
+        <location>
+          <name>Teniente Col Carmelo Peralta Airport</name>
+          <code>SGCO</code>
+          <coordinates>-23.440000 -57.430000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Paraguay -->
+        <name>Encarnación</name>
+        <coordinates>-27.331760 -55.866620</coordinates>
+        <location>
+          <name>Encarnacion Airport</name>
+          <code>SGEN</code>
+          <coordinates>-27.300000 -55.910000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Paraguay -->
+        <name>Mariscal Estigarribia</name>
+        <coordinates>-22.050000 -60.620000</coordinates>
+        <location>
+          <name>Dr. Luis Maria Argana International Airport</name>
+          <code>SGME</code>
+          <coordinates>-22.050000 -60.620000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Paraguay -->
+        <name>Pedro Juan Caballero</name>
+        <coordinates>-22.549250 -55.738700</coordinates>
+        <location>
+          <name>Dr Augusto Roberto Fuster International Airport</name>
+          <code>SGPJ</code>
+          <coordinates>-22.640000 -55.830000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Paraguay -->
+        <name>Pilar</name>
+        <coordinates>-26.858740 -58.306390</coordinates>
+        <location>
+          <name>Carlos Miguel Gimenez Airport</name>
+          <code>SGPI</code>
+          <coordinates>-26.880000 -58.320000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Paraguay -->
+        <name>Puerto Vallemí</name>
+        <coordinates>-22.157550 -57.951250</coordinates>
+        <location>
+          <name>Puerto Casado</name>
+          <code>SGLV</code>
+          <coordinates>-22.283000 -57.933000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Paraguay -->
+        <name>Salto del Guaira</name>
+        <coordinates>-24.063300 -54.307630</coordinates>
+        <location>
+          <name>Salto del Guaira Airport</name>
+          <code>SGGR</code>
+          <coordinates>-24.032270 -54.350830</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Paraguay -->
+        <name>San Juan Bautista</name>
+        <coordinates>-26.670280 -57.140730</coordinates>
+        <location>
+          <name>San Juan Bautista</name>
+          <code>SGSJ</code>
+          <coordinates>-26.667000 -57.150000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Paraguay -->
+        <name>San Pedro del Ycuamandiyu</name>
+        <coordinates>-24.082880 -57.088110</coordinates>
+        <location>
+          <name>San Pedro Airport</name>
+          <code>SGSP</code>
+          <coordinates>-24.082880 -57.088110</coordinates>
+        </location>
+      </city>
     </country>
     <country>
       <!-- PE - Peru -->
@@ -11418,6 +17639,16 @@
           <name>Andahuaylas</name>
           <code>SPHY</code>
           <coordinates>-13.716667 -73.350000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Peru -->
+        <name>Anta</name>
+        <coordinates>-9.356980 -77.597960</coordinates>
+        <location>
+          <name>Comandante FAP German Arias Graziani Airport</name>
+          <code>SPHZ</code>
+          <coordinates>-9.347440 -77.598400</coordinates>
         </location>
       </city>
       <city>
@@ -11442,12 +17673,42 @@
       </city>
       <city>
         <!-- A city in Peru -->
+        <name>Cajamarca</name>
+        <coordinates>-7.163780 -78.500270</coordinates>
+        <location>
+          <name>Mayor General FAP Armando Revoredo Iglesias Airport</name>
+          <code>SPJR</code>
+          <coordinates>-7.139180 -78.489400</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Peru -->
+        <name>Chachapoyas</name>
+        <coordinates>-6.231690 -77.869030</coordinates>
+        <location>
+          <name>Chachapoyas Airport</name>
+          <code>SPPY</code>
+          <coordinates>-6.201810 -77.856100</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Peru -->
         <name>Chiclayo</name>
         <coordinates>-6.773611 -79.841667</coordinates>
         <location>
           <name>Chiclayo</name>
           <code>SPHI</code>
           <coordinates>-6.783333 -79.833333</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Peru -->
+        <name>Chimbote</name>
+        <coordinates>-9.075080 -78.593730</coordinates>
+        <location>
+          <name>Teniente FAP Jaime A De Montreuil Morales Airport</name>
+          <code>SPEO</code>
+          <coordinates>-9.149610 -78.523800</coordinates>
         </location>
       </city>
       <city>
@@ -11462,12 +17723,62 @@
       </city>
       <city>
         <!-- A city in Peru -->
+        <name>Huánuco</name>
+        <coordinates>-9.928820 -76.239890</coordinates>
+        <location>
+          <name>Alferez Fap David Figueroa Fernandini Airport</name>
+          <code>SPNC</code>
+          <coordinates>-9.878810 -76.204800</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Peru -->
+        <name>Ilo</name>
+        <coordinates>-17.631850 -71.341080</coordinates>
+        <location>
+          <name>Ilo Airport</name>
+          <code>SPLO</code>
+          <coordinates>-17.695000 -71.344000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Peru -->
         <name>Iquitos</name>
         <coordinates>-3.748056 -73.247222</coordinates>
         <location>
           <name>Iquitos</name>
           <code>SPQT</code>
           <coordinates>-3.750000 -73.250000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Peru -->
+        <name>Jauja</name>
+        <coordinates>-11.775840 -75.496560</coordinates>
+        <location>
+          <name>Francisco Carle Airport</name>
+          <code>SPJJ</code>
+          <coordinates>-11.783100 -75.473400</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Peru -->
+        <name>Jaén</name>
+        <coordinates>-5.707290 -78.807850</coordinates>
+        <location>
+          <name>Shumba Airport</name>
+          <code>SPJE</code>
+          <coordinates>-5.592480 -78.774000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Peru -->
+        <name>Juanjuí</name>
+        <coordinates>-7.176970 -76.727740</coordinates>
+        <location>
+          <name>Juanjui Airport</name>
+          <code>SPJI</code>
+          <coordinates>-7.169100 -76.728600</coordinates>
         </location>
       </city>
       <city>
@@ -11489,6 +17800,31 @@
           <code>SPIM</code>
           <coordinates>-12.000000 -77.116667</coordinates>
         </location>
+        <location>
+          <name>Jorge Chavez International Airport</name>
+          <code>SPJC</code>
+          <coordinates>-12.021900 -77.114300</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Peru -->
+        <name>Mazamari</name>
+        <coordinates>-11.325830 -74.530830</coordinates>
+        <location>
+          <name>Manuel Prado Ugarteche Airport</name>
+          <code>SPMF</code>
+          <coordinates>-11.325400 -74.535600</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Peru -->
+        <name>Nazca</name>
+        <coordinates>-14.830980 -74.938950</coordinates>
+        <location>
+          <name>Maria Reiche Neuman Airport</name>
+          <code>SPZA</code>
+          <coordinates>-14.854000 -74.961500</coordinates>
+        </location>
       </city>
       <city>
         <!-- A city in Peru -->
@@ -11498,6 +17834,16 @@
           <name>Pisco</name>
           <code>SPSO</code>
           <coordinates>-13.750000 -76.283333</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Peru -->
+        <name>Piura</name>
+        <coordinates>-5.181920 -80.657150</coordinates>
+        <location>
+          <name>Capitan FAP Guillermo Concha Iberico International Airport</name>
+          <code>SPUR</code>
+          <coordinates>-5.205750 -80.616400</coordinates>
         </location>
       </city>
       <city>
@@ -11518,6 +17864,16 @@
           <name>Puerto Maldonado</name>
           <code>SPTU</code>
           <coordinates>-12.633333 -69.200000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Peru -->
+        <name>Rioja</name>
+        <coordinates>-6.056750 -77.166510</coordinates>
+        <location>
+          <name>Juan Simons Vela Airport</name>
+          <code>SPJA</code>
+          <coordinates>-6.067860 -77.160000</coordinates>
         </location>
       </city>
       <city>
@@ -11552,6 +17908,16 @@
       </city>
       <city>
         <!-- A city in Peru -->
+        <name>Tingo Maria</name>
+        <coordinates>-9.295320 -75.995740</coordinates>
+        <location>
+          <name>Tingo Maria Airport</name>
+          <code>SPGM</code>
+          <coordinates>-9.133000 -75.950000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Peru -->
         <name>Trujillo</name>
         <coordinates>-8.111944 -79.025556</coordinates>
         <location>
@@ -11568,6 +17934,16 @@
           <name>Tumbes</name>
           <code>SPME</code>
           <coordinates>-3.550000 -80.400000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Peru -->
+        <name>Yurimaguas</name>
+        <coordinates>-5.901810 -76.122340</coordinates>
+        <location>
+          <name>Moises Benzaquen Rengifo Airport</name>
+          <code>SPMS</code>
+          <coordinates>-5.893770 -76.118200</coordinates>
         </location>
       </city>
     </country>
@@ -11652,6 +18028,11 @@
           <code>TVSV</code>
           <coordinates>13.133333 -61.200000</coordinates>
         </location>
+        <location>
+          <name>Argyle International Airport</name>
+          <code>TVSA</code>
+          <coordinates>13.160000 -61.148667</coordinates>
+        </location>
       </city>
     </country>
     <country>
@@ -11671,7 +18052,7 @@
       <name>Suriname</name>
       <!-- Could not find information about the following stations,
            which may be in Suriname:
-           SMNI SMZO 
+           SMNI
         -->
       <iso-code>SR</iso-code>
       <fips-code>NS</fips-code>
@@ -11687,6 +18068,11 @@
           <name>Johan A. Pengel</name>
           <code>SMJP</code>
           <coordinates>5.450000 -55.183333</coordinates>
+        </location>
+        <location>
+          <name>Zorg en Hoop Airport</name>
+          <code>SMZO</code>
+          <coordinates>5.811080 -55.190700</coordinates>
         </location>
       </city>
       <city>
@@ -11755,6 +18141,26 @@
         <timezone id="America/Grand_Turk" />
       </timezones>
       <tz-hint>America/Grand_Turk</tz-hint>
+      <city>
+        <!-- A city in Turks and Caicos Islands -->
+        <name>Cockburn Town</name>
+        <coordinates>21.461220 -71.141880</coordinates>
+        <location>
+          <name>JAGS McCartney International Airport</name>
+          <code>MBGT</code>
+          <coordinates>21.444500 -71.142300</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Turks and Caicos Islands -->
+        <name>Providenciales</name>
+        <coordinates>21.782540 -72.252060</coordinates>
+        <location>
+          <name>Providenciales Airport</name>
+          <code>MBPV</code>
+          <coordinates>21.773600 -72.265900</coordinates>
+        </location>
+      </city>
     </country>
     <country>
       <!-- UY - Uruguay -->
@@ -11765,6 +18171,26 @@
         <timezone id="America/Montevideo" />
       </timezones>
       <tz-hint>America/Montevideo</tz-hint>
+      <city>
+        <!-- A city in Uruguay -->
+        <name>Artigas</name>
+        <coordinates>-30.404310 -56.469260</coordinates>
+        <location>
+          <name>Artigas International Airport</name>
+          <code>SUAG</code>
+          <coordinates>-30.400700 -56.507900</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Uruguay -->
+        <name>Carmelo</name>
+        <coordinates>-34.000230 -58.284020</coordinates>
+        <location>
+          <name>Zagarzazú International Airport</name>
+          <code>SUCM</code>
+          <coordinates>-33.966110 -58.325280</coordinates>
+        </location>
+      </city>
       <city>
         <!-- A city in Uruguay -->
         <name>Carrasco</name>
@@ -11806,6 +18232,16 @@
         </location>
       </city>
       <city>
+        <!-- A city in Uruguay -->
+        <name>Melo</name>
+        <coordinates>-32.368200 -54.164090</coordinates>
+        <location>
+          <name>Cerro Largo International Airport</name>
+          <code>SUMO</code>
+          <coordinates>-32.337900 -54.216700</coordinates>
+        </location>
+      </city>
+      <city>
         <!-- The capital of Uruguay -->
         <name msgctxt="City in Uruguay">Montevideo</name>
         <coordinates>-34.858056 -56.170833</coordinates>
@@ -11813,6 +18249,36 @@
           <name>Melilla</name>
           <code>SUAA</code>
           <coordinates>-34.783333 -56.250000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Uruguay -->
+        <name>Paysandú</name>
+        <coordinates>-32.317100 -58.080720</coordinates>
+        <location>
+          <name>Tydeo Larre Borges Airport</name>
+          <code>SUPU</code>
+          <coordinates>-32.363300 -58.061900</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Uruguay -->
+        <name>Rivera/Santana do Livramento</name>
+        <coordinates>-30.905340 -55.550760</coordinates>
+        <location>
+          <name>Presidente General Don Oscar D. Gestido International Airport</name>
+          <code>SURV</code>
+          <coordinates>-30.974600 -55.476200</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Uruguay -->
+        <name>Salto</name>
+        <coordinates>-31.388110 -57.959830</coordinates>
+        <location>
+          <name>Nueva Hesperides International Airport</name>
+          <code>SUSO</code>
+          <coordinates>-31.438500 -57.985300</coordinates>
         </location>
       </city>
     </country>
@@ -12397,6 +18863,16 @@
       </city>
       <city>
         <!-- A city in Belarus -->
+        <name>Mogilev</name>
+        <coordinates>53.908760 30.340440</coordinates>
+        <location>
+          <name>Mogilev Airport</name>
+          <code>UMOO</code>
+          <coordinates>53.954900 30.095100</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Belarus -->
         <name>Vitsyebsk</name>
         <coordinates>55.192500 30.194444</coordinates>
         <location>
@@ -12639,6 +19115,16 @@
       </city>
       <city>
         <!-- A city in Bosnia and Herzegovina -->
+        <name>Dubrave Gornje</name>
+        <coordinates>44.472290 18.726850</coordinates>
+        <location>
+          <name>Tuzla International Airport</name>
+          <code>LQTZ</code>
+          <coordinates>44.458700 18.724800</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Bosnia and Herzegovina -->
         <name>Mostar</name>
         <coordinates>43.343333 17.808056</coordinates>
         <location>
@@ -12669,6 +19155,16 @@
       <tz-hint>Europe/Sofia</tz-hint>
       <city>
         <!-- A city in Bulgaria -->
+        <name>Balchik</name>
+        <coordinates>43.421660 28.158480</coordinates>
+        <location>
+          <name>Balchik Air Base</name>
+          <code>LBWB</code>
+          <coordinates>43.423800 28.181300</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Bulgaria -->
         <name>Burgas</name>
         <coordinates>42.506058 27.467810</coordinates>
         <location>
@@ -12679,12 +19175,32 @@
       </city>
       <city>
         <!-- A city in Bulgaria -->
+        <name>Dolna Mitropoliya</name>
+        <coordinates>43.466670 24.533330</coordinates>
+        <location>
+          <name>Dolna Mitropoliya Air Base</name>
+          <code>LBPL</code>
+          <coordinates>43.451400 24.502800</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Bulgaria -->
         <name>Gorna Oryakhovitsa</name>
         <coordinates>43.127778 25.701667</coordinates>
         <location>
           <name>Gorna Oryakhovitsa</name>
           <code>LBGO</code>
           <coordinates>43.150000 25.600000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Bulgaria -->
+        <name>Graf Ignatievo</name>
+        <coordinates>42.290400 24.714000</coordinates>
+        <location>
+          <name>Graf Ignatievo Air Base</name>
+          <code>LBPG</code>
+          <coordinates>42.290400 24.714000</coordinates>
         </location>
       </city>
       <city>
@@ -12718,6 +19234,16 @@
           <name>Varna</name>
           <code>LBWN</code>
           <coordinates>43.200000 27.916667</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Bulgaria -->
+        <name>Yambol</name>
+        <coordinates>42.482430 26.500060</coordinates>
+        <location>
+          <name>Bezmer Air Base</name>
+          <code>LBIA</code>
+          <coordinates>42.454900 26.352200</coordinates>
         </location>
       </city>
     </country>
@@ -12886,7 +19412,7 @@
       <name>Czech Republic</name>
       <!-- Could not find information about the following stations,
            which may be in Czech Republic:
-           LKCV LKKB LKLN LKNA LKPD LKPO 
+           LKPO
         -->
       <iso-code>CZ</iso-code>
       <fips-code>EZ</fips-code>
@@ -12902,6 +19428,16 @@
           <name>Brno-Turany Airport</name>
           <code>LKTB</code>
           <coordinates>49.150000 16.700000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Czech Republic -->
+        <name>Chotusice</name>
+        <coordinates>49.949140 15.394280</coordinates>
+        <location>
+          <name>Caslav Air Base</name>
+          <code>LKCV</code>
+          <coordinates>49.939700 15.381800</coordinates>
         </location>
       </city>
       <city>
@@ -12945,6 +19481,26 @@
         </location>
       </city>
       <city>
+        <!-- A city in Czech Republic -->
+        <name>Pardubice</name>
+        <coordinates>50.040750 15.776590</coordinates>
+        <location>
+          <name>Pardubice Airport</name>
+          <code>LKPD</code>
+          <coordinates>50.013400 15.738600</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Czech Republic -->
+        <name>Plzen</name>
+        <coordinates>49.747470 13.377590</coordinates>
+        <location>
+          <name>Plzen Line Airport</name>
+          <code>LKLN</code>
+          <coordinates>49.675200 13.274600</coordinates>
+        </location>
+      </city>
+      <city>
         <!-- The capital of the Czech Republic.
              "Prague" is the traditional English name.
              The local name in Czech is "Praha".
@@ -12955,6 +19511,41 @@
           <name>Prague-Ruzyne Airport</name>
           <code>LKPR</code>
           <coordinates>50.100000 14.250000</coordinates>
+        </location>
+        <location>
+          <name>Kbely Air Base</name>
+          <code>LKKB</code>
+          <coordinates>50.121400 14.543600</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Czech Republic -->
+        <name>Sedlec</name>
+        <coordinates>48.778890 16.693890</coordinates>
+        <location>
+          <name>Namest Air Base</name>
+          <code>LKNA</code>
+          <coordinates>49.165800 16.124900</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Czech Republic -->
+        <name>Uherské Hradiště</name>
+        <coordinates>49.069750 17.459690</coordinates>
+        <location>
+          <name>Kunovice Airport</name>
+          <code>LKKU</code>
+          <coordinates>49.029400 17.439700</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Czech Republic -->
+        <name>Vodochody</name>
+        <coordinates>50.216600 14.395800</coordinates>
+        <location>
+          <name>Vodochody Airport</name>
+          <code>LKVO</code>
+          <coordinates>50.216600 14.395800</coordinates>
         </location>
       </city>
     </country>
@@ -13120,6 +19711,16 @@
         <timezone id="Europe/Tallinn" />
       </timezones>
       <tz-hint>Europe/Tallinn</tz-hint>
+      <city>
+        <!-- A city in Estonia -->
+        <name>Keila</name>
+        <coordinates>59.303610 24.413060</coordinates>
+        <location>
+          <name>Amari Air Base</name>
+          <code>EEEI</code>
+          <coordinates>59.260300 24.208500</coordinates>
+        </location>
+      </city>
       <city>
         <!-- A city in Estonia -->
         <name>Kuressaare</name>
@@ -13539,6 +20140,16 @@
       </city>
       <city>
         <!-- A city in France -->
+        <name>Albert</name>
+        <coordinates>50.000910 2.650960</coordinates>
+        <location>
+          <name>Albert-Bray Airport</name>
+          <code>LFAQ</code>
+          <coordinates>49.971500 2.697660</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in France -->
         <name>Alençon</name>
         <coordinates>48.433333 0.083333</coordinates>
         <location>
@@ -13561,6 +20172,36 @@
       </city>
       <city>
         <!-- A city in France -->
+        <name>Angers</name>
+        <coordinates>47.471560 -0.552020</coordinates>
+        <location>
+          <name>Angers-Loire Airport</name>
+          <code>LFJR</code>
+          <coordinates>47.560300 -0.312220</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in France -->
+        <name>Angoulême</name>
+        <coordinates>45.649970 0.153450</coordinates>
+        <location>
+          <name>Angouleme-Brie-Champniers Airport</name>
+          <code>LFBU</code>
+          <coordinates>45.729200 0.221460</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in France -->
+        <name>Annecy</name>
+        <coordinates>45.908780 6.125650</coordinates>
+        <location>
+          <name>Annecy-Haute-Savoie-Mont Blanc Airport</name>
+          <code>LFLP</code>
+          <coordinates>45.929200 6.098760</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in France -->
         <name>Auch</name>
         <coordinates>43.650000 0.583333</coordinates>
         <location>
@@ -13577,6 +20218,16 @@
           <name>Aurillac</name>
           <code>LFLW</code>
           <coordinates>44.900000 2.416667</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in France -->
+        <name>Avignon</name>
+        <coordinates>43.948340 4.808920</coordinates>
+        <location>
+          <name>Avignon-Caumont Airport</name>
+          <code>LFMV</code>
+          <coordinates>43.907300 4.901830</coordinates>
         </location>
       </city>
       <city>
@@ -13668,6 +20319,11 @@
           <code>LFBV</code>
           <coordinates>45.150000 1.466667</coordinates>
         </location>
+        <location>
+          <name>Brive Souillac Airport</name>
+          <code>LFSL</code>
+          <coordinates>45.039670 1.485500</coordinates>
+        </location>
       </city>
       <city>
         <!-- A city in France -->
@@ -13687,6 +20343,16 @@
           <name>Caen</name>
           <code>LFRK</code>
           <coordinates>49.183333 -0.450000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in France -->
+        <name>Calais</name>
+        <coordinates>50.951940 1.856350</coordinates>
+        <location>
+          <name>Calais-Dunkerque Airport</name>
+          <code>LFAC</code>
+          <coordinates>50.962100 1.954760</coordinates>
         </location>
       </city>
       <city>
@@ -13731,12 +20397,32 @@
       </city>
       <city>
         <!-- A city in France -->
+        <name>Castres</name>
+        <coordinates>43.605270 2.240880</coordinates>
+        <location>
+          <name>Castres-Mazamet Airport</name>
+          <code>LFCK</code>
+          <coordinates>43.556300 2.289180</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in France -->
         <name>Cazaux</name>
         <coordinates>44.533333 -1.150000</coordinates>
         <location>
           <name>Cazaux</name>
           <code>LFBC</code>
           <coordinates>44.533333 -1.133333</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in France -->
+        <name>Chabeuil, Drôme</name>
+        <coordinates>44.898430 5.014380</coordinates>
+        <location>
+          <name>Valence-Chabeuil Airport</name>
+          <code>LFLU</code>
+          <coordinates>44.921600 4.969900</coordinates>
         </location>
       </city>
       <city>
@@ -13830,6 +20516,21 @@
           <code>LFSC</code>
           <coordinates>47.916667 7.400000</coordinates>
         </location>
+        <location>
+          <name>Colmar-Houssen Airport</name>
+          <code>LFGA</code>
+          <coordinates>48.109900 7.359010</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in France -->
+        <name>Cormeilles-en-Vexin, Val-d'Oise</name>
+        <coordinates>49.115950 2.019420</coordinates>
+        <location>
+          <name>Pontoise - Cormeilles-en-Vexin Airport</name>
+          <code>LFPT</code>
+          <coordinates>49.096600 2.040830</coordinates>
+        </location>
       </city>
       <city>
         <!-- A city in France -->
@@ -13849,6 +20550,16 @@
           <name>Dax</name>
           <code>LFBY</code>
           <coordinates>43.683333 -1.066667</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in France -->
+        <name>Deauville</name>
+        <coordinates>49.357000 0.069950</coordinates>
+        <location>
+          <name>Deauville-Saint-Gatien Airport</name>
+          <code>LFRG</code>
+          <coordinates>49.365300 0.154310</coordinates>
         </location>
       </city>
       <city>
@@ -13923,6 +20634,16 @@
       </city>
       <city>
         <!-- A city in France -->
+        <name>Morlaix/Ploujean</name>
+        <coordinates>48.577840 -3.827920</coordinates>
+        <location>
+          <name>Morlaix-Ploujean Airport</name>
+          <code>LFRU</code>
+          <coordinates>48.603200 -3.815780</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in France -->
         <name>Mulhouse</name>
         <coordinates>47.583333 7.516667</coordinates>
         <location>
@@ -13963,12 +20684,52 @@
       </city>
       <city>
         <!-- A city in France -->
+        <name>Landivisiau</name>
+        <coordinates>48.509060 -4.069060</coordinates>
+        <location>
+          <name>Landivisiau Air Base</name>
+          <code>LFRJ</code>
+          <coordinates>48.530300 -4.151640</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in France -->
         <name>Lannion</name>
         <coordinates>48.733333 -3.466667</coordinates>
         <location>
           <name>Lannion-Servel Airport</name>
           <code>LFRO</code>
           <coordinates>48.750000 -3.466667</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in France -->
+        <name>Lanveoc/Poulmic</name>
+        <coordinates>48.287990 -4.462770</coordinates>
+        <location>
+          <name>Lanveoc-Poulmic Air Base</name>
+          <code>LFRL</code>
+          <coordinates>48.281700 -4.445020</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in France -->
+        <name>Laval, Mayenne</name>
+        <coordinates>48.072470 -0.770190</coordinates>
+        <location>
+          <name>Laval-Entrammes Airport</name>
+          <code>LFOV</code>
+          <coordinates>48.031400 -0.742990</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in France -->
+        <name>Le Luc/Le Cannet</name>
+        <coordinates>43.394530 6.312530</coordinates>
+        <location>
+          <name>Le Luc-Le Cannet Airport</name>
+          <code>LFMC</code>
+          <coordinates>43.384700 6.387140</coordinates>
         </location>
       </city>
       <city>
@@ -13989,6 +20750,16 @@
           <name>Le Puy</name>
           <code>LFHP</code>
           <coordinates>45.083333 3.766667</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in France -->
+        <name>Le Touquet-Paris-Plage</name>
+        <coordinates>50.524320 1.585710</coordinates>
+        <location>
+          <name>Le Touquet-Cote d'Opale Airport</name>
+          <code>LFAT</code>
+          <coordinates>50.517400 1.620590</coordinates>
         </location>
       </city>
       <city>
@@ -14078,6 +20849,16 @@
       </city>
       <city>
         <!-- A city in France -->
+        <name>Montbeliard/Courcelles</name>
+        <coordinates>47.509570 6.798230</coordinates>
+        <location>
+          <name>Montbeliard-Courcelles Airport</name>
+          <code>LFSM</code>
+          <coordinates>47.487000 6.790540</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in France -->
         <name>Montgauch</name>
         <coordinates>43.000000 1.083333</coordinates>
         <location>
@@ -14104,6 +20885,16 @@
           <name>Montélimar</name>
           <code>LFLQ</code>
           <coordinates>44.583333 4.733333</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in France -->
+        <name>Muret</name>
+        <coordinates>44.369400 -1.130560</coordinates>
+        <location>
+          <name>Biscarrosse Parentis Airport</name>
+          <code>LFBS</code>
+          <coordinates>44.369400 -1.130560</coordinates>
         </location>
       </city>
       <city>
@@ -14263,6 +21054,16 @@
       </city>
       <city>
         <!-- A city in France -->
+        <name>Périgueux/Bassillac</name>
+        <coordinates>45.186910 0.714390</coordinates>
+        <location>
+          <name>Perigueux-Bassillac Airport</name>
+          <code>LFBX</code>
+          <coordinates>45.198100 0.815560</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in France -->
         <name>Quimper</name>
         <coordinates>48.000000 -4.100000</coordinates>
         <location>
@@ -14279,6 +21080,16 @@
           <name>Reims</name>
           <code>LFSR</code>
           <coordinates>49.300000 4.033333</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in France -->
+        <name>Reims/Prunay</name>
+        <coordinates>49.265260 4.028530</coordinates>
+        <location>
+          <name>Reims-Prunay Airport</name>
+          <code>LFQA</code>
+          <coordinates>49.208700 4.156580</coordinates>
         </location>
       </city>
       <city>
@@ -14333,6 +21144,16 @@
       </city>
       <city>
         <!-- A city in France -->
+        <name>Saint-Denis-de-l'Hôtel, Loiret</name>
+        <coordinates>47.896900 2.163330</coordinates>
+        <location>
+          <name>Orleans-Saint-Denis-de-l'Hotel Airport</name>
+          <code>LFOZ</code>
+          <coordinates>47.896900 2.163330</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in France -->
         <name>Saint-Quentin</name>
         <coordinates>49.850000 3.283333</coordinates>
         <location>
@@ -14359,6 +21180,16 @@
           <name>Salon</name>
           <code>LFMY</code>
           <coordinates>43.600000 5.100000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in France -->
+        <name>Solenzara</name>
+        <coordinates>41.924400 9.406000</coordinates>
+        <location>
+          <name>Solenzara (BA 126) Air Base</name>
+          <code>LFKS</code>
+          <coordinates>41.924400 9.406000</coordinates>
         </location>
       </city>
       <city>
@@ -14428,6 +21259,16 @@
       </city>
       <city>
         <!-- A city in France -->
+        <name>Vannes/Meucon</name>
+        <coordinates>47.656880 -2.762050</coordinates>
+        <location>
+          <name>Vannes-Meucon Airport</name>
+          <code>LFRV</code>
+          <coordinates>47.723300 -2.718560</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in France -->
         <name>Veauche</name>
         <coordinates>45.550000 4.283333</coordinates>
         <location>
@@ -14458,6 +21299,16 @@
       </city>
       <city>
         <!-- A city in France -->
+        <name>Épinal</name>
+        <coordinates>48.183240 6.453040</coordinates>
+        <location>
+          <name>Epinal-Mirecourt Airport</name>
+          <code>LFSG</code>
+          <coordinates>48.325000 6.069980</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in France -->
         <name>Évreux</name>
         <coordinates>49.016667 1.150000</coordinates>
         <location>
@@ -14472,7 +21323,7 @@
       <name>Germany</name>
       <!-- Could not find information about the following stations,
            which may be in Germany:
-           EDFE EDJA 
+           EDFE
         -->
       <!-- Could not find weather stations for the following major
            cities:
@@ -15314,6 +22165,107 @@
           </location>
         </city>
       </state>
+      <city>
+        <!-- A city in Germany -->
+        <name>Altenstadt</name>
+        <coordinates>47.823590 10.874750</coordinates>
+        <location>
+          <name>Altenstadt Army Airfield</name>
+          <code>ETHA</code>
+          <coordinates>47.835500 10.871200</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Germany -->
+        <name>Diepholz</name>
+        <coordinates>52.607830 8.370050</coordinates>
+        <location>
+          <name>Diepholz Airport</name>
+          <code>ETND</code>
+          <coordinates>52.585560 8.342220</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Germany -->
+        <name>Emden</name>
+        <coordinates>53.365920 7.208460</coordinates>
+        <location>
+          <name>Emden Airport</name>
+          <code>EDWE</code>
+          <coordinates>53.391110 7.227500</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Germany -->
+        <name>Hecklingen</name>
+        <coordinates>51.847050 11.534160</coordinates>
+        <location>
+          <name>Cochstedt Airport</name>
+          <code>EDBC</code>
+          <coordinates>51.856400 11.420300</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Germany -->
+        <name>Hohenfels</name>
+        <coordinates>49.203970 11.848410</coordinates>
+        <location>
+          <name>Hohenfels Army Air Field</name>
+          <code>ETIH</code>
+          <coordinates>49.218100 11.836100</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Germany -->
+        <name>Idar-Oberstein</name>
+        <coordinates>49.714430 7.307760</coordinates>
+        <location>
+          <name>Baumholder Army Air Field</name>
+          <code>ETEK</code>
+          <tz-hint>Europe/Berlin</tz-hint>
+          <coordinates>49.650000 7.300000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Germany -->
+        <name>Manching</name>
+        <coordinates>48.716560 11.493930</coordinates>
+        <location>
+          <name>Ingolstadt Manching Airport</name>
+          <code>ETSI</code>
+          <coordinates>48.715700 11.534000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Germany -->
+        <name>Memmingen</name>
+        <coordinates>47.983720 10.185270</coordinates>
+        <location>
+          <name>Memmingen Allgau Airport</name>
+          <code>EDJA</code>
+          <coordinates>47.988800 10.239500</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Germany -->
+        <name>Meppe</name>
+        <coordinates>52.723200 7.326330</coordinates>
+        <location>
+          <name>Meppe Airport</name>
+          <code>ETWM</code>
+          <coordinates>52.723200 7.326330</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Germany -->
+        <name>Schwabisch Hall</name>
+        <coordinates>49.118330 9.783890</coordinates>
+        <location>
+          <name>Adolf Wurth Airport</name>
+          <code>EDTY</code>
+          <coordinates>49.118330 9.783890</coordinates>
+        </location>
+      </city>
     </country>
     <country>
       <!-- GI - Gibraltar, a British overseas territory on the southern
@@ -15340,10 +22292,6 @@
     <country>
       <!-- GR - Greece -->
       <name>Greece</name>
-      <!-- Could not find information about the following stations,
-           which may be in Greece:
-           LGSY 
-        -->
       <iso-code>GR</iso-code>
       <fips-code>GR</fips-code>
       <timezones>
@@ -15423,6 +22371,16 @@
           <name>Elefsís Airport</name>
           <code>LGEL</code>
           <coordinates>38.066667 23.550000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Greece -->
+        <name>Ioannina</name>
+        <coordinates>39.663410 20.851870</coordinates>
+        <location>
+          <name>Ioannina Airport</name>
+          <code>LGIO</code>
+          <coordinates>39.696400 20.822500</coordinates>
         </location>
       </city>
       <city>
@@ -15595,6 +22553,16 @@
       </city>
       <city>
         <!-- A city in Greece -->
+        <name>Skiros Island</name>
+        <coordinates>38.967600 24.487200</coordinates>
+        <location>
+          <name>Skiros Airport</name>
+          <code>LGSY</code>
+          <coordinates>38.967600 24.487200</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Greece -->
         <name>Skíathos</name>
         <coordinates>39.166667 23.483333</coordinates>
         <location>
@@ -15723,10 +22691,6 @@
     <country>
       <!-- HU - Hungary -->
       <name>Hungary</name>
-      <!-- Could not find information about the following stations,
-           which may be in Hungary:
-           LHPR 
-        -->
       <iso-code>HU</iso-code>
       <fips-code>HU</fips-code>
       <timezones>
@@ -15755,12 +22719,32 @@
       </city>
       <city>
         <!-- A city in Hungary -->
+        <name>Győr</name>
+        <coordinates>47.683330 17.635120</coordinates>
+        <location>
+          <name>Gyor-Per International Airport</name>
+          <code>LHPR</code>
+          <coordinates>47.624400 17.813600</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Hungary -->
         <name>Kecskemét</name>
         <coordinates>46.900000 19.783333</coordinates>
         <location>
           <name>Kecskemét</name>
           <code>LHKE</code>
           <coordinates>46.916667 19.750000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Hungary -->
+        <name>Nyiregyhaza</name>
+        <coordinates>47.955390 21.716710</coordinates>
+        <location>
+          <name>Nyiregyhaza Airport</name>
+          <code>LHNY</code>
+          <coordinates>47.983900 21.692300</coordinates>
         </location>
       </city>
       <city>
@@ -15803,6 +22787,16 @@
           <coordinates>47.116667 20.233333</coordinates>
         </location>
       </city>
+      <city>
+        <!-- A city in Hungary -->
+        <name>Sármellék</name>
+        <coordinates>46.712210 17.168650</coordinates>
+        <location>
+          <name>Sarmellek International Airport</name>
+          <code>LHSM</code>
+          <coordinates>46.686400 17.159100</coordinates>
+        </location>
+      </city>
     </country>
     <country>
       <!-- IS - Iceland -->
@@ -15825,12 +22819,62 @@
       </city>
       <city>
         <!-- A city in Iceland -->
+        <name>Bildudalur</name>
+        <coordinates>65.641300 -23.546200</coordinates>
+        <location>
+          <name>Bíldudalur Airport</name>
+          <code>BIBD</code>
+          <coordinates>65.641300 -23.546200</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Iceland -->
         <name>Eiðar</name>
         <coordinates>65.366667 -14.350000</coordinates>
         <location>
           <name>Egilsstadir</name>
           <code>BIEG</code>
           <coordinates>65.283333 -14.400000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Iceland -->
+        <name>Gjögur</name>
+        <coordinates>65.995300 -21.326900</coordinates>
+        <location>
+          <name>Gjögur Airport</name>
+          <code>BIGJ</code>
+          <coordinates>65.995300 -21.326900</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Iceland -->
+        <name>Grímsey/Sandvík</name>
+        <coordinates>66.545800 -18.017300</coordinates>
+        <location>
+          <name>Grímsey Airport</name>
+          <code>BIGR</code>
+          <coordinates>66.545800 -18.017300</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Iceland -->
+        <name>Höfn</name>
+        <coordinates>64.253880 -15.212120</coordinates>
+        <location>
+          <name>Hornafjörðu Airport</name>
+          <code>BIHN</code>
+          <coordinates>64.295600 -15.227200</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Iceland -->
+        <name>Húsavík</name>
+        <coordinates>66.041480 -17.338340</coordinates>
+        <location>
+          <name>Húsavík Airport</name>
+          <code>BIHU</code>
+          <coordinates>65.952300 -17.426000</coordinates>
         </location>
       </city>
       <city>
@@ -15845,12 +22889,62 @@
       </city>
       <city>
         <!-- A city in Iceland -->
+        <name>Sauðárkrókur</name>
+        <coordinates>65.746110 -19.639440</coordinates>
+        <location>
+          <name>Sauðárkrókur Airport</name>
+          <code>BIKR</code>
+          <coordinates>65.731700 -19.572800</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Iceland -->
+        <name>Vestmannaeyjar</name>
+        <coordinates>63.442730 -20.273390</coordinates>
+        <location>
+          <name>Vestmannaeyjar Airport</name>
+          <code>BIVM</code>
+          <coordinates>63.424300 -20.278900</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Iceland -->
+        <name>Vopnafjörður</name>
+        <coordinates>65.756580 -14.827770</coordinates>
+        <location>
+          <name>Vopnafjörður Airport</name>
+          <code>BIVO</code>
+          <coordinates>65.720600 -14.850600</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Iceland -->
         <name>Ytri-Njarðvík</name>
         <coordinates>63.983333 -22.550000</coordinates>
         <location>
           <name>Keflavikurflugvollur</name>
           <code>BIKF</code>
           <coordinates>63.966667 -22.600000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Iceland -->
+        <name>Ísafjörður</name>
+        <coordinates>66.074750 -23.134980</coordinates>
+        <location>
+          <name>Ísafjörður Airport</name>
+          <code>BIIS</code>
+          <coordinates>66.058100 -23.135300</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Iceland -->
+        <name>Þórshöfn</name>
+        <coordinates>66.218500 -15.335600</coordinates>
+        <location>
+          <name>Þórshöfn (Thorshofn) Airport</name>
+          <code>BITN</code>
+          <coordinates>66.218500 -15.335600</coordinates>
         </location>
       </city>
     </country>
@@ -15869,6 +22963,16 @@
       </timezones>
       <tz-hint>Europe/Dublin</tz-hint>
       <city>
+        <!-- A city in Ireland -->
+        <name>Baldonnel</name>
+        <coordinates>53.301700 -6.451330</coordinates>
+        <location>
+          <name>Casement Air Base</name>
+          <code>EIME</code>
+          <coordinates>53.301700 -6.451330</coordinates>
+        </location>
+      </city>
+      <city>
         <!-- A city in Ireland.
              The local name in Irish is "Corcaigh".
           -->
@@ -15878,6 +22982,16 @@
           <name>Cork Airport</name>
           <code>EICK</code>
           <coordinates>51.850000 -8.483333</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Ireland -->
+        <name>Donegal</name>
+        <coordinates>54.653780 -8.111340</coordinates>
+        <location>
+          <name>Donegal Airport</name>
+          <code>EIDL</code>
+          <coordinates>55.044200 -8.341000</coordinates>
         </location>
       </city>
       <city>
@@ -15906,6 +23020,16 @@
       </city>
       <city>
         <!-- A city in Ireland -->
+        <name>Farranfore</name>
+        <coordinates>52.180900 -9.523780</coordinates>
+        <location>
+          <name>Kerry Airport</name>
+          <code>EIKY</code>
+          <coordinates>52.180900 -9.523780</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Ireland -->
         <name>Glentavraun</name>
         <coordinates>53.883333 -8.800000</coordinates>
         <location>
@@ -15924,6 +23048,26 @@
           <name>Shannon Airport</name>
           <code>EINN</code>
           <coordinates>52.700000 -8.916667</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Ireland -->
+        <name>Sligo</name>
+        <coordinates>54.269690 -8.469430</coordinates>
+        <location>
+          <name>Sligo Airport</name>
+          <code>EISG</code>
+          <coordinates>54.280200 -8.599210</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Ireland -->
+        <name>Waterford</name>
+        <coordinates>52.258330 -7.111940</coordinates>
+        <location>
+          <name>Waterford Airport</name>
+          <code>EIWF</code>
+          <coordinates>52.187200 -7.086960</coordinates>
         </location>
       </city>
     </country>
@@ -16082,12 +23226,33 @@
       </city>
       <city>
         <!-- A city in Italy -->
+        <name>Cagli</name>
+        <coordinates>43.547710 12.652290</coordinates>
+        <location>
+          <name>Frontone</name>
+          <code>LIVF</code>
+          <tz-hint>Europe/Rome</tz-hint>
+          <coordinates>43.517000 12.733000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Italy -->
         <name>Cagliari</name>
         <coordinates>39.216667 9.116667</coordinates>
         <location>
           <name>Elmas Airport</name>
           <code>LIEE</code>
           <coordinates>39.250000 9.066667</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Italy -->
+        <name>Cameri (NO)</name>
+        <coordinates>45.501590 8.662450</coordinates>
+        <location>
+          <name>Cameri Airport</name>
+          <code>LIMN</code>
+          <coordinates>45.529600 8.669220</coordinates>
         </location>
       </city>
       <city>
@@ -16133,6 +23298,37 @@
           <name>Cervia</name>
           <code>LIPC</code>
           <coordinates>44.216667 12.300000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Italy -->
+        <name>Codroipo (UD)</name>
+        <coordinates>45.964690 12.979850</coordinates>
+        <location>
+          <name>Rivolto Air Base</name>
+          <code>LIPI</code>
+          <coordinates>45.978700 13.049300</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Italy -->
+        <name>Comiso</name>
+        <coordinates>36.948930 14.607310</coordinates>
+        <location>
+          <name>Comiso Airport Vincenzo Magliocco</name>
+          <code>LICB</code>
+          <coordinates>36.994600 14.607180</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Italy -->
+        <name>Cosenza</name>
+        <coordinates>39.298900 16.253070</coordinates>
+        <location>
+          <name>Scuro Mountain</name>
+          <code>LIBQ</code>
+          <tz-hint>Europe/Rome</tz-hint>
+          <coordinates>39.333000 16.400000</coordinates>
         </location>
       </city>
       <city>
@@ -16200,6 +23396,16 @@
       </city>
       <city>
         <!-- A city in Italy -->
+        <name>Foggia (FG)</name>
+        <coordinates>41.458450 15.551880</coordinates>
+        <location>
+          <name>Foggia / Gino Lisa Airport</name>
+          <code>LIBF</code>
+          <coordinates>41.432900 15.535000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Italy -->
         <name>Forlì</name>
         <coordinates>44.223611 12.052778</coordinates>
         <location>
@@ -16216,6 +23422,17 @@
           <name>Frosinone</name>
           <code>LIRH</code>
           <coordinates>41.633333 13.300000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Italy -->
+        <name>Gela</name>
+        <coordinates>37.073810 14.240380</coordinates>
+        <location>
+          <name>Gela</name>
+          <code>LICL</code>
+          <tz-hint>Europe/Rome</tz-hint>
+          <coordinates>37.083000 14.217000</coordinates>
         </location>
       </city>
       <city>
@@ -16283,6 +23500,16 @@
       </city>
       <city>
         <!-- A city in Italy -->
+        <name>Guidonia</name>
+        <coordinates>41.993620 12.722380</coordinates>
+        <location>
+          <name>Guidonia Airport</name>
+          <code>LIRG</code>
+          <coordinates>41.990300 12.740800</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Italy -->
         <name>Isola del Cantone</name>
         <coordinates>44.650000 8.950000</coordinates>
         <location>
@@ -16333,6 +23560,17 @@
       </city>
       <city>
         <!-- A city in Italy -->
+        <name>Lido Adriano</name>
+        <coordinates>44.416730 12.305520</coordinates>
+        <location>
+          <name>Point Marina/Ravenna</name>
+          <code>LIVM</code>
+          <tz-hint>Europe/Rome</tz-hint>
+          <coordinates>44.450000 12.300000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Italy -->
         <name>Messina</name>
         <coordinates>38.183333 15.566667</coordinates>
         <location>
@@ -16370,6 +23608,17 @@
         </location>
       </city>
       <city>
+        <!-- A city in Italy -->
+        <name>Monte Argentario</name>
+        <coordinates>42.434520 11.119540</coordinates>
+        <location>
+          <name>Mount Argentario</name>
+          <code>LIQO</code>
+          <tz-hint>Europe/Rome</tz-hint>
+          <coordinates>42.383000 11.167000</coordinates>
+        </location>
+      </city>
+      <city>
         <!-- A city in Italy.
              "Naples" is the traditional English name.
              The local name in Italian is "Napoli".
@@ -16390,6 +23639,16 @@
           <name>Costa Smeralda Airport</name>
           <code>LIEO</code>
           <coordinates>40.900000 9.516667</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Italy -->
+        <name>Padova</name>
+        <coordinates>45.407970 11.885860</coordinates>
+        <location>
+          <name>Padova Airport</name>
+          <code>LIPU</code>
+          <coordinates>45.395800 11.847900</coordinates>
         </location>
       </city>
       <city>
@@ -16440,6 +23699,17 @@
           <name>Parma</name>
           <code>LIMP</code>
           <coordinates>44.821389 10.294722</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Italy -->
+        <name>Pavullo nel Frignano</name>
+        <coordinates>44.333520 10.835440</coordinates>
+        <location>
+          <name>Cimone Mountain</name>
+          <code>LIVC</code>
+          <tz-hint>Europe/Rome</tz-hint>
+          <coordinates>44.200000 10.700000</coordinates>
         </location>
       </city>
       <city>
@@ -16531,6 +23801,12 @@
           <code>LIQN</code>
           <coordinates>42.416667 12.850000</coordinates>
         </location>
+        <location>
+          <name>Terminillo Mountain</name>
+          <code>LIRK</code>
+          <tz-hint>Europe/Rome</tz-hint>
+          <coordinates>42.467000 12.983000</coordinates>
+        </location>
       </city>
       <city>
         <!-- A city in Italy -->
@@ -16577,6 +23853,16 @@
       </city>
       <city>
         <!-- A city in Italy -->
+        <name>Saint-Christophe (AO)</name>
+        <coordinates>45.754060 7.347200</coordinates>
+        <location>
+          <name>Aosta Airport</name>
+          <code>LIMW</code>
+          <coordinates>45.738500 7.368720</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Italy -->
         <name>Salignano</name>
         <coordinates>39.833333 18.350000</coordinates>
         <location>
@@ -16607,6 +23893,16 @@
       </city>
       <city>
         <!-- A city in Italy -->
+        <name>Sarzana</name>
+        <coordinates>44.111780 9.962200</coordinates>
+        <location>
+          <name>Sarzana / Luni Military Airport</name>
+          <code>LIQW</code>
+          <coordinates>44.088000 9.987950</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Italy -->
         <name>Sporminore</name>
         <coordinates>46.166667 11.033333</coordinates>
         <location>
@@ -16633,6 +23929,16 @@
           <name>Tarvisio</name>
           <code>LIVO</code>
           <coordinates>46.500000 13.583333</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Italy -->
+        <name>Torino (TO)</name>
+        <coordinates>45.070490 7.686820</coordinates>
+        <location>
+          <name>Torino / Aeritalia Airport</name>
+          <code>LIMA</code>
+          <coordinates>45.086400 7.603370</coordinates>
         </location>
       </city>
       <city>
@@ -16691,6 +23997,12 @@
           <name>Caselle Airport</name>
           <code>LIMF</code>
           <coordinates>45.216667 7.650000</coordinates>
+        </location>
+        <location>
+          <name>Torino/Bric Croce</name>
+          <code>LIMK</code>
+          <tz-hint>Europe/Rome</tz-hint>
+          <coordinates>45.033000 7.733000</coordinates>
         </location>
       </city>
       <city>
@@ -16770,18 +24082,43 @@
       </city>
     </country>
     <country>
+      <name>Kosovo</name>
+      <iso-code>XK</iso-code>
+      <fips-code>KV</fips-code>
+      <timezones>
+        <timezone id="Europe/Belgrade" />
+      </timezones>
+      <tz-hint>Europe/Belgrade</tz-hint>
+      <city>
+        <!-- A city in Kosovo -->
+        <name>Prishtina</name>
+        <coordinates>42.672720 21.166880</coordinates>
+        <location>
+          <name>Pristina International Airport</name>
+          <code>BKPR</code>
+          <coordinates>42.572830 21.035830</coordinates>
+        </location>
+      </city>
+    </country>
+    <country>
       <!-- LV - Latvia -->
       <name>Latvia</name>
-      <!-- Could not find information about the following stations,
-           which may be in Latvia:
-           EVVA 
-        -->
       <iso-code>LV</iso-code>
       <fips-code>LG</fips-code>
       <timezones>
         <timezone id="Europe/Riga" />
       </timezones>
       <tz-hint>Europe/Riga</tz-hint>
+      <city>
+        <!-- A city in Latvia -->
+        <name>Lielvarde</name>
+        <coordinates>56.720660 24.807430</coordinates>
+        <location>
+          <name>Lielvarde Airport</name>
+          <code>EVGA</code>
+          <coordinates>56.778300 24.853900</coordinates>
+        </location>
+      </city>
       <city>
         <!-- A city in Latvia -->
         <name>Liepāja</name>
@@ -16800,6 +24137,16 @@
           <name>Rīga International Airport</name>
           <code>EVRA</code>
           <coordinates>56.916667 23.966667</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Latvia -->
+        <name>Ventspils</name>
+        <coordinates>57.394850 21.561210</coordinates>
+        <location>
+          <name>Ventspils International Airport</name>
+          <code>EVVA</code>
+          <coordinates>57.357800 21.544200</coordinates>
         </location>
       </city>
     </country>
@@ -16976,13 +24323,23 @@
           <coordinates>46.927778 28.930833</coordinates>
         </location>
       </city>
+      <city>
+        <!-- A city in Moldova -->
+        <name>Mărculeşti</name>
+        <coordinates>47.868970 28.241090</coordinates>
+        <location>
+          <name>Marculesti International Airport</name>
+          <code>LUBM</code>
+          <coordinates>47.862700 28.212800</coordinates>
+        </location>
+      </city>
     </country>
     <country>
       <!-- MC - Monaco -->
       <name msgctxt="Country">Monaco</name>
       <!-- Could not find information about the following stations,
            which may be in Monaco:
-           LFAQ LFDB LFJR LFLP LFMV LFRG 
+           LFDB
         -->
       <iso-code>MC</iso-code>
       <fips-code>MN</fips-code>
@@ -17006,7 +24363,7 @@
       <name>Montenegro</name>
       <!-- Could not find information about the following stations,
            which may be in Montenegro:
-           LYBT LYKV LYUZ 
+           LYUZ
         -->
       <iso-code>ME</iso-code>
       <fips-code>MJ</fips-code>
@@ -17040,12 +24397,13 @@
       <name>Netherlands</name>
       <!-- Could not find information about the following stations,
            which may be in Netherlands:
-           EHFZ EHJR EHSA EHSC 
+           EHFZ EHSA
         -->
       <iso-code>NL</iso-code>
       <fips-code>NL</fips-code>
       <timezones>
         <timezone id="Europe/Amsterdam" />
+        <timezone id="Etc/GMT" />
       </timezones>
       <tz-hint>Europe/Amsterdam</tz-hint>
       <city>
@@ -17080,12 +24438,45 @@
       </city>
       <city>
         <!-- A city in the Netherlands -->
+        <name>Den Burg</name>
+        <coordinates>53.054170 4.797220</coordinates>
+        <location>
+          <name>K14-FA-1C</name>
+          <code>EHKV</code>
+          <tz-hint>Etc/GMT</tz-hint>
+          <coordinates>53.267000 3.633000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in the Netherlands -->
+        <name>Dokkum</name>
+        <coordinates>53.322240 5.996970</coordinates>
+        <location>
+          <name>AWG-1</name>
+          <code>EHMA</code>
+          <tz-hint>Europe/Amsterdam</tz-hint>
+          <coordinates>53.500000 5.950000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in the Netherlands -->
         <name>Eindhoven</name>
         <coordinates>51.450000 5.466667</coordinates>
         <location>
           <name>Eindhoven</name>
           <code>EHEH</code>
           <coordinates>51.450000 5.416667</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in the Netherlands -->
+        <name>F3 - Netherlands</name>
+        <coordinates>54.850000 4.733000</coordinates>
+        <location>
+          <name>F3 - Netherlands</name>
+          <code>EHFD</code>
+          <tz-hint>Etc/GMT</tz-hint>
+          <coordinates>54.850000 4.733000</coordinates>
         </location>
       </city>
       <city>
@@ -17110,12 +24501,44 @@
       </city>
       <city>
         <!-- A city in the Netherlands -->
+        <name>Harlingen</name>
+        <coordinates>53.174770 5.422440</coordinates>
+        <location>
+          <name>L9-FF-1</name>
+          <code>EHMG</code>
+          <tz-hint>Etc/GMT</tz-hint>
+          <coordinates>53.617000 4.967000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in the Netherlands -->
+        <name>K13-A</name>
+        <coordinates>53.217000 3.217000</coordinates>
+        <location>
+          <name>K13-A</name>
+          <code>EHJR</code>
+          <tz-hint>Etc/GMT</tz-hint>
+          <coordinates>53.217000 3.217000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in the Netherlands -->
         <name>Leeuwarden</name>
         <coordinates>53.200000 5.783333</coordinates>
         <location>
           <name>Leeuwarden</name>
           <code>EHLW</code>
           <coordinates>53.216667 5.766667</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in the Netherlands -->
+        <name>Lelystad</name>
+        <coordinates>52.508330 5.475000</coordinates>
+        <location>
+          <name>Lelystad Airport</name>
+          <code>EHLE</code>
+          <coordinates>52.460300 5.527220</coordinates>
         </location>
       </city>
       <city>
@@ -17130,6 +24553,17 @@
       </city>
       <city>
         <!-- A city in the Netherlands -->
+        <name>Monster</name>
+        <coordinates>52.025830 4.175000</coordinates>
+        <location>
+          <name>P11-B / De Ruyter</name>
+          <code>EHPG</code>
+          <tz-hint>Etc/GMT</tz-hint>
+          <coordinates>52.367000 3.350000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in the Netherlands -->
         <name>Oost-Vlieland</name>
         <coordinates>53.283333 5.066667</coordinates>
         <location>
@@ -17140,12 +24574,13 @@
       </city>
       <city>
         <!-- A city in the Netherlands -->
-        <name>Rotterdam</name>
-        <coordinates>51.916667 4.500000</coordinates>
+        <name>Ouddorp</name>
+        <coordinates>51.811670 3.934720</coordinates>
         <location>
-          <name>Zestienhoven Airport</name>
-          <code>EHRD</code>
-          <coordinates>51.950000 4.450000</coordinates>
+          <name>Le Goeree</name>
+          <code>EHSC</code>
+          <tz-hint>Europe/Amsterdam</tz-hint>
+          <coordinates>51.933000 3.667000</coordinates>
         </location>
       </city>
       <city>
@@ -17156,19 +24591,20 @@
         <name>The Hague</name>
         <coordinates>52.083333 4.300000</coordinates>
         <location>
-          <name>Valkenburg</name>
-          <code>EHVB</code>
-          <coordinates>52.183333 4.416667</coordinates>
+          <name>Rotterdam The Hague Airport</name>
+          <code>EHRD</code>
+          <coordinates>51.956944 4.439722</coordinates>
         </location>
       </city>
       <city>
         <!-- A city in the Netherlands -->
-        <name>Valkenburg</name>
-        <coordinates>52.183333 4.433333</coordinates>
+        <name>Vlissingen</name>
+        <coordinates>51.442500 3.573610</coordinates>
         <location>
-          <name>Valkenburg</name>
-          <code>EHVB</code>
-          <coordinates>52.183333 4.416667</coordinates>
+          <name>Vlissingen</name>
+          <code>EHFS</code>
+          <tz-hint>Europe/Amsterdam</tz-hint>
+          <coordinates>51.450000 3.600000</coordinates>
         </location>
       </city>
       <city>
@@ -17195,14 +24631,12 @@
     <country>
       <!-- NO - Norway -->
       <name>Norway</name>
-      <!-- Could not find cities for the following weather stations:
-           ENDR - Draugen (64.355556 7.791667)
-           ENHE - Heidrun (65.325000 2.326667)
-        -->
       <iso-code>NO</iso-code>
       <fips-code>NO</fips-code>
       <timezones>
         <timezone id="Europe/Oslo" />
+        <timezone id="Etc/GMT" />
+        <timezone id="Etc/GMT-1" />
       </timezones>
       <tz-hint>Europe/Oslo</tz-hint>
       <city>
@@ -17233,6 +24667,12 @@
           <name>Bodo Vi</name>
           <code>ENBO</code>
           <coordinates>67.266667 14.366667</coordinates>
+        </location>
+        <location>
+          <name>Vaeroy Heliport</name>
+          <code>ENVR</code>
+          <tz-hint>Europe/Oslo</tz-hint>
+          <coordinates>67.650000 12.717000</coordinates>
         </location>
       </city>
       <city>
@@ -17293,6 +24733,17 @@
           <name>Orland</name>
           <code>ENOL</code>
           <coordinates>63.700000 9.600000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Norway -->
+        <name>Draugen</name>
+        <coordinates>64.350000 7.800000</coordinates>
+        <location>
+          <name>Draugen</name>
+          <code>ENDR</code>
+          <tz-hint>Etc/GMT-1</tz-hint>
+          <coordinates>64.350000 7.800000</coordinates>
         </location>
       </city>
       <city>
@@ -17397,6 +24848,17 @@
       </city>
       <city>
         <!-- A city in Norway -->
+        <name>Heidrun</name>
+        <coordinates>65.333000 7.317000</coordinates>
+        <location>
+          <name>Heidrun</name>
+          <code>ENHE</code>
+          <tz-hint>Etc/GMT</tz-hint>
+          <coordinates>65.333000 7.317000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Norway -->
         <name>Holm</name>
         <coordinates>61.150000 7.166667</coordinates>
         <location>
@@ -17453,6 +24915,16 @@
           <name>Langnes Airport</name>
           <code>ENTC</code>
           <coordinates>69.683333 18.916667</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Norway -->
+        <name>Leirvik</name>
+        <coordinates>59.779770 5.500510</coordinates>
+        <location>
+          <name>Stord Airport</name>
+          <code>ENSO</code>
+          <coordinates>59.791900 5.340850</coordinates>
         </location>
       </city>
       <city>
@@ -17787,6 +25259,16 @@
       </city>
       <city>
         <!-- A city in Poland -->
+        <name>Nowy Dwór Mazowiecki</name>
+        <coordinates>52.430220 20.716520</coordinates>
+        <location>
+          <name>Warsaw Modlin Airport</name>
+          <code>EPMO</code>
+          <coordinates>52.451100 20.651800</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Poland -->
         <name>Olsztyn</name>
         <coordinates>53.778422 20.480119</coordinates>
         <location>
@@ -17905,6 +25387,16 @@
           <name>Beja</name>
           <code>LPBJ</code>
           <coordinates>38.016667 -7.866667</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Portugal -->
+        <name>Cascais</name>
+        <coordinates>38.696810 -9.421470</coordinates>
+        <location>
+          <name>Cascais Airport</name>
+          <code>LPCS</code>
+          <coordinates>38.725000 -9.355230</coordinates>
         </location>
       </city>
       <city>
@@ -18049,6 +25541,16 @@
       </city>
       <city>
         <!-- A city in Portugal -->
+        <name>Vila Franca de Xira</name>
+        <coordinates>38.955250 -8.989660</coordinates>
+        <location>
+          <name>Alverca Airport</name>
+          <code>LPAR</code>
+          <coordinates>38.885362 -9.028311</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Portugal -->
         <name>Água de Pena</name>
         <coordinates>32.700000 -16.766667</coordinates>
         <location>
@@ -18099,6 +25601,16 @@
         </location>
       </city>
       <city>
+        <!-- A city in Romania -->
+        <name>Brașov (Ghimbav)</name>
+        <coordinates>45.648610 25.606130</coordinates>
+        <location>
+          <name>Braşov-Ghimbav International Airport</name>
+          <code>LRBV</code>
+          <coordinates>45.706110 25.523330</coordinates>
+        </location>
+      </city>
+      <city>
         <!-- The capital of Romania.
              "Bucharest" is the traditional English name.
              The local name in Romanian is "Bucureşti".
@@ -18134,6 +25646,16 @@
           <name>Craiova</name>
           <code>LRCV</code>
           <coordinates>44.233333 23.866667</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Romania -->
+        <name>Câmpia Turzii</name>
+        <coordinates>46.550000 23.883330</coordinates>
+        <location>
+          <name>Campia Turzii Air Base</name>
+          <code>LRCT</code>
+          <coordinates>46.502300 23.885900</coordinates>
         </location>
       </city>
       <city>
@@ -18232,13 +25754,11 @@
       <name>Russia</name>
       <!-- Could not find information about the following stations,
            which may be in Russia:
-           UESO UHMP UHNN UHSH ULDD ULKK ULOO UMOO UNKL URKM URML USCM
-           USDD USMU USRK UUOB UUYH UUYS UWKE UWKS UWLL UWOR 
+           UESO UHMP UHNN UHSH ULDD ULKK URKM USMU USRK UUYH UUYS
         -->
       <!-- Could not find weather stations for the following major
            cities:
            Balakovo, Izhevsk, Komsomol'sk, Sarapul, Serpukhov, Tambov,
-           Tomsk, Tula, Tver', Yoshkar-Ola
         -->
       <iso-code>RU</iso-code>
       <fips-code>RS</fips-code>
@@ -18437,6 +25957,39 @@
         </location>
       </city>
       <city>
+        <!-- A city in Russia -->
+        <name>Belgorod</name>
+        <coordinates>50.603430 36.580910</coordinates>
+        <location>
+          <name>Belgorod International Airport</name>
+          <code>UUOB</code>
+          <tz-hint>Europe/Moscow</tz-hint>
+          <coordinates>50.643800 36.590100</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Russia -->
+        <name>Beslan</name>
+        <coordinates>43.192770 44.532740</coordinates>
+        <location>
+          <name>Beslan Airport</name>
+          <code>URMO</code>
+          <tz-hint>Europe/Moscow</tz-hint>
+          <coordinates>43.205100 44.606600</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Russia -->
+        <name>Blagoveschensk</name>
+        <coordinates>50.275930 127.526370</coordinates>
+        <location>
+          <name>Ignatyevo Airport</name>
+          <code>UHBB</code>
+          <tz-hint>Asia/Yakutsk</tz-hint>
+          <coordinates>50.425400 127.412000</coordinates>
+        </location>
+      </city>
+      <city>
         <!-- A city in Russia.
              The local name in Russian is "Брацк".
           -->
@@ -18463,6 +26016,17 @@
         </location>
       </city>
       <city>
+        <!-- A city in Russia -->
+        <name>Cheboksary</name>
+        <coordinates>56.132180 47.246000</coordinates>
+        <location>
+          <name>Cheboksary Airport</name>
+          <code>UWKS</code>
+          <tz-hint>Europe/Moscow</tz-hint>
+          <coordinates>56.090300 47.347300</coordinates>
+        </location>
+      </city>
+      <city>
         <!-- A city in Russia.
              The local name in Russian is "Челябинск".
           -->
@@ -18473,6 +26037,17 @@
           <code>USCC</code>
           <tz-hint>Asia/Yekaterinburg</tz-hint>
           <coordinates>55.166667 61.400000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Russia -->
+        <name>Cherepovets</name>
+        <coordinates>59.133330 37.900000</coordinates>
+        <location>
+          <name>Cherepovets Airport</name>
+          <code>ULWC</code>
+          <tz-hint>Europe/Moscow</tz-hint>
+          <coordinates>59.276670 38.028330</coordinates>
         </location>
       </city>
       <city>
@@ -18489,6 +26064,17 @@
         </location>
       </city>
       <city>
+        <!-- A city in Russia -->
+        <name>Chukotka</name>
+        <coordinates>64.378100 -173.243000</coordinates>
+        <location>
+          <name>Provideniya Bay Airport</name>
+          <code>UHMD</code>
+          <tz-hint>Asia/Anadyr</tz-hint>
+          <coordinates>64.378100 -173.243000</coordinates>
+        </location>
+      </city>
+      <city>
         <!-- A city in Russia.
              The local name in Russian is "Чульман".
           -->
@@ -18502,6 +26088,17 @@
         </location>
       </city>
       <city>
+        <!-- A city in Russia -->
+        <name>Elista</name>
+        <coordinates>46.307940 44.255370</coordinates>
+        <location>
+          <name>Elista Airport</name>
+          <code>URWI</code>
+          <tz-hint>Europe/Moscow</tz-hint>
+          <coordinates>46.373900 44.330900</coordinates>
+        </location>
+      </city>
+      <city>
         <!-- A city in Russia.
              The local name in Russian is "Энгельс".
           -->
@@ -18512,6 +26109,28 @@
           <code>UWSS</code>
           <tz-hint>Europe/Moscow</tz-hint>
           <coordinates>51.570000 46.070000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Russia -->
+        <name>Gorno-Altaysk</name>
+        <coordinates>51.960560 85.918920</coordinates>
+        <location>
+          <name>Gorno-Altaysk Airport</name>
+          <code>UNBG</code>
+          <tz-hint>Asia/Krasnoyarsk</tz-hint>
+          <coordinates>51.966700 85.833300</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Russia -->
+        <name>Grozny</name>
+        <coordinates>43.311950 45.688950</coordinates>
+        <location>
+          <name>Grozny North Airport</name>
+          <code>URMG</code>
+          <tz-hint>Europe/Moscow</tz-hint>
+          <coordinates>43.388300 45.698600</coordinates>
         </location>
       </city>
       <city>
@@ -18538,6 +26157,17 @@
           <code>UMKK</code>
           <tz-hint>Europe/Kaliningrad</tz-hint>
           <coordinates>54.720000 20.500000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Russia -->
+        <name>Kaluga</name>
+        <coordinates>54.530630 36.270000</coordinates>
+        <location>
+          <name>Grabtsevo Airport</name>
+          <code>UUBC</code>
+          <tz-hint>Europe/Moscow</tz-hint>
+          <coordinates>54.550000 36.366670</coordinates>
         </location>
       </city>
       <city>
@@ -18618,6 +26248,28 @@
         </location>
       </city>
       <city>
+        <!-- A city in Russia -->
+        <name>Kursk</name>
+        <coordinates>51.726890 36.184570</coordinates>
+        <location>
+          <name>Kursk East Airport</name>
+          <code>UUOK</code>
+          <tz-hint>Europe/Moscow</tz-hint>
+          <coordinates>51.750600 36.295600</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Russia -->
+        <name>Lipetsk</name>
+        <coordinates>52.587600 39.551510</coordinates>
+        <location>
+          <name>Lipetsk Airport</name>
+          <code>UUOL</code>
+          <tz-hint>Europe/Moscow</tz-hint>
+          <coordinates>52.702800 39.537800</coordinates>
+        </location>
+      </city>
+      <city>
         <!-- A city in Russia.
              The local name in Russian is "Магадан".
           -->
@@ -18628,6 +26280,28 @@
           <code>UHMM</code>
           <tz-hint>Asia/Magadan</tz-hint>
           <coordinates>59.550000 150.783333</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Russia -->
+        <name>Magnitogorsk</name>
+        <coordinates>53.398080 59.006600</coordinates>
+        <location>
+          <name>Magnitogorsk International Airport</name>
+          <code>USCM</code>
+          <tz-hint>Asia/Yekaterinburg</tz-hint>
+          <coordinates>53.393100 58.755700</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Russia -->
+        <name>Makhachkala</name>
+        <coordinates>42.977820 47.500270</coordinates>
+        <location>
+          <name>Uytash Airport</name>
+          <code>URML</code>
+          <tz-hint>Europe/Moscow</tz-hint>
+          <coordinates>42.816800 47.652300</coordinates>
         </location>
       </city>
       <city>
@@ -18715,6 +26389,17 @@
         </location>
       </city>
       <city>
+        <!-- A city in Russia -->
+        <name>Nizhnekamsk</name>
+        <coordinates>55.637940 51.815020</coordinates>
+        <location>
+          <name>Begishevo Airport</name>
+          <code>UWKE</code>
+          <tz-hint>Europe/Moscow</tz-hint>
+          <coordinates>55.564700 52.092500</coordinates>
+        </location>
+      </city>
+      <city>
         <!-- A city in Russia.
              The local name in Russian is "Нижневартовск".
           -->
@@ -18725,6 +26410,17 @@
           <code>USNN</code>
           <tz-hint>Asia/Yekaterinburg</tz-hint>
           <coordinates>60.933333 76.483333</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Russia -->
+        <name>Norilsk</name>
+        <coordinates>69.353500 88.202700</coordinates>
+        <location>
+          <name>Norilsk-Alykel Airport</name>
+          <code>UOOO</code>
+          <tz-hint>Asia/Krasnoyarsk</tz-hint>
+          <coordinates>69.311100 87.332200</coordinates>
         </location>
       </city>
       <city>
@@ -18780,6 +26476,17 @@
         </location>
       </city>
       <city>
+        <!-- A city in Russia -->
+        <name>Orsk</name>
+        <coordinates>51.232060 58.488020</coordinates>
+        <location>
+          <name>Orsk Airport</name>
+          <code>UWOR</code>
+          <tz-hint>Asia/Yekaterinburg</tz-hint>
+          <coordinates>51.072500 58.595600</coordinates>
+        </location>
+      </city>
+      <city>
         <!-- A city in Russia.
              The local name in Russian is "Пенза".
           -->
@@ -18819,6 +26526,28 @@
         </location>
       </city>
       <city>
+        <!-- A city in Russia -->
+        <name>Petrozavodsk</name>
+        <coordinates>61.784910 34.346910</coordinates>
+        <location>
+          <name>Petrozavodsk Airport</name>
+          <code>ULPB</code>
+          <tz-hint>Europe/Moscow</tz-hint>
+          <coordinates>61.885200 34.154700</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Russia -->
+        <name>Pskov</name>
+        <coordinates>57.819220 28.331810</coordinates>
+        <location>
+          <name>Pskov Airport</name>
+          <code>ULOO</code>
+          <tz-hint>Europe/Moscow</tz-hint>
+          <coordinates>57.783900 28.395600</coordinates>
+        </location>
+      </city>
+      <city>
         <!-- A city in Russia.
              The local name in Russian is "Ростов-на-Дону".
           -->
@@ -18829,6 +26558,17 @@
           <code>URRP</code>
           <tz-hint>Europe/Moscow</tz-hint>
           <coordinates>47.493889 39.924722</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Russia -->
+        <name>Sabetta</name>
+        <coordinates>71.215000 72.038000</coordinates>
+        <location>
+          <name>Sabetta Airport</name>
+          <code>USDA</code>
+          <tz-hint>Asia/Yekaterinburg</tz-hint>
+          <coordinates>71.215000 72.038000</coordinates>
         </location>
       </city>
       <city>
@@ -18847,6 +26587,17 @@
         </location>
       </city>
       <city>
+        <!-- A city in Russia -->
+        <name>Salekhard</name>
+        <coordinates>66.533730 66.609550</coordinates>
+        <location>
+          <name>Salekhard Airport</name>
+          <code>USDD</code>
+          <tz-hint>Asia/Yekaterinburg</tz-hint>
+          <coordinates>66.590800 66.611000</coordinates>
+        </location>
+      </city>
+      <city>
         <!-- A city in Russia.
              The local name in Russian is "Самара".
           -->
@@ -18861,6 +26612,17 @@
       </city>
       <city>
         <!-- A city in Russia -->
+        <name>Saransk</name>
+        <coordinates>54.184850 45.171660</coordinates>
+        <location>
+          <name>Saransk Airport</name>
+          <code>UWPS</code>
+          <tz-hint>Europe/Moscow</tz-hint>
+          <coordinates>54.125130 45.212260</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Russia -->
         <name>Saratov</name>
         <coordinates>51.540556 46.008611</coordinates>
         <location>
@@ -18868,6 +26630,12 @@
           <code>UWSS</code>
           <tz-hint>Europe/Moscow</tz-hint>
           <coordinates>51.570000 46.070000</coordinates>
+        </location>
+        <location>
+          <name>Gagarin Airport</name>
+          <code>UWSG</code>
+          <tz-hint>Europe/Samara</tz-hint>
+          <coordinates>51.712830 46.171170</coordinates>
         </location>
       </city>
       <city>
@@ -18933,6 +26701,28 @@
       </city>
       <city>
         <!-- A city in Russia -->
+        <name>Tomsk</name>
+        <coordinates>56.500490 84.982160</coordinates>
+        <location>
+          <name>Bogashevo Airport</name>
+          <code>UNTT</code>
+          <tz-hint>Asia/Krasnoyarsk</tz-hint>
+          <coordinates>56.380300 85.208300</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Russia -->
+        <name>Tunoshna</name>
+        <coordinates>57.545890 40.125430</coordinates>
+        <location>
+          <name>Tunoshna Airport</name>
+          <code>UUDL</code>
+          <tz-hint>Europe/Moscow</tz-hint>
+          <coordinates>57.560700 40.157400</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Russia -->
         <name>Tyumen</name>
         <coordinates>57.15 65.533333</coordinates>
         <location>
@@ -18983,6 +26773,17 @@
           <code>UIUU</code>
           <tz-hint>Asia/Irkutsk</tz-hint>
           <coordinates>51.833333 107.600000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Russia -->
+        <name>Ulyanovsk</name>
+        <coordinates>54.328240 48.386570</coordinates>
+        <location>
+          <name>Ulyanovsk Baratayevka Airport</name>
+          <code>UWLL</code>
+          <tz-hint>Europe/Samara</tz-hint>
+          <coordinates>54.268300 48.226700</coordinates>
         </location>
       </city>
       <city>
@@ -19066,10 +26867,6 @@
     <country>
       <!-- SM - San Marino -->
       <name msgctxt="Country">San Marino</name>
-      <!-- Could not find information about the following stations,
-           which may be in San Marino:
-           LIBF LIMA 
-        -->
       <iso-code>SM</iso-code>
       <fips-code>SM</fips-code>
       <timezones>
@@ -19111,6 +26908,16 @@
       </city>
       <city>
         <!-- A city in Serbia -->
+        <name>Kraljevo</name>
+        <coordinates>43.725830 20.689440</coordinates>
+        <location>
+          <name>Ladevci Airport</name>
+          <code>LYKV</code>
+          <coordinates>43.818300 20.587200</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Serbia -->
         <name>Niš</name>
         <coordinates>43.324722 21.903333</coordinates>
         <location>
@@ -19137,6 +26944,11 @@
           <name>Beograd / Surcin</name>
           <code>LYBE</code>
           <coordinates>44.816667 20.283333</coordinates>
+        </location>
+        <location>
+          <name>Batajnica Air Base</name>
+          <code>LYBT</code>
+          <coordinates>44.935300 20.257500</coordinates>
         </location>
       </city>
     </country>
@@ -19253,16 +27065,22 @@
     <country>
       <!-- SI - Slovenia -->
       <name>Slovenia</name>
-      <!-- Could not find information about the following stations,
-           which may be in Slovenia:
-           LJCE 
-        -->
       <iso-code>SI</iso-code>
       <fips-code>SI</fips-code>
       <timezones>
         <timezone id="Europe/Ljubljana" />
       </timezones>
       <tz-hint>Europe/Ljubljana</tz-hint>
+      <city>
+        <!-- A city in Slovenia -->
+        <name>Cerklje</name>
+        <coordinates>46.250070 14.486200</coordinates>
+        <location>
+          <name>Cerklje Airport</name>
+          <code>LJCE</code>
+          <coordinates>45.900000 15.530200</coordinates>
+        </location>
+      </city>
       <city>
         <!-- The capital of Slovenia -->
         <name>Ljubljana</name>
@@ -19297,10 +27115,6 @@
     <country>
       <!-- ES - Spain -->
       <name>Spain</name>
-      <!-- Could not find information about the following stations,
-           which may be in Spain:
-           LEBR 
-        -->
       <iso-code>ES</iso-code>
       <fips-code>SP</fips-code>
       <timezones>
@@ -19344,6 +27158,17 @@
           <name>Logrono Airport</name>
           <code>LELO</code>
           <coordinates>42.450000 -2.333333</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Spain -->
+        <name>Alajero, La Gomera Island</name>
+        <coordinates>28.062050 -17.240730</coordinates>
+        <location>
+          <name>La Gomera Airport</name>
+          <code>GCGM</code>
+          <tz-hint>Atlantic/Canary</tz-hint>
+          <coordinates>28.029600 -17.214600</coordinates>
         </location>
       </city>
       <city>
@@ -19439,6 +27264,48 @@
       </city>
       <city>
         <!-- A city in Spain -->
+        <name>Burgos</name>
+        <coordinates>42.341060 -3.701840</coordinates>
+        <location>
+          <name>Burgos Airport</name>
+          <code>LEBG</code>
+          <coordinates>42.357600 -3.620760</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Spain -->
+        <name>Castellón de la Plana</name>
+        <coordinates>39.985670 -0.049350</coordinates>
+        <location>
+          <name>Castellón Airport</name>
+          <code>LECH</code>
+          <coordinates>40.214167 0.073667</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Spain -->
+        <name>Ceuta</name>
+        <coordinates>35.889190 -5.320420</coordinates>
+        <location>
+          <name>Ceuta</name>
+          <code>GECE</code>
+          <tz-hint>Africa/Ceuta</tz-hint>
+          <coordinates>35.889000 -5.347000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Spain -->
+        <name>Ciudad Real</name>
+        <coordinates>38.986260 -3.929070</coordinates>
+        <location>
+          <name>Ciudad Real</name>
+          <code>LEAO</code>
+          <tz-hint>Africa/Ceuta</tz-hint>
+          <coordinates>38.983000 -3.917000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Spain -->
         <name>Colmenar Viejo</name>
         <coordinates>40.666667 -3.766667</coordinates>
         <location>
@@ -19456,6 +27323,16 @@
           <code>GCLA</code>
           <tz-hint>Atlantic/Canary</tz-hint>
           <coordinates>28.616667 -17.750000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Spain -->
+        <name>Corvera</name>
+        <coordinates>37.803000 -1.125000</coordinates>
+        <location>
+          <name>Región de Murcia International Airport</name>
+          <code>LEMI</code>
+          <coordinates>37.803000 -1.125000</coordinates>
         </location>
       </city>
       <city>
@@ -19508,6 +27385,17 @@
           <code>GCLP</code>
           <tz-hint>Atlantic/Canary</tz-hint>
           <coordinates>27.933333 -15.383333</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Spain -->
+        <name>Gelves</name>
+        <coordinates>37.334810 -6.026010</coordinates>
+        <location>
+          <name>Sevilla Heliport</name>
+          <code>LEEC</code>
+          <tz-hint>Africa/Ceuta</tz-hint>
+          <coordinates>37.317000 -6.000000</coordinates>
         </location>
       </city>
       <city>
@@ -19573,6 +27461,16 @@
       </city>
       <city>
         <!-- A city in Spain -->
+        <name>La Seu d'Urgell Pyrenees and Andorra</name>
+        <coordinates>42.338600 1.409170</coordinates>
+        <location>
+          <name>Aerodrom dels Pirineus-Alt Urgell Airport</name>
+          <code>LESU</code>
+          <coordinates>42.338600 1.409170</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Spain -->
         <name msgctxt="City in Spain">León</name>
         <coordinates>42.600000 -5.566667</coordinates>
         <location>
@@ -19634,12 +27532,32 @@
       </city>
       <city>
         <!-- A city in Spain -->
+        <name>Marratxí</name>
+        <coordinates>39.621420 2.725300</coordinates>
+        <location>
+          <name>Son Bonet Airport</name>
+          <code>LESB</code>
+          <coordinates>39.598900 2.702780</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Spain -->
         <name>Melilla</name>
         <coordinates>35.316667 -2.950000</coordinates>
         <location>
           <name>Melilla</name>
           <code>GEML</code>
           <coordinates>35.283333 -2.950000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Spain -->
+        <name>Monflorite/Alcalá del Obispo</name>
+        <coordinates>42.076100 -0.316670</coordinates>
+        <location>
+          <name>Huesca/Pirineos Airport</name>
+          <code>LEHC</code>
+          <coordinates>42.076100 -0.316670</coordinates>
         </location>
       </city>
       <city>
@@ -19785,6 +27703,16 @@
       </city>
       <city>
         <!-- A city in Spain -->
+        <name>Teruel</name>
+        <coordinates>40.345600 -1.106460</coordinates>
+        <location>
+          <name>Teruel Airport</name>
+          <code>LETL</code>
+          <coordinates>40.412000 -1.217500</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Spain -->
         <name>Torrejón del Rey</name>
         <coordinates>40.650000 -3.333333</coordinates>
         <location>
@@ -19795,12 +27723,29 @@
       </city>
       <city>
         <!-- A city in Spain -->
+        <name>Tudela</name>
+        <coordinates>42.061660 -1.604520</coordinates>
+        <location>
+          <name>Bardenas Reales</name>
+          <code>LEBR</code>
+          <tz-hint>Africa/Ceuta</tz-hint>
+          <coordinates>42.200000 -1.450000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Spain -->
         <name msgctxt="City in Spain">Valencia</name>
         <coordinates>39.466667 -0.366667</coordinates>
         <location>
           <name>Valencia Airport</name>
           <code>LEVC</code>
           <coordinates>39.500000 -0.466667</coordinates>
+        </location>
+        <location>
+          <name>Valencia</name>
+          <code>LEBT</code>
+          <tz-hint>Africa/Ceuta</tz-hint>
+          <coordinates>39.583000 -0.450000</coordinates>
         </location>
       </city>
       <city>
@@ -19852,7 +27797,7 @@
       <name>Svalbard and Jan Mayen</name>
       <!-- Could not find information about the following stations,
            which may be in Svalbard and Jan Mayen:
-           ENDR ENEK ENGC ENHE ENSL 
+           ENEK ENGC ENSL
         -->
       <iso-code>SJ</iso-code>
       <fips-code>SV|JN</fips-code>
@@ -19876,7 +27821,7 @@
       <name>Sweden</name>
       <!-- Could not find information about the following stations,
            which may be in Sweden:
-           ESGL ESNZ ESUD ESUT 
+           ESGL ESUD
         -->
       <iso-code>SE</iso-code>
       <fips-code>SW</fips-code>
@@ -19884,6 +27829,16 @@
         <timezone id="Europe/Stockholm" />
       </timezones>
       <tz-hint>Europe/Stockholm</tz-hint>
+      <city>
+        <!-- A city in Sweden -->
+        <name>Arvidsjaur</name>
+        <coordinates>65.590330 19.166820</coordinates>
+        <location>
+          <name>Arvidsjaur Airport</name>
+          <code>ESNX</code>
+          <coordinates>65.590300 19.281900</coordinates>
+        </location>
+      </city>
       <city>
         <!-- A city in Sweden -->
         <name>Borlänge</name>
@@ -19921,12 +27876,32 @@
       </city>
       <city>
         <!-- A city in Sweden -->
+        <name>Hagshult</name>
+        <coordinates>57.292200 14.137200</coordinates>
+        <location>
+          <name>Hagshult Airport</name>
+          <code>ESMV</code>
+          <coordinates>57.292200 14.137200</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Sweden -->
         <name>Halmstad</name>
         <coordinates>56.671389 12.855556</coordinates>
         <location>
           <name>Halmstad Swedish Air Force Base</name>
           <code>ESMT</code>
           <coordinates>56.683333 12.833333</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Sweden -->
+        <name>Hemavan</name>
+        <coordinates>65.806100 15.082800</coordinates>
+        <location>
+          <name>Hemavan Airport</name>
+          <code>ESUT</code>
+          <coordinates>65.806100 15.082800</coordinates>
         </location>
       </city>
       <city>
@@ -19947,6 +27922,16 @@
           <name>Kalmar</name>
           <code>ESMQ</code>
           <coordinates>56.733333 16.300000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Sweden -->
+        <name>Karlsborg</name>
+        <coordinates>58.537240 14.504700</coordinates>
+        <location>
+          <name>Karlsborg Air Base</name>
+          <code>ESIA</code>
+          <coordinates>58.513800 14.507100</coordinates>
         </location>
       </city>
       <city>
@@ -19998,6 +27983,11 @@
           <code>ESSL</code>
           <coordinates>58.400000 15.683333</coordinates>
         </location>
+        <location>
+          <name>Malmen Air Base</name>
+          <code>ESCF</code>
+          <coordinates>58.402300 15.525700</coordinates>
+        </location>
       </city>
       <city>
         <!-- A city in Sweden -->
@@ -20041,6 +28031,16 @@
       </city>
       <city>
         <!-- A city in Sweden -->
+        <name>Mora</name>
+        <coordinates>61.007040 14.543160</coordinates>
+        <location>
+          <name>Mora Airport</name>
+          <code>ESKM</code>
+          <coordinates>60.957900 14.511400</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Sweden -->
         <name>Norrköping</name>
         <coordinates>58.600000 16.183333</coordinates>
         <location>
@@ -20061,12 +28061,52 @@
       </city>
       <city>
         <!-- A city in Sweden -->
+        <name>Pajala</name>
+        <coordinates>67.212840 23.366070</coordinates>
+        <location>
+          <name>Pajala Airport</name>
+          <code>ESUP</code>
+          <coordinates>67.245600 23.068900</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Sweden -->
         <name>Ronneby</name>
         <coordinates>56.200000 15.300000</coordinates>
         <location>
           <name>Ronneby</name>
           <code>ESDF</code>
           <coordinates>56.266667 15.283333</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Sweden -->
+        <name>Råda</name>
+        <coordinates>60.020100 13.578900</coordinates>
+        <location>
+          <name>Hagfors Airport</name>
+          <code>ESOH</code>
+          <coordinates>60.020100 13.578900</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Sweden -->
+        <name>Rörbäcksnäs</name>
+        <coordinates>61.164667 12.833833</coordinates>
+        <location>
+          <name>Sälen/Scandinavian Mountains Airport</name>
+          <code>ESKS</code>
+          <coordinates>61.164667 12.833833</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Sweden -->
+        <name>Satenas</name>
+        <coordinates>58.426400 12.714400</coordinates>
+        <location>
+          <name>Satenas Air Base</name>
+          <code>ESIB</code>
+          <coordinates>58.426400 12.714400</coordinates>
         </location>
       </city>
       <city>
@@ -20116,6 +28156,16 @@
       </city>
       <city>
         <!-- A city in Sweden -->
+        <name>Sveg</name>
+        <coordinates>62.034070 14.365770</coordinates>
+        <location>
+          <name>Sveg Airport</name>
+          <code>ESND</code>
+          <coordinates>62.047800 14.422900</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Sweden -->
         <name>Söderhamn</name>
         <coordinates>61.300000 17.050000</coordinates>
         <location>
@@ -20126,12 +28176,62 @@
       </city>
       <city>
         <!-- A city in Sweden -->
+        <name>Torsby</name>
+        <coordinates>60.135270 13.008200</coordinates>
+        <location>
+          <name>Torsby Airport</name>
+          <code>ESST</code>
+          <coordinates>60.157600 12.991300</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Sweden -->
+        <name>Trollhättan</name>
+        <coordinates>58.283650 12.288640</coordinates>
+        <location>
+          <name>Trollhattan-Vanersborg Airport</name>
+          <code>ESGT</code>
+          <coordinates>58.318100 12.345000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Sweden -->
         <name>Umeå</name>
         <coordinates>63.833333 20.250000</coordinates>
         <location>
           <name>Umeå Airport</name>
           <code>ESNU</code>
           <coordinates>63.800000 20.283333</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Sweden -->
+        <name>Uppsala</name>
+        <coordinates>59.858820 17.638890</coordinates>
+        <location>
+          <name>Uppsala Airport</name>
+          <code>ESCM</code>
+          <coordinates>59.897300 17.588600</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Sweden -->
+        <name>Vidsel</name>
+        <coordinates>65.835330 20.519080</coordinates>
+        <location>
+          <name>Vidsel Air Base</name>
+          <code>ESPE</code>
+          <coordinates>65.875300 20.149900</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Sweden -->
+        <name>Vilhelmina</name>
+        <coordinates>64.624170 16.655960</coordinates>
+        <location>
+          <name>Vilhelmina Airport</name>
+          <code>ESNV</code>
+          <coordinates>64.579100 16.833600</coordinates>
         </location>
       </city>
       <city>
@@ -20194,6 +28294,16 @@
           <coordinates>63.400000 18.966667</coordinates>
         </location>
       </city>
+      <city>
+        <!-- A city in Sweden -->
+        <name>Östersund</name>
+        <coordinates>63.179200 14.635660</coordinates>
+        <location>
+          <name>Ostersund Airport</name>
+          <code>ESNZ</code>
+          <coordinates>63.194400 14.500300</coordinates>
+        </location>
+      </city>
     </country>
     <country>
       <!-- CH - Switzerland -->
@@ -20216,12 +28326,42 @@
       </city>
       <city>
         <!-- A city in Switzerland -->
+        <name>Alpnach</name>
+        <coordinates>46.942270 8.271800</coordinates>
+        <location>
+          <name>Alpnach Air Base</name>
+          <code>LSMA</code>
+          <coordinates>46.943900 8.284170</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Switzerland -->
         <name>Basel</name>
         <coordinates>47.583333 7.516667</coordinates>
         <location>
           <name>Bale-Mulhouse</name>
           <code>LFSB</code>
           <coordinates>47.600000 7.516667</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Switzerland -->
+        <name>Buochs</name>
+        <coordinates>46.973980 8.422790</coordinates>
+        <location>
+          <name>Buochs Airport</name>
+          <code>LSZC</code>
+          <coordinates>46.974440 8.396940</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Switzerland -->
+        <name>Emmen</name>
+        <coordinates>47.078190 8.273310</coordinates>
+        <location>
+          <name>Emmen Airport</name>
+          <code>LSME</code>
+          <coordinates>47.092400 8.305120</coordinates>
         </location>
       </city>
       <city>
@@ -20249,6 +28389,16 @@
       </city>
       <city>
         <!-- A city in Switzerland -->
+        <name>Locarno</name>
+        <coordinates>46.170860 8.799530</coordinates>
+        <location>
+          <name>Locarno Airport</name>
+          <code>LSZL</code>
+          <coordinates>46.160800 8.878610</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Switzerland -->
         <name>Lugano</name>
         <coordinates>46.000000 8.966667</coordinates>
         <location>
@@ -20259,12 +28409,32 @@
       </city>
       <city>
         <!-- A city in Switzerland -->
+        <name>Meiringen</name>
+        <coordinates>46.727090 8.187200</coordinates>
+        <location>
+          <name>Meiringen Airport</name>
+          <code>LSMM</code>
+          <coordinates>46.743300 8.110000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Switzerland -->
         <name>Neuchâtel</name>
         <coordinates>47.000000 6.966667</coordinates>
         <location>
           <name>Les Eplatures</name>
           <code>LSGC</code>
           <coordinates>47.084167 6.793611</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Switzerland -->
+        <name>Payerne</name>
+        <coordinates>46.821920 6.938170</coordinates>
+        <location>
+          <name>Payerne Airport</name>
+          <code>LSMP</code>
+          <coordinates>46.843200 6.915060</coordinates>
         </location>
       </city>
       <city>
@@ -20299,6 +28469,16 @@
       </city>
       <city>
         <!-- A city in Switzerland -->
+        <name>Zurich</name>
+        <coordinates>47.366670 8.550000</coordinates>
+        <location>
+          <name>Dubendorf Airport</name>
+          <code>LSMD</code>
+          <coordinates>47.398600 8.648230</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Switzerland -->
         <name>Zürich</name>
         <coordinates>47.366667 8.550000</coordinates>
         <location>
@@ -20311,10 +28491,6 @@
     <country>
       <!-- TR - Turkey -->
       <name>Turkey</name>
-      <!-- Could not find weather stations for the following major
-           cities:
-           Batman, Kiziltepe
-        -->
       <iso-code>TR</iso-code>
       <fips-code>TU</fips-code>
       <timezones>
@@ -20334,6 +28510,36 @@
           <name>Adana-Incirlik Airport</name>
           <code>LTAG</code>
           <coordinates>37.000000 35.416667</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Turkey -->
+        <name>Adıyaman</name>
+        <coordinates>37.764410 38.276290</coordinates>
+        <location>
+          <name>Adiyaman Airport</name>
+          <code>LTCP</code>
+          <coordinates>37.731400 38.468900</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Turkey -->
+        <name>Afyonkarahisar</name>
+        <coordinates>38.756670 30.543330</coordinates>
+        <location>
+          <name>Afyon Airport</name>
+          <code>LTAH</code>
+          <coordinates>38.726400 30.601100</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Turkey -->
+        <name>Akhisar</name>
+        <coordinates>38.918520 27.840060</coordinates>
+        <location>
+          <name>Akhisar Airport</name>
+          <code>LTBT</code>
+          <coordinates>38.808900 27.833900</coordinates>
         </location>
       </city>
       <city>
@@ -20358,12 +28564,42 @@
       </city>
       <city>
         <!-- A city in Turkey -->
+        <name>Antakya</name>
+        <coordinates>36.206550 36.157220</coordinates>
+        <location>
+          <name>Hatay Airport</name>
+          <code>LTDA</code>
+          <coordinates>36.362780 36.282220</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Turkey -->
         <name>Antalya</name>
         <coordinates>36.912500 30.689722</coordinates>
         <location>
           <name>Antalya</name>
           <code>LTAI</code>
           <coordinates>36.700000 30.733333</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Turkey -->
+        <name>Aydın</name>
+        <coordinates>37.845010 27.839630</coordinates>
+        <location>
+          <name>Cildir Airport</name>
+          <code>LTBD</code>
+          <coordinates>37.815000 27.895300</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Turkey -->
+        <name>Ağrı</name>
+        <coordinates>39.714670 43.040150</coordinates>
+        <location>
+          <name>Agri Airport</name>
+          <code>LTCO</code>
+          <coordinates>39.654540 43.025980</coordinates>
         </location>
       </city>
       <city>
@@ -20384,6 +28620,26 @@
           <name>Bandirma</name>
           <code>LTBG</code>
           <coordinates>40.316667 27.966667</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Turkey -->
+        <name>Batman</name>
+        <coordinates>37.887380 41.132210</coordinates>
+        <location>
+          <name>Batman Airport</name>
+          <code>LTCJ</code>
+          <coordinates>37.929000 41.116600</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Turkey -->
+        <name>Bingöl</name>
+        <coordinates>38.884720 40.493890</coordinates>
+        <location>
+          <name>Bingöl Airport</name>
+          <code>LTCU</code>
+          <coordinates>38.861111 40.592500</coordinates>
         </location>
       </city>
       <city>
@@ -20438,12 +28694,52 @@
       </city>
       <city>
         <!-- A city in Turkey -->
+        <name>Denizli</name>
+        <coordinates>37.774170 29.087500</coordinates>
+        <location>
+          <name>Cardak Airport</name>
+          <code>LTAY</code>
+          <coordinates>37.785600 29.701300</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Turkey -->
         <name>Diyarbakir</name>
         <coordinates>37.915833 40.218889</coordinates>
         <location>
           <name>Diyarbakir</name>
           <code>LTCC</code>
           <coordinates>37.883333 40.183333</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Turkey -->
+        <name>Edremit</name>
+        <coordinates>39.596110 27.024440</coordinates>
+        <location>
+          <name>Balikesir Korfez Airport</name>
+          <code>LTFD</code>
+          <coordinates>39.554600 27.013800</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Turkey -->
+        <name>Elazığ</name>
+        <coordinates>38.674310 39.223210</coordinates>
+        <location>
+          <name>Elazig Airport</name>
+          <code>LTCA</code>
+          <coordinates>38.606900 39.291400</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Turkey -->
+        <name>Erzincan</name>
+        <coordinates>39.739190 39.490150</coordinates>
+        <location>
+          <name>Erzincan Airport</name>
+          <code>LTCD</code>
+          <coordinates>39.710200 39.527000</coordinates>
         </location>
       </city>
       <city>
@@ -20468,12 +28764,52 @@
       </city>
       <city>
         <!-- A city in Turkey -->
+        <name>Eskişehir</name>
+        <coordinates>39.776670 30.520560</coordinates>
+        <location>
+          <name>Anadolu University Airport</name>
+          <code>LTBY</code>
+          <coordinates>39.809900 30.519400</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Turkey -->
         <name>Gaziantep</name>
         <coordinates>37.059444 37.382500</coordinates>
         <location>
           <name>Gaziantep</name>
           <code>LTAJ</code>
           <coordinates>37.083333 37.366667</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Turkey -->
+        <name>Gazipaşa</name>
+        <coordinates>36.269420 32.317920</coordinates>
+        <location>
+          <name>Gazipasa Airport</name>
+          <code>LTFG</code>
+          <coordinates>36.299220 32.300600</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Turkey -->
+        <name>Gökçeada</name>
+        <coordinates>40.201070 25.909020</coordinates>
+        <location>
+          <name>Imroz Airport</name>
+          <code>LTFK</code>
+          <coordinates>40.204500 25.883300</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Turkey -->
+        <name>Hakkari</name>
+        <coordinates>37.574440 43.740830</coordinates>
+        <location>
+          <name>Yüksekova Selahaddin Eyyubi Airport</name>
+          <code>LTCW</code>
+          <coordinates>37.549670 44.237500</coordinates>
         </location>
       </city>
       <city>
@@ -20490,6 +28826,11 @@
           <code>LTFJ</code>
           <coordinates>40.898611 29.309167</coordinates>
         </location>
+        <location>
+          <name>Istanbul Airport</name>
+          <code>LTFM</code>
+          <coordinates>41.275330 28.752000</coordinates>
+        </location>
       </city>
       <city>
         <!-- A city in Turkey -->
@@ -20505,6 +28846,31 @@
           <code>LTBJ</code>
           <coordinates>38.266667 27.150000</coordinates>
         </location>
+        <location>
+          <name>Kaklic Airport</name>
+          <code>LTFA</code>
+          <coordinates>38.517600 26.977400</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Turkey -->
+        <name>Iğdır</name>
+        <coordinates>39.923710 44.045000</coordinates>
+        <location>
+          <name>Igdir Airport</name>
+          <code>LTCT</code>
+          <coordinates>39.976630 43.876650</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Turkey -->
+        <name>Kahramanmaraş</name>
+        <coordinates>37.584700 36.926410</coordinates>
+        <location>
+          <name>Kahramanmaras Airport</name>
+          <code>LTCN</code>
+          <coordinates>37.538830 36.953520</coordinates>
+        </location>
       </city>
       <city>
         <!-- A city in Turkey -->
@@ -20514,6 +28880,16 @@
           <name>Kars</name>
           <code>LTCF</code>
           <coordinates>40.600000 43.083333</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Turkey -->
+        <name>Kastamonu</name>
+        <coordinates>41.378050 33.775280</coordinates>
+        <location>
+          <name>Kastamonu Airport</name>
+          <code>LTAL</code>
+          <coordinates>41.314200 33.795800</coordinates>
         </location>
       </city>
       <city>
@@ -20558,12 +28934,32 @@
       </city>
       <city>
         <!-- A city in Turkey -->
+        <name>Mardin</name>
+        <coordinates>37.313090 40.743570</coordinates>
+        <location>
+          <name>Mardin Airport</name>
+          <code>LTCR</code>
+          <coordinates>37.223300 40.631700</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Turkey -->
         <name>Merzifon</name>
         <coordinates>40.873333 35.463056</coordinates>
         <location>
           <name>Merzifon</name>
           <code>LTAP</code>
           <coordinates>40.850000 35.583333</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Turkey -->
+        <name>Muş</name>
+        <coordinates>38.731630 41.484820</coordinates>
+        <location>
+          <name>Mus Airport</name>
+          <code>LTCK</code>
+          <coordinates>38.747800 41.661200</coordinates>
         </location>
       </city>
       <city>
@@ -20578,12 +28974,82 @@
       </city>
       <city>
         <!-- A city in Turkey -->
+        <name>Ordu</name>
+        <coordinates>40.977820 37.890470</coordinates>
+        <location>
+          <name>Ordu–Giresun Airport</name>
+          <code>LTCB</code>
+          <coordinates>40.966670 38.080000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Turkey -->
+        <name>Rize</name>
+        <coordinates>41.020830 40.521940</coordinates>
+        <location>
+          <name>Rize–Artvin Airport</name>
+          <code>LTFO</code>
+          <coordinates>41.169167 40.828889</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Turkey -->
         <name>Samsun</name>
         <coordinates>41.286667 36.330000</coordinates>
         <location>
           <name>Samsun-Carsamba Airport</name>
           <code>LTFH</code>
           <coordinates>41.254167 36.567500</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Turkey -->
+        <name>Selçuk</name>
+        <coordinates>37.951370 27.368490</coordinates>
+        <location>
+          <name>Selcuk Efes Airport</name>
+          <code>LTFB</code>
+          <coordinates>37.950700 27.329000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Turkey -->
+        <name>Sinop</name>
+        <coordinates>42.026830 35.162530</coordinates>
+        <location>
+          <name>Sinop Airport</name>
+          <code>LTCM</code>
+          <coordinates>42.015800 35.066400</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Turkey -->
+        <name>Sivas</name>
+        <coordinates>39.748330 37.016110</coordinates>
+        <location>
+          <name>Sivas Airport</name>
+          <code>LTAR</code>
+          <coordinates>39.813800 36.903500</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Turkey -->
+        <name>Sivrihisar</name>
+        <coordinates>39.450370 31.534090</coordinates>
+        <location>
+          <name>Sivrihisar Airport</name>
+          <code>LTAV</code>
+          <coordinates>39.451500 31.365300</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Turkey -->
+        <name>Tarsus</name>
+        <coordinates>36.917660 34.892770</coordinates>
+        <location>
+          <name>Çukurova International Airport</name>
+          <code>LTDB</code>
+          <coordinates>36.892916 35.071971</coordinates>
         </location>
       </city>
       <city>
@@ -20598,6 +29064,16 @@
       </city>
       <city>
         <!-- A city in Turkey -->
+        <name>Tokat</name>
+        <coordinates>40.313890 36.554440</coordinates>
+        <location>
+          <name>Tokat Airport</name>
+          <code>LTAW</code>
+          <coordinates>40.307430 36.367410</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Turkey -->
         <name>Trabzon</name>
         <coordinates>41.005000 39.726944</coordinates>
         <location>
@@ -20608,12 +29084,63 @@
       </city>
       <city>
         <!-- A city in Turkey -->
+        <name>Uşak</name>
+        <coordinates>38.673510 29.405800</coordinates>
+        <location>
+          <name>Usak Airport</name>
+          <code>LTBO</code>
+          <coordinates>38.681500 29.471700</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Turkey -->
         <name>Van</name>
         <coordinates>38.494167 43.380000</coordinates>
         <location>
           <name>Van</name>
           <code>LTCI</code>
           <coordinates>38.450000 43.316667</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Turkey -->
+        <name>Zonguldak</name>
+        <coordinates>41.451390 31.793050</coordinates>
+        <location>
+          <name>Zonguldak Airport</name>
+          <code>LTAS</code>
+          <coordinates>41.506400 32.088600</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Turkey -->
+        <name>Çanakkale</name>
+        <coordinates>40.155520 26.412710</coordinates>
+        <location>
+          <name>Canakkale Airport</name>
+          <code>LTBH</code>
+          <coordinates>40.137700 26.426800</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Turkey -->
+        <name>Şanlıurfa</name>
+        <coordinates>37.167080 38.793920</coordinates>
+        <location>
+          <name>Sanliurfa GAP Airport</name>
+          <code>LTCS</code>
+          <coordinates>37.445660 38.895590</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Turkey -->
+        <name>Şırnak</name>
+        <coordinates>37.513930 42.454320</coordinates>
+        <location>
+          <name>Şırnak Şerafettin Elçi Airport</name>
+          <code>LTCV</code>
+          <tz-hint>Europe/Istanbul</tz-hint>
+          <coordinates>37.364700 42.058200</coordinates>
         </location>
       </city>
     </country>
@@ -21115,6 +29642,46 @@
         </city>
       </state>
       <city>
+        <!-- A city in United Kingdom -->
+        <name>Alness</name>
+        <coordinates>57.695960 -4.255100</coordinates>
+        <location>
+          <name>Tain Range (SAWS)</name>
+          <code>EGQA</code>
+          <coordinates>57.817000 -3.967000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in United Kingdom -->
+        <name>Alnwick</name>
+        <coordinates>55.413180 -1.705630</coordinates>
+        <location>
+          <name>Boulmer</name>
+          <code>EGQM</code>
+          <coordinates>55.424000 -1.603000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in United Kingdom -->
+        <name>Caernarfon</name>
+        <coordinates>53.141260 -4.270160</coordinates>
+        <location>
+          <name>Caernarfon Airport</name>
+          <code>EGCK</code>
+          <coordinates>53.104200 -4.340280</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in United Kingdom -->
+        <name>Cosford</name>
+        <coordinates>52.640000 -2.305580</coordinates>
+        <location>
+          <name>DCAE Cosford Airport</name>
+          <code>EGWC</code>
+          <coordinates>52.640000 -2.305580</coordinates>
+        </location>
+      </city>
+      <city>
         <!-- A city in the United Kingdom -->
         <name>Fairford</name>
         <coordinates>51.700000 -1.783333</coordinates>
@@ -21122,6 +29689,106 @@
           <name>Fairford Royal Air Force Base</name>
           <code>EGVA</code>
           <coordinates>51.683333 -1.783333</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in United Kingdom -->
+        <name>Grantham</name>
+        <coordinates>52.911490 -0.641840</coordinates>
+        <location>
+          <name>RAF Barkston Heath</name>
+          <code>EGYE</code>
+          <coordinates>52.962200 -0.561630</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in United Kingdom -->
+        <name>Holbeach</name>
+        <coordinates>52.804010 0.014420</coordinates>
+        <location>
+          <name>Holbeach (AUT)</name>
+          <code>EGYH</code>
+          <coordinates>52.867000 0.150000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in United Kingdom -->
+        <name>Humberston</name>
+        <coordinates>53.530360 -0.024650</coordinates>
+        <location>
+          <name>Donna Nook RAF</name>
+          <code>EGXS</code>
+          <coordinates>53.475000 0.152000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in United Kingdom -->
+        <name>Kidlington, Oxfordshire</name>
+        <coordinates>51.821660 -1.288600</coordinates>
+        <location>
+          <name>Oxford (Kidlington) Airport</name>
+          <code>EGTK</code>
+          <coordinates>51.836900 -1.320000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in United Kingdom -->
+        <name>Land's End, Cornwall</name>
+        <coordinates>50.102800 -5.670560</coordinates>
+        <location>
+          <name>Land's End Airport</name>
+          <code>EGHC</code>
+          <coordinates>50.102800 -5.670560</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in United Kingdom -->
+        <name>Leconfield</name>
+        <coordinates>53.877300 -0.457290</coordinates>
+        <location>
+          <name>RAF Leconfield</name>
+          <code>EGXV</code>
+          <coordinates>53.875800 -0.435000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in United Kingdom -->
+        <name>Newquay</name>
+        <coordinates>50.415570 -5.073190</coordinates>
+        <location>
+          <name>Newquay Cornwall Airport</name>
+          <code>EGHQ</code>
+          <coordinates>50.440600 -4.995410</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in United Kingdom -->
+        <name>North Connel</name>
+        <coordinates>56.463500 -5.399670</coordinates>
+        <location>
+          <name>Oban Airport</name>
+          <code>EGEO</code>
+          <coordinates>56.463500 -5.399670</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in United Kingdom -->
+        <name>Southport, Sefton</name>
+        <coordinates>53.645810 -3.010080</coordinates>
+        <location>
+          <name>RAF Woodvale</name>
+          <code>EGOW</code>
+          <coordinates>53.581600 -3.055520</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in United Kingdom -->
+        <name>Warton</name>
+        <coordinates>53.749880 -2.893350</coordinates>
+        <location>
+          <name>Warton Airport</name>
+          <code>EGNO</code>
+          <coordinates>53.745100 -2.883060</coordinates>
         </location>
       </city>
       <state>
@@ -21912,7 +30579,7 @@
       <name>Iran</name>
       <!-- Could not find information about the following stations,
            which may be in Iran:
-           OIBP OICJ OIGK OIHM OIIE OIKO OIMD OINB OINK OINZ OITU 
+           OICJ OIGK OIHM OIKO OIMD OINB OINK OITU
         -->
       <iso-code>IR</iso-code>
       <fips-code>IR</fips-code>
@@ -21982,6 +30649,16 @@
         </location>
       </city>
       <city>
+        <!-- A city in Iran -->
+        <name>Araak</name>
+        <coordinates>34.138100 49.847300</coordinates>
+        <location>
+          <name>Arak Airport</name>
+          <code>OIHR</code>
+          <coordinates>34.138100 49.847300</coordinates>
+        </location>
+      </city>
+      <city>
         <!-- A city in Iran.
              The name is also written "اردبيل".
           -->
@@ -21991,6 +30668,16 @@
           <name>Ardabil</name>
           <code>OITL</code>
           <coordinates>38.326389 48.424444</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Iran -->
+        <name>Bam</name>
+        <coordinates>29.106000 58.357000</coordinates>
+        <location>
+          <name>Bam Airport</name>
+          <code>OIKM</code>
+          <coordinates>29.084200 58.450000</coordinates>
         </location>
       </city>
       <city>
@@ -22043,12 +30730,32 @@
       </city>
       <city>
         <!-- A city in Iran -->
+        <name>Bastak</name>
+        <coordinates>27.199080 54.366760</coordinates>
+        <location>
+          <name>Bastak Airport</name>
+          <code>OIBH</code>
+          <coordinates>27.212700 54.318600</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Iran -->
         <name>Birjand</name>
         <coordinates>32.873889 59.214444</coordinates>
         <location>
           <name>Birjand</name>
           <code>OIMB</code>
           <coordinates>32.866667 59.200000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Iran -->
+        <name>Bojnord</name>
+        <coordinates>37.474730 57.329030</coordinates>
+        <location>
+          <name>Bojnord Airport</name>
+          <code>OIMN</code>
+          <coordinates>37.493000 57.308200</coordinates>
         </location>
       </city>
       <city>
@@ -22168,6 +30875,26 @@
         </location>
       </city>
       <city>
+        <!-- A city in Iran -->
+        <name>Jam</name>
+        <coordinates>27.829770 52.325180</coordinates>
+        <location>
+          <name>Jam Airport</name>
+          <code>OIBJ</code>
+          <coordinates>27.820500 52.352200</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Iran -->
+        <name>Kalaleh</name>
+        <coordinates>37.378990 55.493000</coordinates>
+        <location>
+          <name>Kalaleh Airport</name>
+          <code>OINE</code>
+          <coordinates>37.383300 55.452000</coordinates>
+        </location>
+      </city>
+      <city>
         <!-- A city in Iran.
              The name is also written "كرج".
           -->
@@ -22210,6 +30937,26 @@
         </location>
       </city>
       <city>
+        <!-- A city in Iran -->
+        <name>Khark</name>
+        <coordinates>29.261390 50.330560</coordinates>
+        <location>
+          <name>Khark Island Airport</name>
+          <code>OIBQ</code>
+          <coordinates>29.260300 50.323900</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Iran -->
+        <name>Khiyaroo</name>
+        <coordinates>27.379600 52.737700</coordinates>
+        <location>
+          <name>Persian Gulf International Airport</name>
+          <code>OIBP</code>
+          <coordinates>27.379600 52.737700</coordinates>
+        </location>
+      </city>
+      <city>
         <!-- A city in Iran.
              The name is also written "خرم آباد".
           -->
@@ -22219,6 +30966,16 @@
           <name>Khorramabad</name>
           <code>OICK</code>
           <coordinates>33.436389 48.285833</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Iran -->
+        <name>Khoy</name>
+        <coordinates>38.550300 44.952100</coordinates>
+        <location>
+          <name>Khoy Airport</name>
+          <code>OITK</code>
+          <coordinates>38.427500 44.973600</coordinates>
         </location>
       </city>
       <city>
@@ -22235,12 +30992,42 @@
       </city>
       <city>
         <!-- A city in Iran -->
+        <name>Lamerd</name>
+        <coordinates>27.334000 53.179000</coordinates>
+        <location>
+          <name>Lamerd Airport</name>
+          <code>OISR</code>
+          <coordinates>27.372700 53.188800</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Iran -->
         <name>Lar</name>
         <coordinates>27.684167 54.343611</coordinates>
         <location>
           <name>Lar</name>
           <code>OISL</code>
           <coordinates>27.673889 54.381389</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Iran -->
+        <name>Lavan Island</name>
+        <coordinates>26.810300 53.356300</coordinates>
+        <location>
+          <name>Lavan Island Airport</name>
+          <code>OIBV</code>
+          <coordinates>26.810300 53.356300</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Iran -->
+        <name>Maragheh</name>
+        <coordinates>37.392060 46.239090</coordinates>
+        <location>
+          <name>Sahand Airport</name>
+          <code>OITM</code>
+          <coordinates>37.348000 46.127900</coordinates>
         </location>
       </city>
       <city>
@@ -22292,6 +31079,16 @@
         </location>
       </city>
       <city>
+        <!-- A city in Iran -->
+        <name>Parsabad</name>
+        <coordinates>39.648200 47.917400</coordinates>
+        <location>
+          <name>Parsabade Moghan Airport</name>
+          <code>OITP</code>
+          <coordinates>39.603600 47.881500</coordinates>
+        </location>
+      </city>
+      <city>
         <!-- A city in Iran.
              The name is also written "قزوین".
           -->
@@ -22301,6 +31098,16 @@
           <name>Ghazvin</name>
           <code>OIIK</code>
           <coordinates>36.250000 50.000000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Iran -->
+        <name>Rafsanjan</name>
+        <coordinates>30.406700 55.993900</coordinates>
+        <location>
+          <name>Rafsanjan Airport</name>
+          <code>OIKR</code>
+          <coordinates>30.297700 56.051100</coordinates>
         </location>
       </city>
       <city>
@@ -22356,6 +31163,16 @@
         </location>
       </city>
       <city>
+        <!-- A city in Iran -->
+        <name>Sari</name>
+        <coordinates>36.563320 53.060090</coordinates>
+        <location>
+          <name>Dasht-e Naz Airport</name>
+          <code>OINZ</code>
+          <coordinates>36.635800 53.193600</coordinates>
+        </location>
+      </city>
+      <city>
         <!-- A city in Iran.
              The name is also written "سمنان".
           -->
@@ -22389,6 +31206,16 @@
           <name>Shahr-e Kord</name>
           <code>OIFS</code>
           <coordinates>32.333333 50.850000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Iran -->
+        <name>Shahrud</name>
+        <coordinates>36.418190 54.976280</coordinates>
+        <location>
+          <name>Shahroud Airport</name>
+          <code>OIMJ</code>
+          <coordinates>36.425300 55.104200</coordinates>
         </location>
       </city>
       <city>
@@ -22436,6 +31263,11 @@
           <code>OIII</code>
           <coordinates>35.683333 51.350000</coordinates>
         </location>
+        <location>
+          <name>Imam Khomeini International Airport</name>
+          <code>OIIE</code>
+          <coordinates>35.416100 51.152200</coordinates>
+        </location>
       </city>
       <city>
         <!-- A city in Iran.
@@ -22473,20 +31305,76 @@
           <coordinates>29.466667 60.883333</coordinates>
         </location>
       </city>
+      <city>
+        <!-- A city in Iran -->
+        <name>Zanjan</name>
+        <coordinates>36.676420 48.496280</coordinates>
+        <location>
+          <name>Zanjan Airport</name>
+          <code>OITZ</code>
+          <coordinates>36.773700 48.359400</coordinates>
+        </location>
+      </city>
     </country>
     <country>
       <!-- IQ - Iraq -->
       <name>Iraq</name>
-      <!-- Could not find weather stations for the following major
-           cities:
-           Baghdad
-        -->
       <iso-code>IQ</iso-code>
       <fips-code>IZ</fips-code>
       <timezones>
         <timezone id="Asia/Baghdad" />
       </timezones>
       <tz-hint>Asia/Baghdad</tz-hint>
+      <city>
+        <!-- A city in Iraq -->
+        <name>Arbil</name>
+        <coordinates>36.191170 44.009430</coordinates>
+        <location>
+          <name>Erbil International Airport</name>
+          <code>ORER</code>
+          <coordinates>36.237600 43.963200</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Iraq -->
+        <name>Baghdad</name>
+        <coordinates>33.340580 44.400880</coordinates>
+        <location>
+          <name>Baghdad International Airport</name>
+          <code>ORBI</code>
+          <coordinates>33.262500 44.234600</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Iraq -->
+        <name>Basra</name>
+        <coordinates>30.508520 47.780400</coordinates>
+        <location>
+          <name>Basrah International Airport</name>
+          <code>ORMM</code>
+          <coordinates>30.549100 47.662100</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Iraq -->
+        <name>Najaf</name>
+        <coordinates>32.025940 44.346250</coordinates>
+        <location>
+          <name>Al Najaf International Airport</name>
+          <code>ORNI</code>
+          <coordinates>31.989720 44.404170</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Iraq -->
+        <name>Sulaymaniyah</name>
+        <coordinates>35.564960 45.432900</coordinates>
+        <location>
+          <name>Sulaymaniyah International Airport</name>
+          <code>ORSU</code>
+          <coordinates>35.561750 45.316740</coordinates>
+        </location>
+      </city>
     </country>
     <country>
       <!-- IL - Israel -->
@@ -22497,6 +31385,16 @@
         <timezone id="Asia/Jerusalem" />
       </timezones>
       <tz-hint>Asia/Jerusalem</tz-hint>
+      <city>
+        <!-- A city in Israel -->
+        <name>Eilat</name>
+        <coordinates>29.727170 35.014170</coordinates>
+        <location>
+          <name>Ilan and Asaf Ramon Airport</name>
+          <code>LLER</code>
+          <coordinates>29.727170 35.014170</coordinates>
+        </location>
+      </city>
       <city>
         <!-- A city in Israel -->
         <name>Elat</name>
@@ -22611,6 +31509,17 @@
       </timezones>
       <tz-hint>Asia/Kuwait</tz-hint>
       <city>
+        <!-- A city in Kuwait -->
+        <name>Al Jahrā’</name>
+        <coordinates>29.337500 47.658060</coordinates>
+        <location>
+          <name>Ali al Salem Air Base</name>
+          <code>OKAS</code>
+          <tz-hint>Asia/Kuwait</tz-hint>
+          <coordinates>29.347000 47.521000</coordinates>
+        </location>
+      </city>
+      <city>
         <!-- The capital of Kuwait.
              "Kuwait" is the traditional English name.
              The local name in Arabic is "Al Kuwayt / الكويت".
@@ -22621,6 +31530,16 @@
           <name>Kuwait International Airport</name>
           <code>OKBK</code>
           <coordinates>29.216667 47.983333</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Kuwait -->
+        <name>Kuwait City</name>
+        <coordinates>29.367000 47.974290</coordinates>
+        <location>
+          <name>Kuwait International Airport</name>
+          <code>OKKK</code>
+          <coordinates>29.226770 47.979950</coordinates>
         </location>
       </city>
     </country>
@@ -22658,6 +31577,36 @@
       <tz-hint>Asia/Muscat</tz-hint>
       <city>
         <!-- A city in Oman -->
+        <name>Adam</name>
+        <coordinates>22.379340 57.527180</coordinates>
+        <location>
+          <name>Adam Airport</name>
+          <code>OOAD</code>
+          <coordinates>22.493056 57.381944</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Oman -->
+        <name>Duqm</name>
+        <coordinates>19.501900 57.634200</coordinates>
+        <location>
+          <name>Duqm International Airport</name>
+          <code>OODQ</code>
+          <coordinates>19.501900 57.634200</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Oman -->
+        <name>Khasab</name>
+        <coordinates>26.179930 56.247740</coordinates>
+        <location>
+          <name>Khasab Air Base</name>
+          <code>OOKB</code>
+          <coordinates>26.171000 56.240600</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Oman -->
         <name>Mu'askar al Murtafi'ah</name>
         <coordinates>23.563611 58.250000</coordinates>
         <location>
@@ -22689,6 +31638,16 @@
           <coordinates>17.033333 54.083333</coordinates>
         </location>
       </city>
+      <city>
+        <!-- A city in Oman -->
+        <name>Suhar</name>
+        <coordinates>24.347450 56.709370</coordinates>
+        <location>
+          <name>Sohar Airport</name>
+          <code>OOSH</code>
+          <coordinates>24.464170 56.628330</coordinates>
+        </location>
+      </city>
     </country>
     <country>
       <!-- PS - Occupied Palestinian Territory -->
@@ -22717,6 +31676,16 @@
       </timezones>
       <tz-hint>Asia/Qatar</tz-hint>
       <city>
+        <!-- A city in Qatar -->
+        <name>Ar Rayyan</name>
+        <coordinates>25.291940 51.424440</coordinates>
+        <location>
+          <name>Al Udeid Air Base</name>
+          <code>OTBH</code>
+          <coordinates>25.117300 51.315000</coordinates>
+        </location>
+      </city>
+      <city>
         <!-- The capital of Qatar.
              "Doha" is the traditional English name.
              The local name in Arabic is "Ad Dawhah / الدوحة".
@@ -22733,6 +31702,11 @@
           <code>KQIR</code>
           <coordinates>25.116667 51.300000</coordinates>
         </location>
+        <location>
+          <name>Hamad International Airport</name>
+          <code>OTHH</code>
+          <coordinates>25.260590 51.613770</coordinates>
+        </location>
       </city>
     </country>
     <country>
@@ -22740,7 +31714,7 @@
       <name>Saudi Arabia</name>
       <!-- Could not find information about the following stations,
            which may be in Saudi Arabia:
-           OEDM OEKB OEKJ OEMH 
+           OEKB OEMH
         -->
       <iso-code>SA</iso-code>
       <fips-code>SA</fips-code>
@@ -22800,6 +31774,22 @@
       </city>
       <city>
         <!-- A city in Saudi Arabia -->
+        <name>Al Kharj</name>
+        <coordinates>24.155410 47.334570</coordinates>
+        <location>
+          <name>Al Kharj Airport</name>
+          <code>OEKJ</code>
+          <tz-hint>Asia/Riyadh</tz-hint>
+          <coordinates>24.060722 47.410805</coordinates>
+        </location>
+        <location>
+          <name>Prince Sultan Air Base</name>
+          <code>OEPS</code>
+          <coordinates>24.062700 47.580500</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Saudi Arabia -->
         <name>Al Qaysumah</name>
         <coordinates>28.309722 46.127500</coordinates>
         <location>
@@ -22840,6 +31830,17 @@
       </city>
       <city>
         <!-- A city in Saudi Arabia -->
+        <name>Al-Ula</name>
+        <coordinates>26.483634 38.117048</coordinates>
+        <location>
+          <name>Al-Ula International Airport</name>
+          <code>OEAO</code>
+          <tz-hint>Asia/Riyadh</tz-hint>
+          <coordinates>26.483634 38.117048</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Saudi Arabia -->
         <name>Ar Ruqayyiqah</name>
         <coordinates>25.350000 49.566667</coordinates>
         <location>
@@ -22856,6 +31857,16 @@
           <name>At Ta'if</name>
           <code>OETF</code>
           <coordinates>21.483333 40.550000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Saudi Arabia -->
+        <name>Dawadmi</name>
+        <coordinates>24.449722 44.121111</coordinates>
+        <location>
+          <name>Al Dawadmi Airport</name>
+          <code>OEDM</code>
+          <coordinates>24.449722 44.121111</coordinates>
         </location>
       </city>
       <city>
@@ -22879,6 +31890,16 @@
           <name>Ha'il</name>
           <code>OEHL</code>
           <coordinates>27.433333 41.683333</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Saudi Arabia -->
+        <name>Hanak</name>
+        <coordinates>25.628333 37.088889</coordinates>
+        <location>
+          <name>Red Sea International Airport</name>
+          <code>OERS</code>
+          <coordinates>25.628333 37.088889</coordinates>
         </location>
       </city>
       <city>
@@ -23136,6 +32157,11 @@
           <code>OMAA</code>
           <coordinates>24.433333 54.650000</coordinates>
         </location>
+        <location>
+          <name>Al Bateen Executive Airport</name>
+          <code>OMAD</code>
+          <coordinates>24.428300 54.458100</coordinates>
+        </location>
       </city>
       <city>
         <!-- A city in the United Arab Emirates -->
@@ -23168,6 +32194,16 @@
           <name>Dubai International Airport</name>
           <code>OMDB</code>
           <coordinates>25.250000 55.333333</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in United Arab Emirates -->
+        <name>Dubai (Jebel Ali)</name>
+        <coordinates>25.077250 55.309270</coordinates>
+        <location>
+          <name>Al Maktoum International Airport</name>
+          <code>OMDW</code>
+          <coordinates>24.896670 55.161390</coordinates>
         </location>
       </city>
       <city>
@@ -23308,58 +32344,38 @@
       <!-- CA - Canada -->
       <name>Canada</name>
       <!-- Could not find cities for the following weather stations:
-           CYLA - Aupaluk (59.296667 -69.599722)
-           CWWL - Bonilla Island Meteorological Aeronautical
            Presentation System (53.500000 -130.633333)
-           CWKD - Bonnard (50.733333 -71.016667)
            CWOB - Brevoort Island (63.333333 -64.150000)
            CWUP - Cape Hooper (68.466667 -66.800000)
            CWKW - Cape Kakkiviak (59.983333 -64.166667)
            CWYM - Cape Mercy (64.950000 -63.583333)
            CWPX - Cape Peel West (69.033333 -107.816667)
-           CWEE - Chamouchouane Automatic Weather Reporting System
            (49.283333 -73.350000)
-           CZUM - Churchill Falls (53.550000 -64.100000)
-           CWDT - Chute des Passes (49.900000 -71.250000)
            CWXR - Croker River (69.266667 -119.216667)
            CWUW - Dewar Lakes (68.650000 -71.166667)
            CYOA - Ekati (64.700000 -110.616667)
-           CZFA - Faro Airport (62.200000 -133.366667)
-           CWWS - George Island Meteorological Aeronautical
            Presentation System (52.800000 -97.616667)
            CWIL - Hat Island (68.316667 -100.083333)
            CWHN - Jimmy Lake (54.916667 -109.950000)
-           CYKJ - Key Lake (57.250000 -105.616667)
            CWKM - Komakuk Beach (69.616667 -140.200000)
-           CYAH - La Grande (53.750000 -73.666667)
-           CWJU - Langara (54.250000 -133.050000)
            CWLI - Liverpool Bay (69.600000 -130.900000)
            CWLX - Longstaff Bluff (68.883333 -75.133333)
            CXLC - Lower Carp Lake (63.600000 -113.866667)
            CYHH - Nemiscau Airport (51.700000 -76.116667)
            CWRF - Pelly Bay (69.433333 -89.733333)
-           CWND - Pelly Island Automatic Weather Reporting System
            (69.633333 -135.433333)
            CXQA - Qavvik Lake (68.257778 -122.103611)
            CWRH - Resolution Island (61.583333 -64.650000)
            CWRX - Rowley Island (69.066667 -79.066667)
-           CWSA - Sable Island (43.933333 -60.016667)
            CYUS - Shepherd Bay (68.816667 -93.433333)
            CWTU - Tukialik Bay (54.716667 -58.350000)
-           CXTN - Tuktut Nogait (69.183333 -122.350000)
-           CWZV - Virginia Falls (61.633333 -125.800000)
-           CWGM - Waterton Park Gate (59.133333 -113.800000)
         -->
       <!-- Could not find information about the following stations,
            which may be in Canada:
-           CWBU CWKP CWTT CXAF CXAG CXAJ CXAK CXAT CXBA CXBI CXBR CXBW
-           CXCA CXCD CXCP CXCS CXCY CXDB CXDE CXDK CXDP CXEA CXEC CXEG
-           CXET CXFM CXFR CXHA CXHD CXHM CXHP CXHR CXIB CXKA CXKE CXKI
-           CXKM CXLB CXMG CXMI CXMM CXMN CXMO CXNP CXOL CXOX CXOY CXPA
-           CXPC CXPL CXRB CXRL CXSC CXSE CXSL CXSP CXTD CXTH CXTO CXTV
-           CXVM CXVN CXVW CXWM CXWN CXZC CXZU CXZV CYRA CYSP CZCR CZDB
-           CZEL CZEV CZFS CZHY CZMJ CZMT CZMU CZOL CZPS CZRP CZSM CZSP
-           CZTB CZZJ 
+           CWKP CXAF CXAG CXAJ CXAK CXBA CXBR CXBW CXCD CXCP CXCS CXCY
+           CXDB CXDP CXFM CXFR CXHD CXHP CXHR CXKM CXMG CXMN CXMO CXOL
+           CXOY CXPA CXPL CXRL CXSC CXSL CXSP CXTH CXVM CXVW CXWM CXZU
+           CZMU CZOL CZPS
         -->
       <iso-code>CA</iso-code>
       <fips-code>CA</fips-code>
@@ -27545,6 +36561,1334 @@
           </location>
         </city>
       </state>
+      <city>
+        <!-- A city in Canada -->
+        <name>Akulivik</name>
+        <coordinates>60.800560 -78.199350</coordinates>
+        <location>
+          <name>Akulivik Airport</name>
+          <code>CYKO</code>
+          <tz-hint>America/Toronto</tz-hint>
+          <coordinates>60.818600 -78.148600</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Alert</name>
+        <coordinates>82.517800 -62.280600</coordinates>
+        <location>
+          <name>Alert Airport</name>
+          <code>CYLT</code>
+          <tz-hint>America/Toronto</tz-hint>
+          <coordinates>82.517800 -62.280600</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Alliston</name>
+        <coordinates>44.150110 -79.866350</coordinates>
+        <location>
+          <name>Egbert CS, ON</name>
+          <code>CXET</code>
+          <tz-hint>America/Nipigon</tz-hint>
+          <coordinates>44.233000 -79.783000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Amherst</name>
+        <coordinates>45.833450 -64.198740</coordinates>
+        <location>
+          <name>Nappan Auto, NS</name>
+          <code>CXNP</code>
+          <tz-hint>America/Halifax</tz-hint>
+          <coordinates>45.750000 -64.233000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Antigonish</name>
+        <coordinates>45.616850 -61.998580</coordinates>
+        <location>
+          <name>Tracadie, NS</name>
+          <code>CXTD</code>
+          <tz-hint>America/Halifax</tz-hint>
+          <coordinates>45.600000 -61.667000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Arctic Bay</name>
+        <coordinates>73.037520 -85.150570</coordinates>
+        <location>
+          <name>Arctic Bay Airport</name>
+          <code>CYAB</code>
+          <tz-hint>America/Rankin_Inlet</tz-hint>
+          <coordinates>73.005770 -85.042510</coordinates>
+        </location>
+        <location>
+          <name>Arctic Bay CS</name>
+          <code>CXAT</code>
+          <tz-hint>America/Resolute</tz-hint>
+          <coordinates>73.000000 -85.017000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Armstrong</name>
+        <coordinates>50.290300 -88.909700</coordinates>
+        <location>
+          <name>Armstrong Airport</name>
+          <code>CYYW</code>
+          <tz-hint>America/Toronto</tz-hint>
+          <coordinates>50.290300 -88.909700</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Attawapiskat</name>
+        <coordinates>52.927740 -82.416690</coordinates>
+        <location>
+          <name>Attawapiskat Airport</name>
+          <code>CYAT</code>
+          <tz-hint>America/Toronto</tz-hint>
+          <coordinates>52.927500 -82.431900</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Aupaluk</name>
+        <coordinates>59.296700 -69.599700</coordinates>
+        <location>
+          <name>Aupaluk Airport</name>
+          <code>CYLA</code>
+          <tz-hint>America/Toronto</tz-hint>
+          <coordinates>59.296700 -69.599700</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Barrie</name>
+        <coordinates>44.400110 -79.666340</coordinates>
+        <location>
+          <name>Barrie-Oro</name>
+          <code>CXBI</code>
+          <tz-hint>America/Nipigon</tz-hint>
+          <coordinates>44.480000 -79.550000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Bella Bella</name>
+        <coordinates>52.163110 -128.143990</coordinates>
+        <location>
+          <name>Bella Bella (Campbell Island) Airport</name>
+          <code>CBBC</code>
+          <tz-hint>America/Vancouver</tz-hint>
+          <coordinates>52.185000 -128.157000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Berens River</name>
+        <coordinates>52.358900 -97.018300</coordinates>
+        <location>
+          <name>Berens River Airport</name>
+          <code>CYBV</code>
+          <tz-hint>America/Winnipeg</tz-hint>
+          <coordinates>52.358900 -97.018300</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Bleibler Ranch</name>
+        <coordinates>51.266667 -121.683333</coordinates>
+        <location>
+          <name>Bleibler Ranch</name>
+          <code>CYIN</code>
+          <tz-hint>America/Vancouver</tz-hint>
+          <coordinates>51.266667 -121.683333</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Bonnard 1</name>
+        <coordinates>50.717000 -71.000000</coordinates>
+        <location>
+          <name>Bonnard 1, QC</name>
+          <code>CWKD</code>
+          <tz-hint>America/Nipigon</tz-hint>
+          <coordinates>50.717000 -71.000000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Bridgewater</name>
+        <coordinates>44.378560 -64.518820</coordinates>
+        <location>
+          <name>Lunenburg</name>
+          <code>CXLB</code>
+          <tz-hint>America/Halifax</tz-hint>
+          <coordinates>44.370000 -64.300000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Cameron Falls</name>
+        <coordinates>49.150000 -88.333000</coordinates>
+        <location>
+          <name>Cameron Falls (AUT), ON</name>
+          <code>CXCA</code>
+          <tz-hint>America/Nipigon</tz-hint>
+          <coordinates>49.150000 -88.333000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Campbellton</name>
+        <coordinates>48.007510 -66.672720</coordinates>
+        <location>
+          <name>Charlo Auto, NB</name>
+          <code>CZCR</code>
+          <tz-hint>America/Halifax</tz-hint>
+          <coordinates>47.983000 -66.333000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Cape St James</name>
+        <coordinates>51.933000 -131.000000</coordinates>
+        <location>
+          <name>Cape St James CS, BC</name>
+          <code>CWZV</code>
+          <tz-hint>America/Vancouver</tz-hint>
+          <coordinates>51.933000 -131.000000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Caribou Island</name>
+        <coordinates>47.333000 -85.833000</coordinates>
+        <location>
+          <name>Caribou Island (AUT), ON</name>
+          <code>CWCI</code>
+          <tz-hint>America/Nipigon</tz-hint>
+          <coordinates>47.333000 -85.833000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Cartwright</name>
+        <coordinates>53.682800 -57.041900</coordinates>
+        <location>
+          <name>Cartwright Airport</name>
+          <code>CYCA</code>
+          <tz-hint>America/Halifax</tz-hint>
+          <coordinates>53.682800 -57.041900</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Charlesbourg</name>
+        <coordinates>46.899000 -71.305000</coordinates>
+        <location>
+          <name>Foret Montmorency RCS, QC</name>
+          <code>CMFM</code>
+          <tz-hint>America/Nipigon</tz-hint>
+          <coordinates>47.317000 -71.133000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Charlottetown</name>
+        <coordinates>46.234590 -63.125600</coordinates>
+        <location>
+          <name>Harrington CDA CS, PE</name>
+          <code>CAHR</code>
+          <tz-hint>America/Halifax</tz-hint>
+          <coordinates>46.350000 -63.167000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Chatham-Kent</name>
+        <coordinates>42.412240 -82.184940</coordinates>
+        <location>
+          <name>Chatham Kent Airport</name>
+          <code>CYCK</code>
+          <tz-hint>America/Toronto</tz-hint>
+          <coordinates>42.306400 -82.081900</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Churchill Falls</name>
+        <coordinates>53.531530 -64.008490</coordinates>
+        <location>
+          <name>Churchill Falls Airport</name>
+          <code>CZUM</code>
+          <tz-hint>America/Halifax</tz-hint>
+          <coordinates>53.561900 -64.106400</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Chutes Des Passes</name>
+        <coordinates>49.833000 -71.167000</coordinates>
+        <location>
+          <name>Chutes des Passes, QC</name>
+          <code>CWDT</code>
+          <tz-hint>America/Nipigon</tz-hint>
+          <coordinates>49.833000 -71.167000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Colville Lake</name>
+        <coordinates>67.020150 -126.128364</coordinates>
+        <location>
+          <name>Tommy Kochon Airport</name>
+          <code>CYVL</code>
+          <tz-hint>America/Yellowknife</tz-hint>
+          <coordinates>67.020150 -126.128364</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Cumshewa Island</name>
+        <coordinates>53.033000 -131.600000</coordinates>
+        <location>
+          <name>Cumshewa Island, BC</name>
+          <code>CWZL</code>
+          <tz-hint>America/Vancouver</tz-hint>
+          <coordinates>53.033000 -131.600000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Dawson Creek</name>
+        <coordinates>55.759840 -120.240300</coordinates>
+        <location>
+          <name>Dawson Creek Airport</name>
+          <code>CYDQ</code>
+          <tz-hint>America/Dawson_Creek</tz-hint>
+          <coordinates>55.742300 -120.183000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Deadmen Valley</name>
+        <coordinates>61.250000 -124.467000</coordinates>
+        <location>
+          <name>Deadmen Valley, NT</name>
+          <code>CXDK</code>
+          <tz-hint>America/Yellowknife</tz-hint>
+          <coordinates>61.250000 -124.467000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Dease Lake</name>
+        <coordinates>58.422200 -130.032000</coordinates>
+        <location>
+          <name>Dease Lake Airport</name>
+          <code>CYDL</code>
+          <tz-hint>America/Vancouver</tz-hint>
+          <coordinates>58.422200 -130.032000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Deline</name>
+        <coordinates>65.198440 -123.405650</coordinates>
+        <location>
+          <name>Deline CS, NT</name>
+          <code>CXDE</code>
+          <tz-hint>America/Yellowknife</tz-hint>
+          <coordinates>65.217000 -123.433000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Dolbeau-Mistassini</name>
+        <coordinates>48.878600 -72.231420</coordinates>
+        <location>
+          <name>Chamouchouane, QC</name>
+          <code>CWEE</code>
+          <tz-hint>America/Nipigon</tz-hint>
+          <coordinates>49.267000 -73.350000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Dryden</name>
+        <coordinates>49.775040 -92.833630</coordinates>
+        <location>
+          <name>Ear Falls (AUT)</name>
+          <code>CXEA</code>
+          <tz-hint>America/Resolute</tz-hint>
+          <coordinates>50.633000 -93.217000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Eastmain River</name>
+        <coordinates>52.226400 -78.522500</coordinates>
+        <location>
+          <name>Eastmain River Airport</name>
+          <code>CZEM</code>
+          <tz-hint>America/Toronto</tz-hint>
+          <coordinates>52.226400 -78.522500</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Edmonton</name>
+        <coordinates>53.550140 -113.468710</coordinates>
+        <location>
+          <name>Edmonton / Villeneuve Airport</name>
+          <code>CZVL</code>
+          <tz-hint>America/Edmonton</tz-hint>
+          <coordinates>53.667500 -113.854000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Edmundston</name>
+        <coordinates>47.373700 -68.325120</coordinates>
+        <location>
+          <name>Edmunston</name>
+          <code>CERM</code>
+          <tz-hint>America/Halifax</tz-hint>
+          <coordinates>47.420000 -68.320000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Edson</name>
+        <coordinates>53.583450 -116.435590</coordinates>
+        <location>
+          <name>Edson Climate</name>
+          <code>CZZJ</code>
+          <tz-hint>America/Yellowknife</tz-hint>
+          <coordinates>53.583000 -116.467000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Elora</name>
+        <coordinates>43.683400 -80.432990</coordinates>
+        <location>
+          <name>Elora RCS, ON</name>
+          <code>CZEL</code>
+          <tz-hint>America/Nipigon</tz-hint>
+          <coordinates>43.650000 -80.417000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Embrun</name>
+        <coordinates>45.275730 -75.272660</coordinates>
+        <location>
+          <name>Moose Creek</name>
+          <code>CTCK</code>
+          <tz-hint>America/Nipigon</tz-hint>
+          <coordinates>45.250000 -74.967000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Faro</name>
+        <coordinates>62.207500 -133.376010</coordinates>
+        <location>
+          <name>Faro Airport</name>
+          <code>CZFA</code>
+          <tz-hint>America/Vancouver</tz-hint>
+          <coordinates>62.207500 -133.376010</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Fort Liard</name>
+        <coordinates>60.239470 -123.473710</coordinates>
+        <location>
+          <name>Fort Liard Airport</name>
+          <code>CYJF</code>
+          <tz-hint>America/Yellowknife</tz-hint>
+          <coordinates>60.235800 -123.469000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Fort McMurray</name>
+        <coordinates>56.726760 -111.381030</coordinates>
+        <location>
+          <name>Fort McMurray CS, AB</name>
+          <code>CXMM</code>
+          <tz-hint>America/Yellowknife</tz-hint>
+          <coordinates>56.650000 -111.217000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Fort Mcpherson</name>
+        <coordinates>67.438630 -134.885430</coordinates>
+        <location>
+          <name>Fort Mcpherson Airport</name>
+          <code>CZFM</code>
+          <tz-hint>America/Edmonton</tz-hint>
+          <coordinates>67.407500 -134.860990</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Fort Resolution</name>
+        <coordinates>61.180800 -113.690000</coordinates>
+        <location>
+          <name>Fort Resolution Airport</name>
+          <code>CYFR</code>
+          <tz-hint>America/Edmonton</tz-hint>
+          <coordinates>61.180800 -113.690000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Fort Severn</name>
+        <coordinates>56.018900 -87.676100</coordinates>
+        <location>
+          <name>Fort Severn Airport</name>
+          <code>CYER</code>
+          <tz-hint>America/Toronto</tz-hint>
+          <coordinates>56.018900 -87.676100</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Fort Simpson Climate</name>
+        <coordinates>61.750000 -121.233000</coordinates>
+        <location>
+          <name>Fort Simpson Climate, NT</name>
+          <code>CZFS</code>
+          <tz-hint>America/Yellowknife</tz-hint>
+          <coordinates>61.750000 -121.233000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Fort Smith Climate</name>
+        <coordinates>60.017000 -111.917000</coordinates>
+        <location>
+          <name>Fort Smith Climate, NT</name>
+          <code>CZSM</code>
+          <tz-hint>America/Yellowknife</tz-hint>
+          <coordinates>60.017000 -111.917000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Gamètì</name>
+        <coordinates>64.116100 -117.310000</coordinates>
+        <location>
+          <name>Rae Lakes Airport</name>
+          <code>CYRA</code>
+          <tz-hint>America/Yellowknife</tz-hint>
+          <coordinates>64.116100 -117.310000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>George Island</name>
+        <coordinates>52.817000 -97.600000</coordinates>
+        <location>
+          <name>George Island (AUT), MB</name>
+          <code>CWWS</code>
+          <tz-hint>America/Resolute</tz-hint>
+          <coordinates>52.817000 -97.600000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Granby</name>
+        <coordinates>45.400080 -72.732430</coordinates>
+        <location>
+          <name>Granby</name>
+          <code>CMGB</code>
+          <tz-hint>America/Nipigon</tz-hint>
+          <coordinates>45.367000 -72.767000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Greely</name>
+        <coordinates>45.261390 -75.561110</coordinates>
+        <location>
+          <name>Kemptville CS, ON</name>
+          <code>CXKE</code>
+          <tz-hint>America/Nipigon</tz-hint>
+          <coordinates>45.000000 -75.633000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Grise Fiord</name>
+        <coordinates>76.417000 -82.900000</coordinates>
+        <location>
+          <name>Grise Fiord Airport</name>
+          <code>CWGZ</code>
+          <tz-hint>America/Nipigon</tz-hint>
+          <coordinates>76.417000 -82.900000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Hamilton</name>
+        <coordinates>43.250110 -79.849630</coordinates>
+        <location>
+          <name>Hamilton RBG CS, ON</name>
+          <code>CXHM</code>
+          <tz-hint>America/Nipigon</tz-hint>
+          <coordinates>43.283000 -79.900000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Hay River Climate</name>
+        <coordinates>60.833000 -115.767000</coordinates>
+        <location>
+          <name>Hay River Climate, NT</name>
+          <code>CZHY</code>
+          <tz-hint>America/Yellowknife</tz-hint>
+          <coordinates>60.833000 -115.767000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Huntsville</name>
+        <coordinates>45.333410 -79.216320</coordinates>
+        <location>
+          <name>Algonquin Park East Gate</name>
+          <code>CTNK</code>
+          <tz-hint>America/Nipigon</tz-hint>
+          <coordinates>45.533000 -78.267000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Imperoyal</name>
+        <coordinates>44.636180 -63.527300</coordinates>
+        <location>
+          <name>McNabs Island (AUT)</name>
+          <code>CXMI</code>
+          <tz-hint>America/Halifax</tz-hint>
+          <coordinates>44.602000 -63.533000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Inuvik Climate</name>
+        <coordinates>68.317000 -133.517000</coordinates>
+        <location>
+          <name>Inuvik Climate, NT</name>
+          <code>CZEV</code>
+          <tz-hint>America/Yellowknife</tz-hint>
+          <coordinates>68.317000 -133.517000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Kangiqsualujjuaq</name>
+        <coordinates>58.691430 -65.952470</coordinates>
+        <location>
+          <name>Kangiqsualujjuaq (Georges River) Airport</name>
+          <code>CYLU</code>
+          <tz-hint>America/Iqaluit</tz-hint>
+          <coordinates>58.711400 -65.992800</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Kapuskasing</name>
+        <coordinates>49.416940 -82.433080</coordinates>
+        <location>
+          <name>Kapuskasing CDA, ON</name>
+          <code>CXKA</code>
+          <tz-hint>America/Nipigon</tz-hint>
+          <coordinates>49.400000 -82.433000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Kenora</name>
+        <coordinates>49.767410 -94.489850</coordinates>
+        <location>
+          <name>Rawson Lake (AUT)</name>
+          <code>CTRA</code>
+          <tz-hint>America/Resolute</tz-hint>
+          <coordinates>49.650000 -93.717000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Key Lake</name>
+        <coordinates>57.256100 -105.618000</coordinates>
+        <location>
+          <name>Key Lake Airport</name>
+          <code>CYKJ</code>
+          <tz-hint>America/Regina</tz-hint>
+          <coordinates>57.256100 -105.618000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Kimmirut</name>
+        <coordinates>62.850000 -69.883300</coordinates>
+        <location>
+          <name>Kimmirut Airport</name>
+          <code>CYLC</code>
+          <tz-hint>America/Toronto</tz-hint>
+          <coordinates>62.850000 -69.883300</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Kingsville</name>
+        <coordinates>42.100090 -82.733120</coordinates>
+        <location>
+          <name>Harrow CDA Auto</name>
+          <code>CXHA</code>
+          <tz-hint>America/Nipigon</tz-hint>
+          <coordinates>42.033000 -82.900000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Kirkland Lake</name>
+        <coordinates>48.144610 -80.037670</coordinates>
+        <location>
+          <name>Kirkland Lake CS, ON</name>
+          <code>CXKI</code>
+          <tz-hint>America/Nipigon</tz-hint>
+          <coordinates>48.150000 -80.000000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>La Grande-4</name>
+        <coordinates>53.754700 -73.675300</coordinates>
+        <location>
+          <name>La Grande-4 Airport</name>
+          <code>CYAH</code>
+          <tz-hint>America/Toronto</tz-hint>
+          <coordinates>53.754700 -73.675300</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>La Ronge</name>
+        <coordinates>55.100130 -105.284220</coordinates>
+        <location>
+          <name>La Ronge RCS, SK</name>
+          <code>CXOX</code>
+          <tz-hint>America/Regina</tz-hint>
+          <coordinates>55.150000 -105.267000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Langara</name>
+        <coordinates>54.250000 -133.050000</coordinates>
+        <location>
+          <name>Langara</name>
+          <code>CWJU</code>
+          <tz-hint>America/Vancouver</tz-hint>
+          <coordinates>54.250000 -133.050000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Lansdowne House</name>
+        <coordinates>52.195600 -87.934200</coordinates>
+        <location>
+          <name>Lansdowne House Airport</name>
+          <code>CYLH</code>
+          <tz-hint>America/Toronto</tz-hint>
+          <coordinates>52.195600 -87.934200</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Leduc</name>
+        <coordinates>53.266820 -113.552010</coordinates>
+        <location>
+          <name>Edmonton International CS, AB</name>
+          <code>CXEG</code>
+          <tz-hint>America/Yellowknife</tz-hint>
+          <coordinates>53.300000 -113.600000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Lethbridge</name>
+        <coordinates>49.699990 -112.818560</coordinates>
+        <location>
+          <name>Waterton Park Gate</name>
+          <code>CWGM</code>
+          <tz-hint>America/Yellowknife</tz-hint>
+          <coordinates>49.133000 -113.817000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Louiseville</name>
+        <coordinates>46.255940 -72.941450</coordinates>
+        <location>
+          <name>Lac Saint-Pierre, QC</name>
+          <code>CWBS</code>
+          <tz-hint>America/Nipigon</tz-hint>
+          <coordinates>46.183000 -72.917000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Lupin</name>
+        <coordinates>65.750000 -111.250000</coordinates>
+        <location>
+          <name>Lupin, NT</name>
+          <code>CWIJ</code>
+          <tz-hint>America/Yellowknife</tz-hint>
+          <coordinates>65.750000 -111.250000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Lutselk'e</name>
+        <coordinates>62.418300 -110.682000</coordinates>
+        <location>
+          <name>Lutselk'e Airport</name>
+          <code>CYLK</code>
+          <tz-hint>America/Yellowknife</tz-hint>
+          <coordinates>62.418300 -110.682000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Magog</name>
+        <coordinates>45.266780 -72.149090</coordinates>
+        <location>
+          <name>Lac Memphremagog</name>
+          <code>CWTT</code>
+          <tz-hint>America/Nipigon</tz-hint>
+          <coordinates>45.270000 -72.170000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Marathon</name>
+        <coordinates>48.755300 -86.344400</coordinates>
+        <location>
+          <name>Marathon Airport</name>
+          <code>CYSP</code>
+          <tz-hint>America/Toronto</tz-hint>
+          <coordinates>48.755300 -86.344400</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Masset</name>
+        <coordinates>54.011410 -132.147070</coordinates>
+        <location>
+          <name>Masset Airport</name>
+          <code>CZMT</code>
+          <tz-hint>America/Vancouver</tz-hint>
+          <coordinates>54.027500 -132.125000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Moose Jaw</name>
+        <coordinates>50.400050 -105.534450</coordinates>
+        <location>
+          <name>Moose Jaw Air Vice Marshal C. M. McEwen Airport</name>
+          <code>CYMJ</code>
+          <tz-hint>America/Regina</tz-hint>
+          <coordinates>50.330300 -105.559000</coordinates>
+        </location>
+        <location>
+          <name>Moose Jaw CS, SK</name>
+          <code>CZMJ</code>
+          <tz-hint>America/Regina</tz-hint>
+          <coordinates>50.317000 -105.550000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Moosonee</name>
+        <coordinates>51.279310 -80.634500</coordinates>
+        <location>
+          <name>Moosonee RCS, ON</name>
+          <code>CXZC</code>
+          <tz-hint>America/Nipigon</tz-hint>
+          <coordinates>51.150000 -80.390000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Muskrat Dam</name>
+        <coordinates>53.441400 -91.762800</coordinates>
+        <location>
+          <name>Muskrat Dam Airport</name>
+          <code>CZMD</code>
+          <tz-hint>America/Winnipeg</tz-hint>
+          <coordinates>53.441400 -91.762800</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Nipawin</name>
+        <coordinates>53.366780 -104.000920</coordinates>
+        <location>
+          <name>Nipawin, SK</name>
+          <code>CWBU</code>
+          <tz-hint>America/Regina</tz-hint>
+          <coordinates>53.333000 -104.000000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Ogoki Post</name>
+        <coordinates>51.658600 -85.901703</coordinates>
+        <location>
+          <name>Ogoki Post Airport</name>
+          <code>CYKP</code>
+          <tz-hint>America/Nipigon</tz-hint>
+          <coordinates>51.658600 -85.901703</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Orillia</name>
+        <coordinates>44.608680 -79.420680</coordinates>
+        <location>
+          <name>Lagoon City, ON</name>
+          <code>CWGL</code>
+          <tz-hint>America/Nipigon</tz-hint>
+          <coordinates>44.533000 -79.217000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Oshawa</name>
+        <coordinates>43.900120 -78.849570</coordinates>
+        <location>
+          <name>Oshawa Airport</name>
+          <code>CYOO</code>
+          <tz-hint>America/Toronto</tz-hint>
+          <coordinates>43.922800 -78.895000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Parry Sound</name>
+        <coordinates>45.347320 -80.035270</coordinates>
+        <location>
+          <name>Parry Sound CCG, ON</name>
+          <code>CXPC</code>
+          <tz-hint>America/Nipigon</tz-hint>
+          <coordinates>45.333000 -80.033000</coordinates>
+        </location>
+        <location>
+          <name>Western Island (AUT), ON</name>
+          <code>CWMZ</code>
+          <tz-hint>America/Nipigon</tz-hint>
+          <coordinates>45.033000 -80.367000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Peawanuck</name>
+        <coordinates>54.988100 -85.443300</coordinates>
+        <location>
+          <name>Peawanuck Airport</name>
+          <code>CYPO</code>
+          <tz-hint>America/Toronto</tz-hint>
+          <coordinates>54.988100 -85.443300</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Pelly Island</name>
+        <coordinates>69.617000 -135.433000</coordinates>
+        <location>
+          <name>Pelly Island, NT</name>
+          <code>CWND</code>
+          <tz-hint>America/Yellowknife</tz-hint>
+          <coordinates>69.617000 -135.433000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Port Colborne</name>
+        <coordinates>42.900120 -79.232880</coordinates>
+        <location>
+          <name>Port Colborne (AUT), ON</name>
+          <code>CWPC</code>
+          <tz-hint>America/Nipigon</tz-hint>
+          <coordinates>42.867000 -79.250000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Port Hawkesbury</name>
+        <coordinates>45.616520 -61.356360</coordinates>
+        <location>
+          <name>Port Hawkesbury Airport</name>
+          <code>CYPD</code>
+          <tz-hint>America/Halifax</tz-hint>
+          <coordinates>45.656700 -61.368100</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Portage la Prairie</name>
+        <coordinates>49.972820 -98.292630</coordinates>
+        <location>
+          <name>Southport Airport</name>
+          <code>CYPG</code>
+          <tz-hint>America/Winnipeg</tz-hint>
+          <coordinates>49.903100 -98.273900</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Prince Rupert</name>
+        <coordinates>54.315070 -130.320980</coordinates>
+        <location>
+          <name>Bonilla Island (AUT), BC</name>
+          <code>CWWL</code>
+          <tz-hint>America/Vancouver</tz-hint>
+          <coordinates>53.500000 -130.633000</coordinates>
+        </location>
+        <location>
+          <name>Holland Rock, BC</name>
+          <code>CWHL</code>
+          <tz-hint>America/Vancouver</tz-hint>
+          <coordinates>54.167000 -130.350000</coordinates>
+        </location>
+        <location>
+          <name>Lucy Island Lightstation</name>
+          <code>CWLC</code>
+          <tz-hint>America/Vancouver</tz-hint>
+          <coordinates>54.296000 -130.609000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Queen Mary Park</name>
+        <coordinates>53.554790 -113.517180</coordinates>
+        <location>
+          <name>Edmonton Municipal CR10, AB</name>
+          <code>CXEC</code>
+          <tz-hint>America/Yellowknife</tz-hint>
+          <coordinates>53.567000 -113.517000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Rea Point</name>
+        <coordinates>75.367000 -105.717000</coordinates>
+        <location>
+          <name>Rea Point, NU</name>
+          <code>CZRP</code>
+          <tz-hint>America/Yellowknife</tz-hint>
+          <coordinates>75.367000 -105.717000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Resolute</name>
+        <coordinates>74.717000 -94.983000</coordinates>
+        <location>
+          <name>Resolute CS</name>
+          <code>CXRB</code>
+          <tz-hint>America/Resolute</tz-hint>
+          <coordinates>74.717000 -94.983000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Sable Island</name>
+        <coordinates>43.933333 -60.000000</coordinates>
+        <location>
+          <name>Sable Island</name>
+          <code>CWSA</code>
+          <tz-hint>America/Halifax</tz-hint>
+          <coordinates>43.933333 -60.000000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Salluit</name>
+        <coordinates>62.204110 -75.643440</coordinates>
+        <location>
+          <name>Salluit Airport</name>
+          <code>CYZG</code>
+          <tz-hint>America/Toronto</tz-hint>
+          <coordinates>62.179400 -75.667200</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Sandy Lake</name>
+        <coordinates>53.064200 -93.344400</coordinates>
+        <location>
+          <name>Sandy Lake Airport</name>
+          <code>CZSJ</code>
+          <tz-hint>America/Winnipeg</tz-hint>
+          <coordinates>53.064200 -93.344400</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Sanikiluaq</name>
+        <coordinates>56.541060 -79.225760</coordinates>
+        <location>
+          <name>Sanikiluaq Airport</name>
+          <code>CYSK</code>
+          <tz-hint>America/Iqaluit</tz-hint>
+          <coordinates>56.537800 -79.246700</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Sept-Îles</name>
+        <coordinates>50.200110 -66.382080</coordinates>
+        <location>
+          <name>Sept-Iles, QC</name>
+          <code>CXZV</code>
+          <tz-hint>America/Nipigon</tz-hint>
+          <coordinates>50.217000 -66.250000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Shearwater</name>
+        <coordinates>44.626760 -63.513690</coordinates>
+        <location>
+          <name>Shearwater</name>
+          <code>CYAW</code>
+          <tz-hint>America/Halifax</tz-hint>
+          <coordinates>44.640000 -63.499000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>St. Catharines</name>
+        <coordinates>43.171260 -79.242670</coordinates>
+        <location>
+          <name>Vineland Station RCS, ON</name>
+          <code>CXVN</code>
+          <tz-hint>America/Nipigon</tz-hint>
+          <coordinates>43.183000 -79.400000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Stefansson Island</name>
+        <coordinates>73.750000 -105.283000</coordinates>
+        <location>
+          <name>Stefansson Island, NU</name>
+          <code>CXSE</code>
+          <tz-hint>America/Yellowknife</tz-hint>
+          <coordinates>73.750000 -105.283000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Sydney Mines</name>
+        <coordinates>46.236690 -60.217670</coordinates>
+        <location>
+          <name>Ingonish Beach CS</name>
+          <code>CXIB</code>
+          <tz-hint>America/Halifax</tz-hint>
+          <coordinates>46.667000 -60.400000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Tadoule Lake</name>
+        <coordinates>58.706100 -98.512200</coordinates>
+        <location>
+          <name>Tadoule Lake Airport</name>
+          <code>CYBQ</code>
+          <tz-hint>America/Winnipeg</tz-hint>
+          <coordinates>58.706100 -98.512200</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Thompson</name>
+        <coordinates>55.743500 -97.855790</coordinates>
+        <location>
+          <name>Kelsey Dam CS, MB</name>
+          <code>CZKD</code>
+          <tz-hint>America/Resolute</tz-hint>
+          <coordinates>56.033000 -96.500000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Three Rivers</name>
+        <coordinates>46.184500 -62.567900</coordinates>
+        <location>
+          <name>St. Peters, PE</name>
+          <code>CZSP</code>
+          <tz-hint>America/Halifax</tz-hint>
+          <coordinates>46.450000 -62.567000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Thunder Bay</name>
+        <coordinates>48.382020 -89.250180</coordinates>
+        <location>
+          <name>Thunder Bay CS</name>
+          <code>CZTB</code>
+          <tz-hint>America/Nipigon</tz-hint>
+          <coordinates>48.370000 -89.320000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Trail Valley</name>
+        <coordinates>68.750000 -133.500000</coordinates>
+        <location>
+          <name>Trail Valley, NT</name>
+          <code>CXTV</code>
+          <tz-hint>America/Yellowknife</tz-hint>
+          <coordinates>68.750000 -133.500000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Trois-Rivières</name>
+        <coordinates>46.345150 -72.547700</coordinates>
+        <location>
+          <name>Trois-Rivieres Airport</name>
+          <code>CYRQ</code>
+          <tz-hint>America/Toronto</tz-hint>
+          <coordinates>46.352800 -72.679400</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Truro</name>
+        <coordinates>45.366850 -63.265380</coordinates>
+        <location>
+          <name>Debert</name>
+          <code>CZDB</code>
+          <tz-hint>America/Halifax</tz-hint>
+          <coordinates>45.417000 -63.467000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Tuktut Nogait</name>
+        <coordinates>69.183000 -122.350000</coordinates>
+        <location>
+          <name>Tuktut Nogait, NT</name>
+          <code>CXTN</code>
+          <tz-hint>America/Yellowknife</tz-hint>
+          <coordinates>69.183000 -122.350000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Tulita</name>
+        <coordinates>64.909700 -125.573000</coordinates>
+        <location>
+          <name>Tulita Airport</name>
+          <code>CZFN</code>
+          <tz-hint>America/Edmonton</tz-hint>
+          <coordinates>64.909700 -125.573000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Umiujaq</name>
+        <coordinates>56.553050 -76.549470</coordinates>
+        <location>
+          <name>Umiujaq Airport</name>
+          <code>CYMU</code>
+          <tz-hint>America/Toronto</tz-hint>
+          <coordinates>56.536100 -76.518300</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>University</name>
+        <coordinates>43.662510 -79.401180</coordinates>
+        <location>
+          <name>Toronto City</name>
+          <code>CXTO</code>
+          <tz-hint>America/Nipigon</tz-hint>
+          <coordinates>43.666667 -79.400000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Wager Bay</name>
+        <coordinates>65.867000 -89.433000</coordinates>
+        <location>
+          <name>Wager Bay (AUT), MB</name>
+          <code>CXWB</code>
+          <tz-hint>America/Resolute</tz-hint>
+          <coordinates>65.867000 -89.433000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Wekweètì</name>
+        <coordinates>64.190800 -114.077000</coordinates>
+        <location>
+          <name>Wekweeti Airport</name>
+          <code>CYWE</code>
+          <tz-hint>America/Edmonton</tz-hint>
+          <coordinates>64.190800 -114.077000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Whale Cove</name>
+        <coordinates>62.240000 -92.598100</coordinates>
+        <location>
+          <name>Whale Cove Airport</name>
+          <code>CYXN</code>
+          <tz-hint>America/Winnipeg</tz-hint>
+          <coordinates>62.240000 -92.598100</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Winnipeg</name>
+        <coordinates>49.884400 -97.147040</coordinates>
+        <location>
+          <name>Winnipeg The Forks, MB</name>
+          <code>CXWN</code>
+          <tz-hint>America/Resolute</tz-hint>
+          <coordinates>49.883000 -97.133000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Canada -->
+        <name>Yohin</name>
+        <coordinates>61.233000 -123.733000</coordinates>
+        <location>
+          <name>Yohin, NT</name>
+          <code>CXYH</code>
+          <tz-hint>America/Yellowknife</tz-hint>
+          <coordinates>61.233000 -123.733000</coordinates>
+        </location>
+      </city>
     </country>
     <country>
       <!-- MX - Mexico -->
@@ -28365,6 +38709,61 @@
           </location>
         </city>
       </state>
+      <city>
+        <!-- A city in Mexico -->
+        <name>Cabo San Lucas</name>
+        <coordinates>22.890880 -109.912380</coordinates>
+        <location>
+          <name>Cabo San Lucas International Airport</name>
+          <code>MMSL</code>
+          <tz-hint>America/Mazatlan</tz-hint>
+          <coordinates>22.947700 -109.937000</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Mexico -->
+        <name>Mexico City</name>
+        <coordinates>19.428470 -99.127660</coordinates>
+        <location>
+          <name>Santa Lucia Air Force Base</name>
+          <code>MMSM</code>
+          <tz-hint>America/Mexico_City</tz-hint>
+          <coordinates>19.755300 -99.016400</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Mexico -->
+        <name>Palenque</name>
+        <coordinates>17.509140 -91.981250</coordinates>
+        <location>
+          <name>Palenque International Airport</name>
+          <code>MMPQ</code>
+          <tz-hint>America/Mexico_City</tz-hint>
+          <coordinates>17.533400 -91.984500</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Mexico -->
+        <name>Puerto Peñasco</name>
+        <coordinates>31.317160 -113.537990</coordinates>
+        <location>
+          <name>Puerto Penasco International Airport</name>
+          <code>MMPE</code>
+          <tz-hint>America/Hermosillo</tz-hint>
+          <coordinates>31.356200 -113.525680</coordinates>
+        </location>
+      </city>
+      <city>
+        <!-- A city in Mexico -->
+        <name>Tulum</name>
+        <coordinates>20.211730 -87.463250</coordinates>
+        <location>
+          <name>Felipe Carrillo Puerto International Airport</name>
+          <code>MMTL</code>
+          <tz-hint>America/Cancun</tz-hint>
+          <coordinates>20.166667 -87.666667</coordinates>
+        </location>
+      </city>
     </country>
     <country>
       <!-- PM - Saint Pierre and Miquelon, a French territory in North
@@ -28393,44 +38792,12 @@
       <!-- US - United States, aka United States of America -->
       <name>United States</name>
       <!-- Could not find cities for the following weather stations:
-           PALU - Cape Lisburne, Cape Lisburne LRRS Airport (68.883333
-           -166.100000)
-           PAHZ - Hayes River, Hayes River Airport (61.983333
-           -152.083333)
-           PTSA - Kosrae Island, Kosrae Airport (5.350000 162.950000)
-           PAKU - Kuparuk, Ugnu-Kuparuk Airport (70.316667 -149.583333)
-           KBJN - Las Vegas, Tonopah Range #74 Nellis Air Force Base
-           (37.617222 -116.264167)
-           PAER - Merrill Pass West (61.250000 -153.816667)
-           PAMD - Middleton Island, Middleton Island Airport (59.433333
-           -146.300000)
-           PTTP - Pohnpei (6.966667 158.216667)
-           PTPN - Pohnpei Island, Pohnpei International Airport
-           (6.983333 158.200000)
-           PAPT - Puntilla (62.100000 -152.750000)
-           PGRO - Rota Island, N. Mariana Is, Rota International
-           Airport (14.183333 145.250000)
-           KNSI - San Nicholas Island (33.234722 -119.452778)
-           PASY - Shemya, Eareckson Air Force Base (52.716667
-           174.116667)
-           KGSM - Ship Shoal 207A (28.533333 -90.983333)
-           KSRN - South Marsh 268A (29.116667 -91.866667)
-           KS58 - South Timbalier (28.533333 -90.583333)
-           PTKK - Weno Island, Chuuk International Airport (7.466667
-           151.850000)
-           PTYA - Yap Island, Yap International Airport (9.483333
-           138.083333)
+           LRRS PAHZ KBJN PAER KGSM KSRN KS58
         -->
       <!-- Could not find information about the following stations,
            which may be in United States:
-           K0J4 K0R3 K14Y K21D K2G4 K2W6 K4C0 K4I3 KABH KAJO KAXX KBDH
-           KBEA KBKD KBQP KBTA KCCA KCGE KCLS KCNB KCNW KCVB KCWC KDIJ
-           KDMW KDRM KDVK KDVO KDZJ KEFK KFFX KFSO KGAI KGCD KGGI KGHG
-           KGWB KGYH KH78 KHAI KHBB KHOE KHRX KHWY KICR KIFA KJKA KL35
-           KLDJ KMJX KMNZ KMQS KMWO KPEZ KPLU KPRN KPRO KPVB KRCM KRCZ
-           KRJD KRSP KRYN KRYT KRYW KSIF KTFP KTMK KTYQ KUNI KUXL KW29
-           KXSA KY63 PACE PACM PADG PADM PAFS PAHC PAIG PAJZ PALG PAMB
-           PAMK PAMO PANW PAOU PAPN PARS PARY PATQ PAVC 
+           K0J4 K0R3 K14Y K21D K2G4 K2W6 K4C0 K4I3 KABH KH78 KHBB KL35
+           KRJD KRYT KTFP KW29 KY63 PACE PACM
         -->
       <iso-code>US</iso-code>
       <fips-code>US</fips-code>
@@ -28529,6 +38896,13 @@
             <code>K8A0</code>
             <coordinates>34.228889 -86.255556</coordinates>
           </location>
+          <location>
+            <name>Albertville Regional/Thomas J Brumlik Field</name>
+            <code>KBFZ</code>
+            <zone>ALZ008</zone>
+            <radar>bhm</radar>
+            <coordinates>34.229109 -86.255756</coordinates>
+          </location>
         </city>
         <city>
           <!-- A city in Alabama in the United States -->
@@ -28575,6 +38949,18 @@
           </location>
         </city>
         <city>
+          <!-- A city in Alabama in United States -->
+          <name>Bessemer</name>
+          <coordinates>33.401780 -86.954440</coordinates>
+          <location>
+            <name>Bessemer Ntl Airport</name>
+            <code>KEKY</code>
+            <zone>ALZ025</zone>
+            <radar>bhm</radar>
+            <coordinates>33.312611 -86.926306</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Alabama in the United States -->
           <name msgctxt="City in Alabama, United States">Birmingham</name>
           <coordinates>33.520661 -86.802490</coordinates>
@@ -28594,6 +38980,13 @@
             <name>Folsom Field Airport</name>
             <code>K3A1</code>
             <coordinates>34.268611 -86.858333</coordinates>
+          </location>
+          <location>
+            <name>Cullman Regional/Folsom Field</name>
+            <code>KCMD</code>
+            <zone>ALZ016</zone>
+            <radar>tip</radar>
+            <coordinates>34.268703 -86.858035</coordinates>
           </location>
         </city>
         <city>
@@ -28618,6 +39011,18 @@
           </location>
         </city>
         <city>
+          <!-- A city in Alabama in United States -->
+          <name>Demopolis</name>
+          <coordinates>32.517640 -87.836400</coordinates>
+          <location>
+            <name>Demopolis Regional Airport</name>
+            <code>KDYA</code>
+            <zone>ALZ030</zone>
+            <radar>bhm</radar>
+            <coordinates>32.463833 -87.954056</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Alabama in the United States -->
           <name>Dothan</name>
           <coordinates>31.223231 -85.390489</coordinates>
@@ -28630,6 +39035,37 @@
           </location>
         </city>
         <city>
+          <!-- A city in Alabama in United States -->
+          <name>Enterprise</name>
+          <coordinates>31.315170 -85.855220</coordinates>
+          <location>
+            <name>Enterprise Municipal Airport</name>
+            <code>KEDN</code>
+            <zone>ALZ065</zone>
+            <radar>tlh</radar>
+            <coordinates>31.299722 -85.899833</coordinates>
+          </location>
+          <location>
+            <name>Shell Army Heliport</name>
+            <code>KSXS</code>
+            <zone>ALZ065</zone>
+            <radar>tlh</radar>
+            <coordinates>31.363000 -85.849000</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Alabama in United States -->
+          <name>Eufaula</name>
+          <coordinates>31.891270 -85.145490</coordinates>
+          <location>
+            <name>Weedon Field</name>
+            <code>KEUF</code>
+            <zone>GAZ120</zone>
+            <radar>tlh</radar>
+            <coordinates>31.951306 -85.128917</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Alabama in the United States -->
           <name>Evergreen</name>
           <coordinates>31.433499 -86.956918</coordinates>
@@ -28638,6 +39074,30 @@
             <code>KGZH</code>
             <radar>jan</radar>
             <coordinates>31.418889 -87.048056</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Alabama in United States -->
+          <name>Fairhope</name>
+          <coordinates>30.522970 -87.903330</coordinates>
+          <location>
+            <name>H L Sonny Callahan Airport</name>
+            <code>KCQF</code>
+            <zone>ALZ262</zone>
+            <radar>bix</radar>
+            <coordinates>30.460500 -87.877028</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Alabama in United States -->
+          <name>Foley</name>
+          <coordinates>30.406590 -87.683600</coordinates>
+          <location>
+            <name>Barin Nolf Airport</name>
+            <code>KNBJ</code>
+            <zone>ALZ262</zone>
+            <radar>bix</radar>
+            <coordinates>30.390314 -87.631560</coordinates>
           </location>
         </city>
         <city>
@@ -28660,6 +39120,30 @@
             <zone>ALZ018</zone>
             <radar>bhm</radar>
             <coordinates>33.966667 -86.083333</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Alabama in United States -->
+          <name>Greenville</name>
+          <coordinates>31.829600 -86.617750</coordinates>
+          <location>
+            <name>Mac Crenshaw Memorial Airport</name>
+            <code>KPRN</code>
+            <zone>ALZ057</zone>
+            <radar>bhm</radar>
+            <coordinates>31.845694 -86.610750</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Alabama in United States -->
+          <name>Gulf Shores</name>
+          <coordinates>30.246040 -87.700820</coordinates>
+          <location>
+            <name>Gulf Shores International/Jack Edwards Field</name>
+            <code>KJKA</code>
+            <zone>ALZ262</zone>
+            <radar>bix</radar>
+            <coordinates>30.289639 -87.671778</coordinates>
           </location>
         </city>
         <city>
@@ -28689,6 +39173,18 @@
             <zone>ALZ006</zone>
             <radar>tip</radar>
             <coordinates>34.643611 -86.785556</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Alabama in United States -->
+          <name>Jasper</name>
+          <coordinates>33.831220 -87.277510</coordinates>
+          <location>
+            <name>Walker County/Bevill Field</name>
+            <code>KJFX</code>
+            <zone>ALZ015</zone>
+            <radar>bhm</radar>
+            <coordinates>33.902000 -87.313833</coordinates>
           </location>
         </city>
         <city>
@@ -28759,6 +39255,66 @@
           </location>
         </city>
         <city>
+          <!-- A city in Alabama in United States -->
+          <name>Pell City</name>
+          <coordinates>33.586210 -86.286090</coordinates>
+          <location>
+            <name>St Clair County Airport</name>
+            <code>KPLR</code>
+            <zone>ALZ026</zone>
+            <radar>bhm</radar>
+            <coordinates>33.558833 -86.249056</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Alabama in United States -->
+          <name>Redstone Arsnl Huntsville</name>
+          <coordinates>34.678661 -86.684791</coordinates>
+          <location>
+            <name>Redstone Army Air Field</name>
+            <code>KHUA</code>
+            <zone>ALZ006</zone>
+            <radar>tip</radar>
+            <coordinates>34.678661 -86.684791</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Alabama in United States -->
+          <name>Selma</name>
+          <coordinates>32.407360 -87.021100</coordinates>
+          <location>
+            <name>Craig Field</name>
+            <code>KSEM</code>
+            <zone>ALZ040</zone>
+            <radar>bhm</radar>
+            <coordinates>32.343947 -86.987806</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Alabama in United States -->
+          <name>Sylacauga</name>
+          <coordinates>33.173170 -86.251640</coordinates>
+          <location>
+            <name>Merkel Field Sylacauga Municipal Airport</name>
+            <code>KSCD</code>
+            <zone>ALZ027</zone>
+            <radar>bhm</radar>
+            <coordinates>33.171833 -86.305528</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Alabama in United States -->
+          <name>Talladega</name>
+          <coordinates>33.435940 -86.105800</coordinates>
+          <location>
+            <name>Talladega Municipal Airport</name>
+            <code>KASN</code>
+            <zone>ALZ027</zone>
+            <radar>bhm</radar>
+            <coordinates>33.569504 -86.051201</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Alabama in the United States -->
           <name msgctxt="City in Alabama, United States">Troy</name>
           <coordinates>31.808768 -85.969951</coordinates>
@@ -28797,6 +39353,30 @@
             <zone>AKZ020</zone>
             <radar>alaska</radar>
             <coordinates>51.877778 -176.645833</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Alaska in United States -->
+          <name>Akhiok</name>
+          <coordinates>56.938691 -154.182556</coordinates>
+          <location>
+            <name>Akhiok Airport</name>
+            <code>PAKH</code>
+            <zone>AKZ772</zone>
+            <radar>alaska</radar>
+            <coordinates>56.938691 -154.182556</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Alaska in United States -->
+          <name>Akiachak</name>
+          <coordinates>60.909440 -161.431390</coordinates>
+          <location>
+            <name>Akiachak Airport</name>
+            <code>PFZK</code>
+            <zone>AKZ756</zone>
+            <radar>alaska</radar>
+            <coordinates>60.913810 -161.493329</coordinates>
           </location>
         </city>
         <city>
@@ -28925,6 +39505,31 @@
           </location>
         </city>
         <city>
+          <!-- A city in Alaska in United States -->
+          <name>Atka</name>
+          <coordinates>52.220583 -174.206194</coordinates>
+          <location>
+            <name>Atka Airport</name>
+            <code>PAAK</code>
+            <tz-hint>America/Adak</tz-hint>
+            <zone>AKZ787</zone>
+            <radar>alaska</radar>
+            <coordinates>52.220583 -174.206194</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Alaska in United States -->
+          <name>Atqasuk</name>
+          <coordinates>70.467111 -157.435667</coordinates>
+          <location>
+            <name>Atqasuk Edward Burnell Sr Memorial Airport</name>
+            <code>PATQ</code>
+            <zone>AKZ802</zone>
+            <radar>alaska</radar>
+            <coordinates>70.467111 -157.435667</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Alaska in the United States -->
           <name>Barrow</name>
           <coordinates>71.290556 -156.788611</coordinates>
@@ -28972,6 +39577,18 @@
           </location>
         </city>
         <city>
+          <!-- A city in Alaska in United States -->
+          <name>Brevig Mission</name>
+          <coordinates>65.331333 -166.465722</coordinates>
+          <location>
+            <name>Brevig Mission Airport</name>
+            <code>PFKT</code>
+            <zone>AKZ821</zone>
+            <radar>alaska</radar>
+            <coordinates>65.331333 -166.465722</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Alaska in the United States -->
           <name>Buckland</name>
           <coordinates>65.979722 -161.123056</coordinates>
@@ -28980,6 +39597,18 @@
             <code>PABL</code>
             <radar>alaska</radar>
             <coordinates>65.982222 -161.151944</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Alaska in United States -->
+          <name>Cape Lisburne</name>
+          <coordinates>68.875128 -166.111082</coordinates>
+          <location>
+            <name>Cape Lisburne Lrrs Airport</name>
+            <code>PALU</code>
+            <zone>AKZ801</zone>
+            <radar>alaska</radar>
+            <coordinates>68.875128 -166.111082</coordinates>
           </location>
         </city>
         <city>
@@ -28992,6 +39621,30 @@
             <zone>AKZ004</zone>
             <radar>alaska</radar>
             <coordinates>67.500000 -148.483333</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Alaska in United States -->
+          <name>Chenega</name>
+          <coordinates>60.078561 -147.994735</coordinates>
+          <location>
+            <name>Chenega Bay Airport</name>
+            <code>PFCB</code>
+            <zone>AKZ721</zone>
+            <radar>alaska</radar>
+            <coordinates>60.078561 -147.994735</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Alaska in United States -->
+          <name>Chevak</name>
+          <coordinates>61.527780 -165.586390</coordinates>
+          <location>
+            <name>Chevak Airport</name>
+            <code>PAVA</code>
+            <zone>AKZ825</zone>
+            <radar>alaska</radar>
+            <coordinates>61.540833 -165.600889</coordinates>
           </location>
         </city>
         <city>
@@ -29050,6 +39703,18 @@
           </location>
         </city>
         <city>
+          <!-- A city in Alaska in United States -->
+          <name>Coldfoot</name>
+          <coordinates>67.252171 -150.203908</coordinates>
+          <location>
+            <name>Coldfoot Airport</name>
+            <code>PACX</code>
+            <zone>AKZ812</zone>
+            <radar>alaska</radar>
+            <coordinates>67.252171 -150.203908</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Alaska in the United States -->
           <name>Cordova</name>
           <coordinates>60.542778 -145.757500</coordinates>
@@ -29071,6 +39736,25 @@
             <zone>AKZ001</zone>
             <radar>alaska</radar>
             <coordinates>70.200000 -148.466667</coordinates>
+          </location>
+          <location>
+            <name>Point Thomson Airstrip</name>
+            <code>PAAD</code>
+            <zone>AKZ805</zone>
+            <radar>alaska</radar>
+            <coordinates>70.136000 -146.290028</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Alaska in United States -->
+          <name>Deering</name>
+          <coordinates>66.069111 -162.767056</coordinates>
+          <location>
+            <name>Deering Airport</name>
+            <code>PADE</code>
+            <zone>AKZ818</zone>
+            <radar>alaska</radar>
+            <coordinates>66.069111 -162.767056</coordinates>
           </location>
         </city>
         <city>
@@ -29131,6 +39815,18 @@
           </location>
         </city>
         <city>
+          <!-- A city in Alaska in United States -->
+          <name>Elim</name>
+          <coordinates>64.614972 -162.270528</coordinates>
+          <location>
+            <name>Elim Airport</name>
+            <code>PFEL</code>
+            <zone>AKZ824</zone>
+            <radar>alaska</radar>
+            <coordinates>64.614972 -162.270528</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Alaska in the United States -->
           <name>Emmonak</name>
           <coordinates>62.777778 -164.523056</coordinates>
@@ -29185,6 +39881,18 @@
           </location>
         </city>
         <city>
+          <!-- A city in Alaska in United States -->
+          <name>Fort Richardson</name>
+          <coordinates>61.265900 -149.653308</coordinates>
+          <location>
+            <name>Bryant Army Air Field</name>
+            <code>PAFR</code>
+            <zone>AKZ701</zone>
+            <radar>alaska</radar>
+            <coordinates>61.265900 -149.653308</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Alaska in the United States -->
           <name>Fort Yukon</name>
           <coordinates>66.564722 -145.273889</coordinates>
@@ -29193,6 +39901,18 @@
             <code>PFYU</code>
             <radar>alaska</radar>
             <coordinates>66.566667 -145.266667</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Alaska in United States -->
+          <name>Galbraith Lake</name>
+          <coordinates>68.479667 -149.489917</coordinates>
+          <location>
+            <name>Galbraith Lake Airport</name>
+            <code>PAGB</code>
+            <zone>AKZ809</zone>
+            <radar>alaska</radar>
+            <coordinates>68.479667 -149.489917</coordinates>
           </location>
         </city>
         <city>
@@ -29215,6 +39935,18 @@
             <zone>AKZ006</zone>
             <radar>alaska</radar>
             <coordinates>63.766667 -171.733333</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Alaska in United States -->
+          <name>Golovin</name>
+          <coordinates>64.550459 -163.007172</coordinates>
+          <location>
+            <name>Golovin Airport</name>
+            <code>PAGL</code>
+            <zone>AKZ822</zone>
+            <radar>alaska</radar>
+            <coordinates>64.550459 -163.007172</coordinates>
           </location>
         </city>
         <city>
@@ -29263,6 +39995,18 @@
             <zone>AKZ004</zone>
             <radar>alaska</radar>
             <coordinates>63.866667 -148.966667</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Alaska in United States -->
+          <name>Holy Cross</name>
+          <coordinates>62.188306 -159.774944</coordinates>
+          <location>
+            <name>Holy Cross Airport</name>
+            <code>PAHC</code>
+            <zone>AKZ754</zone>
+            <radar>alaska</radar>
+            <coordinates>62.188306 -159.774944</coordinates>
           </location>
         </city>
         <city>
@@ -29322,6 +40066,18 @@
           </location>
         </city>
         <city>
+          <!-- A city in Alaska in United States -->
+          <name>Igiugig</name>
+          <coordinates>59.324042 -155.901773</coordinates>
+          <location>
+            <name>Igiugig Airport</name>
+            <code>PAIG</code>
+            <zone>AKZ764</zone>
+            <radar>alaska</radar>
+            <coordinates>59.324042 -155.901773</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Alaska in the United States -->
           <name msgctxt="City in Alaska, United States">Juneau</name>
           <coordinates>58.301944 -134.419722</coordinates>
@@ -29357,6 +40113,18 @@
           </location>
         </city>
         <city>
+          <!-- A city in Alaska in United States -->
+          <name>Kalskag</name>
+          <coordinates>61.535972 -160.345583</coordinates>
+          <location>
+            <name>Kalskag Airport</name>
+            <code>PALG</code>
+            <zone>AKZ754</zone>
+            <radar>alaska</radar>
+            <coordinates>61.535972 -160.345583</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Alaska in the United States -->
           <name>Kaltag</name>
           <coordinates>64.327222 -158.721944</coordinates>
@@ -29388,6 +40156,30 @@
             <zone>AKZ027</zone>
             <radar>alaska</radar>
             <coordinates>55.355556 -131.713611</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Alaska in United States -->
+          <name>Kiana</name>
+          <coordinates>66.976178 -160.438599</coordinates>
+          <location>
+            <name>Bob Baker Memorial Airport</name>
+            <code>PAIK</code>
+            <zone>AKZ816</zone>
+            <radar>alaska</radar>
+            <coordinates>66.976178 -160.438599</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Alaska in United States -->
+          <name>King Cove</name>
+          <coordinates>55.060870 -162.318530</coordinates>
+          <location>
+            <name>King Cove Airport</name>
+            <code>PAVC</code>
+            <zone>AKZ781</zone>
+            <radar>alaska</radar>
+            <coordinates>55.116384 -162.266536</coordinates>
           </location>
         </city>
         <city>
@@ -29447,6 +40239,30 @@
           </location>
         </city>
         <city>
+          <!-- A city in Alaska in United States -->
+          <name>Koliganek</name>
+          <coordinates>59.726750 -157.260250</coordinates>
+          <location>
+            <name>Koliganek Airport</name>
+            <code>PAJZ</code>
+            <zone>AKZ761</zone>
+            <radar>alaska</radar>
+            <coordinates>59.726750 -157.260250</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Alaska in United States -->
+          <name>Kotlik</name>
+          <coordinates>63.032980 -163.556270</coordinates>
+          <location>
+            <name>Kotlik Airport</name>
+            <code>PFKO</code>
+            <zone>AKZ825</zone>
+            <radar>alaska</radar>
+            <coordinates>63.030583 -163.532639</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Alaska in the United States -->
           <name>Kotzebue</name>
           <coordinates>66.898333 -162.596667</coordinates>
@@ -29467,6 +40283,18 @@
             <code>PAKK</code>
             <radar>alaska</radar>
             <coordinates>64.933889 -161.158056</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Alaska in United States -->
+          <name>Kuparuk</name>
+          <coordinates>70.330667 -149.598056</coordinates>
+          <location>
+            <name>Ugnu-Kuparuk Airport</name>
+            <code>PAKU</code>
+            <zone>AKZ804</zone>
+            <radar>alaska</radar>
+            <coordinates>70.330667 -149.598056</coordinates>
           </location>
         </city>
         <city>
@@ -29511,6 +40339,31 @@
             <name>Manly Hot Springs Airport</name>
             <code>PAML</code>
             <coordinates>64.983333 -150.633333</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Alaska in United States -->
+          <name>Manokotak</name>
+          <coordinates>58.932056 -158.901889</coordinates>
+          <location>
+            <name>Manokotak Airport</name>
+            <code>PAMB</code>
+            <zone>AKZ765</zone>
+            <radar>alaska</radar>
+            <coordinates>58.932056 -158.901889</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Alaska in United States -->
+          <name>Marshall</name>
+          <coordinates>61.864167 -162.026111</coordinates>
+          <location>
+            <name>Marshall Don Hunter Sr Airport</name>
+            <code>PADM</code>
+            <tz-hint>America/Nome</tz-hint>
+            <zone>AKZ826</zone>
+            <radar>alaska</radar>
+            <coordinates>61.864167 -162.026111</coordinates>
           </location>
         </city>
         <city>
@@ -29572,6 +40425,30 @@
           </location>
         </city>
         <city>
+          <!-- A city in Alaska in United States -->
+          <name>Middleton Island</name>
+          <coordinates>59.449944 -146.307241</coordinates>
+          <location>
+            <name>Middleton Island Airport</name>
+            <code>PAMD</code>
+            <zone>AKZ735</zone>
+            <radar>alaska</radar>
+            <coordinates>59.449944 -146.307241</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Alaska in United States -->
+          <name>Mountain Village</name>
+          <coordinates>62.085560 -163.729440</coordinates>
+          <location>
+            <name>Mountain Village Airport</name>
+            <code>PAMO</code>
+            <zone>AKZ825</zone>
+            <radar>alaska</radar>
+            <coordinates>62.094778 -163.682861</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Alaska in the United States -->
           <name>Nabesna</name>
           <coordinates>62.371944 -143.008611</coordinates>
@@ -29580,6 +40457,18 @@
             <code>PABN</code>
             <radar>alaska</radar>
             <coordinates>62.400000 -143.000000</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Alaska in United States -->
+          <name>Nelson Lagoon</name>
+          <coordinates>56.007536 -161.160367</coordinates>
+          <location>
+            <name>Nelson Lagoon Airport</name>
+            <code>PAOU</code>
+            <zone>AKZ781</zone>
+            <radar>alaska</radar>
+            <coordinates>56.007536 -161.160367</coordinates>
           </location>
         </city>
         <city>
@@ -29595,6 +40484,18 @@
           </location>
         </city>
         <city>
+          <!-- A city in Alaska in United States -->
+          <name>New Stuyahok</name>
+          <coordinates>59.452780 -157.311940</coordinates>
+          <location>
+            <name>New Stuyahok Airport</name>
+            <code>PANW</code>
+            <zone>AKZ761</zone>
+            <radar>alaska</radar>
+            <coordinates>59.451528 -157.373167</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Alaska in the United States -->
           <name>Newhalen</name>
           <coordinates>59.720000 -154.897222</coordinates>
@@ -29604,6 +40505,18 @@
             <zone>AKZ010</zone>
             <radar>alaska</radar>
             <coordinates>59.750000 -154.900000</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Alaska in United States -->
+          <name>Nikolai</name>
+          <coordinates>63.018559 -154.358438</coordinates>
+          <location>
+            <name>Nikolai Airport</name>
+            <code>PAFS</code>
+            <zone>AKZ852</zone>
+            <radar>alaska</radar>
+            <coordinates>63.018559 -154.358438</coordinates>
           </location>
         </city>
         <city>
@@ -29630,6 +40543,18 @@
           </location>
         </city>
         <city>
+          <!-- A city in Alaska in United States -->
+          <name>Noorvik</name>
+          <coordinates>66.838330 -161.032780</coordinates>
+          <location>
+            <name>Robert/Bob/Curtis Memorial Airport</name>
+            <code>PFNO</code>
+            <zone>AKZ816</zone>
+            <radar>alaska</radar>
+            <coordinates>66.817528 -161.022250</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Alaska in the United States -->
           <name>Northway</name>
           <coordinates>62.961667 -141.937222</coordinates>
@@ -29650,6 +40575,18 @@
             <code>PAQT</code>
             <radar>alaska</radar>
             <coordinates>70.210000 -151.005556</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Alaska in United States -->
+          <name>Nulato</name>
+          <coordinates>64.729333 -158.074222</coordinates>
+          <location>
+            <name>Nulato Airport</name>
+            <code>PANU</code>
+            <zone>AKZ829</zone>
+            <radar>alaska</radar>
+            <coordinates>64.729333 -158.074222</coordinates>
           </location>
         </city>
         <city>
@@ -29689,6 +40626,18 @@
           </location>
         </city>
         <city>
+          <!-- A city in Alaska in United States -->
+          <name>Pilot Point</name>
+          <coordinates>57.580381 -157.571957</coordinates>
+          <location>
+            <name>Pilot Point Airport</name>
+            <code>PAPN</code>
+            <zone>AKZ762</zone>
+            <radar>alaska</radar>
+            <coordinates>57.580381 -157.571957</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Alaska in the United States -->
           <name>Platinum</name>
           <coordinates>59.013056 -161.816389</coordinates>
@@ -29697,6 +40646,13 @@
             <code>PAEH</code>
             <radar>alaska</radar>
             <coordinates>58.650000 -162.066667</coordinates>
+          </location>
+          <location>
+            <name>Platinum Airport</name>
+            <code>PAPM</code>
+            <zone>AKZ757</zone>
+            <radar>alaska</radar>
+            <coordinates>59.017831 -161.827192</coordinates>
           </location>
         </city>
         <city>
@@ -29745,6 +40701,13 @@
             <radar>alaska</radar>
             <coordinates>60.200000 -154.316667</coordinates>
           </location>
+          <location>
+            <name>Wilder Runway Airport</name>
+            <code>PAKX</code>
+            <zone>AKZ764</zone>
+            <radar>alaska</radar>
+            <coordinates>60.198481 -154.323049</coordinates>
+          </location>
         </city>
         <city>
           <!-- A city in Alaska in the United States -->
@@ -29756,6 +40719,79 @@
             <zone>AKZ010</zone>
             <radar>alaska</radar>
             <coordinates>56.950000 -158.633333</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Alaska in United States -->
+          <name>Prospect Creek</name>
+          <coordinates>66.814056 -150.643611</coordinates>
+          <location>
+            <name>Prospect Creek Airport</name>
+            <code>PAPR</code>
+            <zone>AKZ832</zone>
+            <radar>alaska</radar>
+            <coordinates>66.814056 -150.643611</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Alaska in United States -->
+          <name>Puntilla Lake</name>
+          <coordinates>62.091000 -152.735000</coordinates>
+          <location>
+            <name>Puntilla Lake</name>
+            <code>PAPT</code>
+            <zone>AKZ748</zone>
+            <radar>alaska</radar>
+            <coordinates>62.091000 -152.735000</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Alaska in United States -->
+          <name>Quinhagak</name>
+          <coordinates>59.748890 -161.915830</coordinates>
+          <location>
+            <name>Quinhagak Airport</name>
+            <code>PAQH</code>
+            <zone>AKZ757</zone>
+            <radar>alaska</radar>
+            <coordinates>59.755093 -161.845366</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Alaska in United States -->
+          <name>Red Dog</name>
+          <coordinates>68.032111 -162.899194</coordinates>
+          <location>
+            <name>Red Dog Airport</name>
+            <code>PADG</code>
+            <tz-hint>America/Nome</tz-hint>
+            <zone>AKZ814</zone>
+            <radar>alaska</radar>
+            <coordinates>68.032111 -162.899194</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Alaska in United States -->
+          <name>Ruby</name>
+          <coordinates>64.727222 -155.469889</coordinates>
+          <location>
+            <name>Ruby Airport</name>
+            <code>PARY</code>
+            <zone>AKZ829</zone>
+            <radar>alaska</radar>
+            <coordinates>64.727222 -155.469889</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Alaska in United States -->
+          <name>Russian Mission</name>
+          <coordinates>61.774890 -161.319399</coordinates>
+          <location>
+            <name>Russian Mission Airport</name>
+            <code>PARS</code>
+            <zone>AKZ826</zone>
+            <radar>alaska</radar>
+            <coordinates>61.774890 -161.319399</coordinates>
           </location>
         </city>
         <city>
@@ -29861,6 +40897,43 @@
           </location>
         </city>
         <city>
+          <!-- A city in Alaska in United States -->
+          <name>Shageluk</name>
+          <coordinates>62.692306 -159.569222</coordinates>
+          <location>
+            <name>Shageluk Airport</name>
+            <code>PAHX</code>
+            <zone>AKZ830</zone>
+            <radar>alaska</radar>
+            <coordinates>62.692306 -159.569222</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Alaska in United States -->
+          <name>Shaktoolik</name>
+          <coordinates>64.371083 -161.223972</coordinates>
+          <location>
+            <name>Shaktoolik Airport</name>
+            <code>PFSH</code>
+            <zone>AKZ824</zone>
+            <radar>alaska</radar>
+            <coordinates>64.371083 -161.223972</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Alaska in United States -->
+          <name>Shemya</name>
+          <coordinates>52.712258 174.113589</coordinates>
+          <location>
+            <name>Eareckson Air Station</name>
+            <code>PASY</code>
+            <tz-hint>America/Adak</tz-hint>
+            <zone>AKZ791</zone>
+            <radar>alaska</radar>
+            <coordinates>52.712258 174.113589</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Alaska in the United States -->
           <name>Shishmaref</name>
           <coordinates>66.256667 -166.071944</coordinates>
@@ -29870,6 +40943,18 @@
             <zone>AKZ006</zone>
             <radar>alaska</radar>
             <coordinates>66.266667 -166.083333</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Alaska in United States -->
+          <name>Shungnak</name>
+          <coordinates>66.888083 -157.162417</coordinates>
+          <location>
+            <name>Shungnak Airport</name>
+            <code>PAGH</code>
+            <zone>AKZ819</zone>
+            <radar>alaska</radar>
+            <coordinates>66.888083 -157.162417</coordinates>
           </location>
         </city>
         <city>
@@ -29920,6 +41005,19 @@
           </location>
         </city>
         <city>
+          <!-- A city in Alaska in United States -->
+          <name>St Michael</name>
+          <coordinates>63.490056 -162.110389</coordinates>
+          <location>
+            <name>St Michael Airport</name>
+            <code>PAMK</code>
+            <tz-hint>America/Nome</tz-hint>
+            <zone>AKZ824</zone>
+            <radar>alaska</radar>
+            <coordinates>63.490056 -162.110389</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Alaska in the United States -->
           <name msgctxt="City in Alaska, United States">Sutton</name>
           <coordinates>61.711389 -148.894167</coordinates>
@@ -29965,6 +41063,18 @@
           </location>
         </city>
         <city>
+          <!-- A city in Alaska in United States -->
+          <name>Teller</name>
+          <coordinates>65.240389 -166.339389</coordinates>
+          <location>
+            <name>Teller Airport</name>
+            <code>PATE</code>
+            <zone>AKZ821</zone>
+            <radar>alaska</radar>
+            <coordinates>65.240389 -166.339389</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Alaska in the United States -->
           <name>Tin City</name>
           <coordinates>65.558611 -167.948056</coordinates>
@@ -29985,6 +41095,30 @@
             <zone>AKZ010</zone>
             <radar>alaska</radar>
             <coordinates>59.050000 -160.400000</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Alaska in United States -->
+          <name>Tok</name>
+          <coordinates>63.336670 -142.985560</coordinates>
+          <location>
+            <name>Tok Junction Airport</name>
+            <code>PFTO</code>
+            <zone>AKZ836</zone>
+            <radar>alaska</radar>
+            <coordinates>63.329514 -142.953684</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Alaska in United States -->
+          <name>Toksook Bay</name>
+          <coordinates>60.533780 -165.103660</coordinates>
+          <location>
+            <name>Toksook Bay Airport</name>
+            <code>PAOO</code>
+            <zone>AKZ755</zone>
+            <radar>alaska</radar>
+            <coordinates>60.541336 -165.087184</coordinates>
           </location>
         </city>
         <city>
@@ -30012,6 +41146,18 @@
           </location>
         </city>
         <city>
+          <!-- A city in Alaska in United States -->
+          <name>Utopia Creek</name>
+          <coordinates>65.992772 -153.703489</coordinates>
+          <location>
+            <name>Indian Mountain Lrrs Airport</name>
+            <code>PAIM</code>
+            <zone>AKZ831</zone>
+            <radar>alaska</radar>
+            <coordinates>65.992772 -153.703489</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Alaska in the United States -->
           <name>Valdez</name>
           <coordinates>61.130833 -146.348333</coordinates>
@@ -30036,6 +41182,18 @@
           </location>
         </city>
         <city>
+          <!-- A city in Alaska in United States -->
+          <name>Wales</name>
+          <coordinates>65.622556 -168.094972</coordinates>
+          <location>
+            <name>Wales Airport</name>
+            <code>PAIW</code>
+            <zone>AKZ821</zone>
+            <radar>alaska</radar>
+            <coordinates>65.622556 -168.094972</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Alaska in the United States -->
           <name>Wasilla</name>
           <coordinates>61.581389 -149.439444</coordinates>
@@ -30044,6 +41202,18 @@
             <code>PAWS</code>
             <radar>alaska</radar>
             <coordinates>61.571944 -149.540556</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Alaska in United States -->
+          <name>White Mountain</name>
+          <coordinates>64.689194 -163.412750</coordinates>
+          <location>
+            <name>White Mountain Airport</name>
+            <code>PAWM</code>
+            <zone>AKZ822</zone>
+            <radar>alaska</radar>
+            <coordinates>64.689194 -163.412750</coordinates>
           </location>
         </city>
         <city>
@@ -30107,6 +41277,18 @@
         <fips-code>US04</fips-code>
         <tz-hint>America/Phoenix</tz-hint>
         <city>
+          <!-- A city in Arizona in United States -->
+          <name>Buckeye</name>
+          <coordinates>33.370320 -112.583780</coordinates>
+          <location>
+            <name>Buckeye Municipal Airport</name>
+            <code>KBXK</code>
+            <zone>AZZ538</zone>
+            <radar>phx</radar>
+            <coordinates>33.422534 -112.686234</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Arizona in the United States -->
           <name>Bullhead City</name>
           <coordinates>35.147777 -114.568298</coordinates>
@@ -30151,6 +41333,18 @@
           </location>
         </city>
         <city>
+          <!-- A city in Arizona in United States -->
+          <name>Colorado City</name>
+          <coordinates>36.990260 -112.975770</coordinates>
+          <location>
+            <name>Colorado City Municipal Airport</name>
+            <code>KAZC</code>
+            <zone>UTZ124</zone>
+            <radar>las</radar>
+            <coordinates>36.959944 -113.013889</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Arizona in the United States -->
           <name msgctxt="City in Arizona, United States">Douglas</name>
           <coordinates>31.344547 -109.545345</coordinates>
@@ -30172,6 +41366,18 @@
             <zone>AZZ015</zone>
             <radar>phx</radar>
             <coordinates>35.140278 -111.672222</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Arizona in United States -->
+          <name>Gila Bend</name>
+          <coordinates>32.947820 -112.716830</coordinates>
+          <location>
+            <name>Gila Bend Af Aux Airport</name>
+            <code>KGXF</code>
+            <zone>AZZ559</zone>
+            <radar>phx</radar>
+            <coordinates>32.887845 -112.719613</coordinates>
           </location>
         </city>
         <city>
@@ -30231,6 +41437,37 @@
           </location>
         </city>
         <city>
+          <!-- A city in Arizona in United States -->
+          <name>Lake Havasu City</name>
+          <coordinates>34.483900 -114.322450</coordinates>
+          <location>
+            <name>Lake Havasu City Airport</name>
+            <code>KHII</code>
+            <zone>AZZ002</zone>
+            <radar>las</radar>
+            <coordinates>34.571124 -114.358277</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Arizona in United States -->
+          <name>Marana</name>
+          <coordinates>32.436740 -111.225380</coordinates>
+          <location>
+            <name>Marana Regional Airport</name>
+            <code>KAVQ</code>
+            <zone>AZZ504</zone>
+            <radar>phx</radar>
+            <coordinates>32.409556 -111.218389</coordinates>
+          </location>
+          <location>
+            <name>Pinal Airpark</name>
+            <code>KMZJ</code>
+            <zone>AZZ505</zone>
+            <radar>phx</radar>
+            <coordinates>32.509833 -111.325333</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Arizona in the United States -->
           <name>Mesa</name>
           <coordinates>33.422269 -111.822640</coordinates>
@@ -30269,6 +41506,18 @@
             <zone>AZZ005</zone>
             <radar>las</radar>
             <coordinates>36.920556 -111.448056</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Arizona in United States -->
+          <name>Payson</name>
+          <coordinates>34.230870 -111.325140</coordinates>
+          <location>
+            <name>Payson Airport</name>
+            <code>KPAN</code>
+            <zone>AZZ018</zone>
+            <radar>phx</radar>
+            <coordinates>34.256836 -111.339256</coordinates>
           </location>
         </city>
         <city>
@@ -30354,6 +41603,18 @@
           </location>
         </city>
         <city>
+          <!-- A city in Arizona in United States -->
+          <name>Sedona</name>
+          <coordinates>34.869740 -111.760990</coordinates>
+          <location>
+            <name>Sedona Airport</name>
+            <code>KSEZ</code>
+            <zone>AZZ038</zone>
+            <radar>phx</radar>
+            <coordinates>34.848589 -111.788448</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Arizona in the United States -->
           <name>Show Low</name>
           <coordinates>34.254208 -110.029833</coordinates>
@@ -30375,6 +41636,37 @@
             <zone>AZZ035</zone>
             <radar>phx</radar>
             <coordinates>31.583333 -110.333333</coordinates>
+          </location>
+          <location>
+            <name>Pioneer Airfield</name>
+            <code>KALK</code>
+            <zone>AZZ513</zone>
+            <radar>phx</radar>
+            <coordinates>31.606000 -110.428000</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Arizona in United States -->
+          <name>Springerville</name>
+          <coordinates>34.133550 -109.288340</coordinates>
+          <location>
+            <name>Springerville Municipal Airport</name>
+            <code>KJTC</code>
+            <zone>AZZ017</zone>
+            <radar>phx</radar>
+            <coordinates>34.129417 -109.310861</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Arizona in United States -->
+          <name>Taylor</name>
+          <coordinates>34.465040 -110.091230</coordinates>
+          <location>
+            <name>Taylor Airport</name>
+            <code>KTYL</code>
+            <zone>AZZ013</zone>
+            <radar>phx</radar>
+            <coordinates>34.452732 -110.115035</coordinates>
           </location>
         </city>
         <city>
@@ -30406,6 +41698,37 @@
             <zone>AZZ033</zone>
             <radar>phx</radar>
             <coordinates>32.131389 -110.955278</coordinates>
+          </location>
+          <location>
+            <name>Ryan Field</name>
+            <code>KRYN</code>
+            <zone>AZZ504</zone>
+            <radar>phx</radar>
+            <coordinates>32.142211 -111.174579</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Arizona in United States -->
+          <name>Wellton</name>
+          <coordinates>32.672830 -114.146880</coordinates>
+          <location>
+            <name>Wellton</name>
+            <code>KNOZ</code>
+            <zone>AZZ532</zone>
+            <radar>phx</radar>
+            <coordinates>32.516667 -114.466667</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Arizona in United States -->
+          <name>Williams</name>
+          <coordinates>35.249460 -112.191000</coordinates>
+          <location>
+            <name>H A Clark Memorial Field</name>
+            <code>KCMR</code>
+            <zone>AZZ015</zone>
+            <radar>phx</radar>
+            <coordinates>35.305494 -112.194348</coordinates>
           </location>
         </city>
         <city>
@@ -30442,6 +41765,18 @@
             <coordinates>32.650000 -114.600000</coordinates>
           </location>
         </city>
+        <city>
+          <!-- A city in Arizona in United States -->
+          <name>Yuma Proving Ground (Yuma)</name>
+          <coordinates>32.864581 -114.392975</coordinates>
+          <location>
+            <name>Laguna Army Air Field (Yuma Proving Ground) Airport</name>
+            <code>KLGF</code>
+            <zone>AZZ532</zone>
+            <radar>phx</radar>
+            <coordinates>32.864581 -114.392975</coordinates>
+          </location>
+        </city>
       </state>
       <state>
         <!-- A state/province/territory in United States -->
@@ -30457,6 +41792,13 @@
             <code>KM89</code>
             <coordinates>34.099722 -93.066111</coordinates>
           </location>
+          <location>
+            <name>Dexter B Florence Memorial Field</name>
+            <code>KADF</code>
+            <zone>ARZ053</zone>
+            <radar>lit</radar>
+            <coordinates>34.099806 -93.066083</coordinates>
+          </location>
         </city>
         <city>
           <!-- A city in Arkansas in the United States -->
@@ -30468,6 +41810,18 @@
             <zone>ARZ016</zone>
             <radar>lit</radar>
             <coordinates>35.733333 -91.650000</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Arkansas in United States -->
+          <name>Benton</name>
+          <coordinates>34.564540 -92.586830</coordinates>
+          <location>
+            <name>Saline County Regional Airport</name>
+            <code>KSUZ</code>
+            <zone>ARZ043</zone>
+            <radar>lit</radar>
+            <coordinates>34.590389 -92.479444</coordinates>
           </location>
         </city>
         <city>
@@ -30500,6 +41854,42 @@
             <name>Camden / Harrell Field</name>
             <code>KCDH</code>
             <coordinates>33.616667 -92.766667</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Arkansas in United States -->
+          <name>Clinton</name>
+          <coordinates>35.591470 -92.460440</coordinates>
+          <location>
+            <name>Clinton Municipal Airport</name>
+            <code>KCCA</code>
+            <zone>ARZ123</zone>
+            <radar>lit</radar>
+            <coordinates>35.597750 -92.451583</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Arkansas in United States -->
+          <name>Colt</name>
+          <coordinates>35.120052 -90.826501</coordinates>
+          <location>
+            <name>Delta Regional Airport</name>
+            <code>KDRP</code>
+            <zone>ARZ048</zone>
+            <radar>lit</radar>
+            <coordinates>35.120052 -90.826501</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Arkansas in United States -->
+          <name>Conway</name>
+          <coordinates>35.088700 -92.442100</coordinates>
+          <location>
+            <name>Conway Regional Airport</name>
+            <code>KCXW</code>
+            <zone>ARZ032</zone>
+            <radar>lit</radar>
+            <coordinates>35.019889 -92.555111</coordinates>
           </location>
         </city>
         <city>
@@ -30615,6 +42005,18 @@
           </location>
         </city>
         <city>
+          <!-- A city in Arkansas in United States -->
+          <name>Magnolia</name>
+          <coordinates>33.267070 -93.239330</coordinates>
+          <location>
+            <name>Ralph C Weiser Field</name>
+            <code>KAGO</code>
+            <zone>ARZ072</zone>
+            <radar>shv</radar>
+            <coordinates>33.227472 -93.217000</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Arkansas in the United States -->
           <name>Mena</name>
           <coordinates>34.586217 -94.239655</coordinates>
@@ -30662,6 +42064,18 @@
             <name>Newport Municipal Airport</name>
             <code>KM19</code>
             <coordinates>35.637500 -91.176111</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Arkansas in United States -->
+          <name>North Little Rock</name>
+          <coordinates>34.769540 -92.267090</coordinates>
+          <location>
+            <name>North Little Rock Municipal Airport</name>
+            <code>KORK</code>
+            <zone>ARZ044</zone>
+            <radar>lit</radar>
+            <coordinates>34.833139 -92.254139</coordinates>
           </location>
         </city>
         <city>
@@ -31011,6 +42425,13 @@
             <radar>lax</radar>
             <coordinates>33.975556 -117.623611</coordinates>
           </location>
+          <location>
+            <name>Corona Municipal Airport</name>
+            <code>KAJO</code>
+            <zone>CAZ554</zone>
+            <radar>lax</radar>
+            <coordinates>33.897654 -117.602440</coordinates>
+          </location>
         </city>
         <city>
           <!-- A city in California in the United States -->
@@ -31058,6 +42479,42 @@
             <zone>CAZ006</zone>
             <radar>sfo</radar>
             <coordinates>37.619722 -122.364722</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in California in United States -->
+          <name>Davis</name>
+          <coordinates>38.544910 -121.740520</coordinates>
+          <location>
+            <name>University Airport</name>
+            <code>KEDU</code>
+            <zone>CAZ153</zone>
+            <radar>sfo</radar>
+            <coordinates>38.531462 -121.786464</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in California in United States -->
+          <name>Davis/Woodland/Winters</name>
+          <coordinates>38.544910 -121.740520</coordinates>
+          <location>
+            <name>Yolo County Airport</name>
+            <code>KDWA</code>
+            <zone>CAZ153</zone>
+            <radar>sfo</radar>
+            <coordinates>38.579389 -121.856944</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in California in United States -->
+          <name>Delano</name>
+          <coordinates>35.768840 -119.247050</coordinates>
+          <location>
+            <name>Delano Municipal Airport</name>
+            <code>KDLO</code>
+            <zone>CAZ310</zone>
+            <radar>fat</radar>
+            <coordinates>35.745556 -119.236500</coordinates>
           </location>
         </city>
         <city>
@@ -31149,6 +42606,30 @@
           </location>
         </city>
         <city>
+          <!-- A city in California in United States -->
+          <name>Fort Irwin/Barstow</name>
+          <coordinates>35.262750 -116.684750</coordinates>
+          <location>
+            <name>Bicycle Lake Army Air Field</name>
+            <code>KBYS</code>
+            <zone>CAZ523</zone>
+            <radar>lax</radar>
+            <coordinates>35.280530 -116.630029</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in California in United States -->
+          <name>Fortuna</name>
+          <coordinates>40.598190 -124.157280</coordinates>
+          <location>
+            <name>Rohnerville Airport</name>
+            <code>KFOT</code>
+            <zone>CAZ101</zone>
+            <radar>rbl</radar>
+            <coordinates>40.553941 -124.132656</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in California in the United States -->
           <name msgctxt="City in California, United States">Fremont</name>
           <coordinates>37.548270 -121.988572</coordinates>
@@ -31170,6 +42651,13 @@
             <zone>CAZ020</zone>
             <radar>fat</radar>
             <coordinates>36.780000 -119.719444</coordinates>
+          </location>
+          <location>
+            <name>Fresno Chandler Executive Airport</name>
+            <code>KFCH</code>
+            <zone>CAZ307</zone>
+            <radar>fat</radar>
+            <coordinates>36.732124 -119.820333</coordinates>
           </location>
         </city>
         <city>
@@ -31195,6 +42683,18 @@
           </location>
         </city>
         <city>
+          <!-- A city in California in United States -->
+          <name>Gardnerville Ranchos</name>
+          <coordinates>38.888240 -119.741290</coordinates>
+          <location>
+            <name>Bridgeport Sonora Junction</name>
+            <code>KBAN</code>
+            <zone>CAZ139</zone>
+            <radar>sfo</radar>
+            <coordinates>38.356000 -119.519000</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in California in the United States -->
           <name msgctxt="City in California, United States">Glendale</name>
           <coordinates>34.142508 -118.255075</coordinates>
@@ -31204,6 +42704,30 @@
             <zone>CAZ047</zone>
             <radar>lax</radar>
             <coordinates>34.199722 -118.364722</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in California in United States -->
+          <name>Grass Valley</name>
+          <coordinates>39.219060 -121.061060</coordinates>
+          <location>
+            <name>Nevada County Airport</name>
+            <code>KGOO</code>
+            <zone>CAZ131</zone>
+            <radar>sfo</radar>
+            <coordinates>39.224060 -121.002549</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in California in United States -->
+          <name>Half Moon Bay</name>
+          <coordinates>37.463550 -122.428590</coordinates>
+          <location>
+            <name>Half Moon Bay Airport</name>
+            <code>KHAF</code>
+            <zone>CAZ509</zone>
+            <radar>sfo</radar>
+            <coordinates>37.513444 -122.501167</coordinates>
           </location>
         </city>
         <city>
@@ -31238,6 +42762,30 @@
             <zone>CAZ007</zone>
             <radar>sfo</radar>
             <coordinates>37.660833 -122.118333</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in California in United States -->
+          <name>Hemet</name>
+          <coordinates>33.747610 -116.973070</coordinates>
+          <location>
+            <name>Hemet-Ryan Airport</name>
+            <code>KHMT</code>
+            <zone>CAZ048</zone>
+            <radar>lax</radar>
+            <coordinates>33.734028 -117.022306</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in California in United States -->
+          <name>Hollister</name>
+          <coordinates>36.852450 -121.401600</coordinates>
+          <location>
+            <name>Hollister Municipal Airport</name>
+            <code>KCVH</code>
+            <zone>CAZ528</zone>
+            <radar>fat</radar>
+            <coordinates>36.893347 -121.410274</coordinates>
           </location>
         </city>
         <city>
@@ -31313,6 +42861,18 @@
           </location>
         </city>
         <city>
+          <!-- A city in California in United States -->
+          <name>Jackson</name>
+          <coordinates>38.348800 -120.774100</coordinates>
+          <location>
+            <name>Westover Field Amador County Airport</name>
+            <code>KJAQ</code>
+            <zone>CAZ134</zone>
+            <radar>sfo</radar>
+            <coordinates>38.376802 -120.793910</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in California in the United States -->
           <name>La Verne</name>
           <coordinates>34.100843 -117.767836</coordinates>
@@ -31346,6 +42906,30 @@
             <zone>CAZ021</zone>
             <radar>fat</radar>
             <coordinates>36.303611 -119.938056</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in California in United States -->
+          <name>Lincoln</name>
+          <coordinates>38.891560 -121.293010</coordinates>
+          <location>
+            <name>Lincoln Regional/Karl Harder Field</name>
+            <code>KLHM</code>
+            <zone>CAZ150</zone>
+            <radar>sfo</radar>
+            <coordinates>38.909167 -121.351333</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in California in United States -->
+          <name>Little River</name>
+          <coordinates>39.262056 -123.753778</coordinates>
+          <location>
+            <name>Little River Airport</name>
+            <code>KLLR</code>
+            <zone>CAZ109</zone>
+            <radar>sfo</radar>
+            <coordinates>39.262056 -123.753778</coordinates>
           </location>
         </city>
         <city>
@@ -31438,6 +43022,30 @@
           </location>
         </city>
         <city>
+          <!-- A city in California in United States -->
+          <name>Mammoth Lakes</name>
+          <coordinates>37.648550 -118.972080</coordinates>
+          <location>
+            <name>Mammoth Yosemite Airport</name>
+            <code>KMMH</code>
+            <zone>CAZ326</zone>
+            <radar>sfo</radar>
+            <coordinates>37.624056 -118.838750</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in California in United States -->
+          <name>Marina</name>
+          <coordinates>36.684400 -121.802170</coordinates>
+          <location>
+            <name>Marina Municipal Airport</name>
+            <code>KOAR</code>
+            <zone>CAZ530</zone>
+            <radar>fat</radar>
+            <coordinates>36.681528 -121.761667</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in California in the United States -->
           <name msgctxt="City in California, United States">Marysville</name>
           <coordinates>39.145725 -121.591355</coordinates>
@@ -31483,6 +43091,18 @@
             <zone>CAZ019</zone>
             <radar>sfo</radar>
             <coordinates>37.624167 -120.950556</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in California in United States -->
+          <name>Mojave</name>
+          <coordinates>35.052470 -118.173960</coordinates>
+          <location>
+            <name>Mojave Air &amp; Space Port/Rutan Field</name>
+            <code>KMHV</code>
+            <zone>CAZ338</zone>
+            <radar>lax</radar>
+            <coordinates>35.058944 -118.150611</coordinates>
           </location>
         </city>
         <city>
@@ -31589,6 +43209,18 @@
             <zone>CAZ042</zone>
             <radar>lax</radar>
             <coordinates>33.871944 -117.984722</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in California in United States -->
+          <name>Novato</name>
+          <coordinates>38.107420 -122.569700</coordinates>
+          <location>
+            <name>Gnoss Field</name>
+            <code>KDVO</code>
+            <zone>CAZ502</zone>
+            <radar>sfo</radar>
+            <coordinates>38.143576 -122.557091</coordinates>
           </location>
         </city>
         <city>
@@ -31738,6 +43370,18 @@
           </location>
         </city>
         <city>
+          <!-- A city in California in United States -->
+          <name>Placerville</name>
+          <coordinates>38.729630 -120.798550</coordinates>
+          <location>
+            <name>Placerville Airport</name>
+            <code>KPVF</code>
+            <zone>CAZ134</zone>
+            <radar>sfo</radar>
+            <coordinates>38.724227 -120.753309</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in California in the United States -->
           <name>Pomona</name>
           <coordinates>34.055289 -117.752279</coordinates>
@@ -31849,6 +43493,13 @@
             <code>KMHR</code>
             <coordinates>38.550000 -121.300000</coordinates>
           </location>
+          <location>
+            <name>Mc Clellan Airfield</name>
+            <code>KMCC</code>
+            <zone>CAZ154</zone>
+            <radar>sfo</radar>
+            <coordinates>38.667639 -121.400611</coordinates>
+          </location>
         </city>
         <city>
           <!-- A city in California in the United States -->
@@ -31863,6 +43514,18 @@
           </location>
         </city>
         <city>
+          <!-- A city in California in United States -->
+          <name>San Andreas</name>
+          <coordinates>38.196030 -120.680490</coordinates>
+          <location>
+            <name>Calaveras County/Maury Rasmussen Field</name>
+            <code>KCPU</code>
+            <zone>CAZ137</zone>
+            <radar>sfo</radar>
+            <coordinates>38.146111 -120.648167</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in California in the United States -->
           <name>San Bernardino</name>
           <coordinates>34.108345 -117.289765</coordinates>
@@ -31872,6 +43535,13 @@
             <zone>CAZ048</zone>
             <radar>lax</radar>
             <coordinates>33.951389 -117.450556</coordinates>
+          </location>
+          <location>
+            <name>San Bernardino International Airport</name>
+            <code>KSBD</code>
+            <zone>CAZ055</zone>
+            <radar>lax</radar>
+            <coordinates>34.095361 -117.234889</coordinates>
           </location>
         </city>
         <city>
@@ -31884,6 +43554,18 @@
             <zone>CAZ006</zone>
             <radar>sfo</radar>
             <coordinates>37.516667 -122.250000</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in California in United States -->
+          <name>San Clemente Island</name>
+          <coordinates>33.022749 -118.588497</coordinates>
+          <location>
+            <name>San Clemente Island Nalf Airport</name>
+            <code>KNUC</code>
+            <zone>CAZ087</zone>
+            <radar>lax</radar>
+            <coordinates>33.022749 -118.588497</coordinates>
           </location>
         </city>
         <city>
@@ -31974,6 +43656,18 @@
           </location>
         </city>
         <city>
+          <!-- A city in California in United States -->
+          <name>San Nicolas Island</name>
+          <coordinates>33.239784 -119.458206</coordinates>
+          <location>
+            <name>San Nicolas Island Nolf Airport</name>
+            <code>KNSI</code>
+            <zone>CAZ550</zone>
+            <radar>lax</radar>
+            <coordinates>33.239784 -119.458206</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in California in the United States -->
           <name>Sandberg</name>
           <coordinates>34.741093 -118.709534</coordinates>
@@ -32057,6 +43751,18 @@
           </location>
         </city>
         <city>
+          <!-- A city in California in United States -->
+          <name>Santa Ynez</name>
+          <coordinates>34.614430 -120.079870</coordinates>
+          <location>
+            <name>Santa Ynez/Kunkle Field</name>
+            <code>KIZA</code>
+            <zone>CAZ348</zone>
+            <radar>lax</radar>
+            <coordinates>34.606815 -120.075550</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in California in the United States -->
           <name>Simi Valley</name>
           <coordinates>34.269447 -118.781482</coordinates>
@@ -32103,6 +43809,30 @@
           </location>
         </city>
         <city>
+          <!-- A city in California in United States -->
+          <name>Susanville</name>
+          <coordinates>40.416280 -120.653010</coordinates>
+          <location>
+            <name>Susanville Municipal Airport</name>
+            <code>KSVE</code>
+            <zone>CAZ071</zone>
+            <radar>sfo</radar>
+            <coordinates>40.375694 -120.572694</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in California in United States -->
+          <name>Tehachapi</name>
+          <coordinates>35.132190 -118.448970</coordinates>
+          <location>
+            <name>Tehachapi Municipal Airport</name>
+            <code>KTSP</code>
+            <zone>CAZ334</zone>
+            <radar>lax</radar>
+            <coordinates>35.134994 -118.439300</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in California in the United States -->
           <name>Thousand Oaks</name>
           <coordinates>34.170561 -118.837594</coordinates>
@@ -32124,6 +43854,18 @@
             <zone>CAZ042</zone>
             <radar>lax</radar>
             <coordinates>33.800000 -118.333333</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in California in United States -->
+          <name>Tracy</name>
+          <coordinates>37.739870 -121.426180</coordinates>
+          <location>
+            <name>Tracy Municipal Airport</name>
+            <code>KTCY</code>
+            <zone>CAZ160</zone>
+            <radar>sfo</radar>
+            <coordinates>37.688895 -121.441575</coordinates>
           </location>
         </city>
         <city>
@@ -32158,6 +43900,18 @@
             <name>Ukiah Municipal Airport</name>
             <code>KUKI</code>
             <coordinates>39.125833 -123.200833</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in California in United States -->
+          <name>Upland</name>
+          <coordinates>34.097510 -117.648390</coordinates>
+          <location>
+            <name>Cable Airport</name>
+            <code>KCCB</code>
+            <zone>CAZ380</zone>
+            <radar>lax</radar>
+            <coordinates>34.111609 -117.687388</coordinates>
           </location>
         </city>
         <city>
@@ -32327,6 +44081,7 @@
           </location>
         </city>
         <city>
+          <!-- A city in Colorado in United States -->
           <name msgctxt="City in Colorado, United States">Boulder</name>
           <coordinates>40.019444 -105.292778</coordinates>
           <location>
@@ -32335,6 +44090,25 @@
             <zone>COZ039</zone>
             <radar>den</radar>
             <coordinates>40.039444 -105.225833</coordinates>
+          </location>
+          <location>
+            <name>Boulder Municipal Airport</name>
+            <code>KBDU</code>
+            <zone>COZ039</zone>
+            <radar>den</radar>
+            <coordinates>40.039365 -105.226090</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Colorado in United States -->
+          <name>Buena Vista</name>
+          <coordinates>38.842220 -106.131130</coordinates>
+          <location>
+            <name>Central Colorado Regional Airport</name>
+            <code>KAEJ</code>
+            <zone>COZ063</zone>
+            <radar>den</radar>
+            <coordinates>38.814194 -106.120611</coordinates>
           </location>
         </city>
         <city>
@@ -32358,6 +44132,18 @@
           </location>
         </city>
         <city>
+          <!-- A city in Colorado in United States -->
+          <name>Cimarron Hills</name>
+          <coordinates>38.858610 -104.698860</coordinates>
+          <location>
+            <name>Schriever Air Force Base</name>
+            <code>KSHM</code>
+            <zone>COZ085</zone>
+            <radar>den</radar>
+            <coordinates>38.800000 -104.517000</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Colorado in the United States -->
           <name>Colorado Springs</name>
           <coordinates>38.833882 -104.821363</coordinates>
@@ -32374,6 +44160,13 @@
             <zone>COZ071</zone>
             <radar>den</radar>
             <coordinates>38.966667 -104.816667</coordinates>
+          </location>
+          <location>
+            <name>Meadow Lake Airport</name>
+            <code>KFLY</code>
+            <zone>COZ084</zone>
+            <radar>den</radar>
+            <coordinates>38.942770 -104.569905</coordinates>
           </location>
         </city>
         <city>
@@ -32401,6 +44194,30 @@
           </location>
         </city>
         <city>
+          <!-- A city in Colorado in United States -->
+          <name>Del Norte</name>
+          <coordinates>37.678890 -106.353370</coordinates>
+          <location>
+            <name>Astronaut Kent Rominger Airport</name>
+            <code>KRCV</code>
+            <zone>COZ067</zone>
+            <radar>pub</radar>
+            <coordinates>37.713784 -106.352018</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Colorado in United States -->
+          <name>Delta</name>
+          <coordinates>38.742210 -108.068960</coordinates>
+          <location>
+            <name>Blake Field</name>
+            <code>KAJZ</code>
+            <zone>COZ011</zone>
+            <radar>slc</radar>
+            <coordinates>38.785603 -108.062014</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Colorado in the United States -->
           <name>Denver</name>
           <coordinates>39.739154 -104.984703</coordinates>
@@ -32422,6 +44239,13 @@
             <name>Denver NEXRAD Station</name>
             <code>KFTG</code>
             <coordinates>39.783333 -104.550000</coordinates>
+          </location>
+          <location>
+            <name>Colorado Air And Space Port Airport</name>
+            <code>KCFO</code>
+            <zone>COZ040</zone>
+            <radar>den</radar>
+            <coordinates>39.784194 -104.537639</coordinates>
           </location>
         </city>
         <city>
@@ -32459,6 +44283,18 @@
           </location>
         </city>
         <city>
+          <!-- A city in Colorado in United States -->
+          <name>Erie</name>
+          <coordinates>40.050260 -105.049980</coordinates>
+          <location>
+            <name>Erie Municipal Airport</name>
+            <code>KEIK</code>
+            <zone>COZ039</zone>
+            <radar>den</radar>
+            <coordinates>40.010250 -105.048083</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Colorado in the United States -->
           <name>Fort Carson</name>
           <coordinates>38.737494 -104.788861</coordinates>
@@ -32468,6 +44304,13 @@
             <zone>COZ071</zone>
             <radar>pub</radar>
             <coordinates>38.700000 -104.766667</coordinates>
+          </location>
+          <location>
+            <name>Cheyenne Mountain Air Station</name>
+            <code>KCWN</code>
+            <zone>COZ082</zone>
+            <radar>pub</radar>
+            <coordinates>38.750000 -104.850000</coordinates>
           </location>
         </city>
         <city>
@@ -32483,6 +44326,30 @@
           </location>
         </city>
         <city>
+          <!-- A city in Colorado in United States -->
+          <name>Fort Morgan</name>
+          <coordinates>40.250260 -103.799950</coordinates>
+          <location>
+            <name>Fort Morgan Municipal Airport</name>
+            <code>KFMM</code>
+            <zone>COZ044</zone>
+            <radar>den</radar>
+            <coordinates>40.335444 -103.804167</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Colorado in United States -->
+          <name>Granby</name>
+          <coordinates>40.086100 -105.939460</coordinates>
+          <location>
+            <name>Granby-Grand County Airport</name>
+            <code>KGNB</code>
+            <zone>COZ032</zone>
+            <radar>den</radar>
+            <coordinates>40.090056 -105.916639</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Colorado in the United States -->
           <name>Grand Junction</name>
           <coordinates>39.063871 -108.550649</coordinates>
@@ -32492,6 +44359,18 @@
             <zone>COZ006</zone>
             <radar>slc</radar>
             <coordinates>39.133889 -108.538611</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Colorado in United States -->
+          <name>Greeley</name>
+          <coordinates>40.423310 -104.709130</coordinates>
+          <location>
+            <name>Greeley-Weld County Airport</name>
+            <code>KGXY</code>
+            <zone>COZ043</zone>
+            <radar>den</radar>
+            <coordinates>40.437417 -104.633222</coordinates>
           </location>
         </city>
         <city>
@@ -32516,6 +44395,18 @@
             <zone>COZ005</zone>
             <radar>den</radar>
             <coordinates>40.483333 -107.216667</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Colorado in United States -->
+          <name>Holyoke</name>
+          <coordinates>40.584440 -102.302410</coordinates>
+          <location>
+            <name>Holyoke Airport</name>
+            <code>KHEQ</code>
+            <zone>COZ051</zone>
+            <radar>den</radar>
+            <coordinates>40.569430 -102.272689</coordinates>
           </location>
         </city>
         <city>
@@ -32587,6 +44478,18 @@
           </location>
         </city>
         <city>
+          <!-- A city in Colorado in United States -->
+          <name>Longmont</name>
+          <coordinates>40.167210 -105.101930</coordinates>
+          <location>
+            <name>Vance Brand Airport</name>
+            <code>KLMO</code>
+            <zone>COZ039</zone>
+            <radar>den</radar>
+            <coordinates>40.164389 -105.163639</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Colorado in the United States -->
           <name>Meeker</name>
           <coordinates>40.037473 -107.913130</coordinates>
@@ -32609,6 +44512,18 @@
           </location>
         </city>
         <city>
+          <!-- A city in Colorado in United States -->
+          <name>Nucla</name>
+          <coordinates>38.269430 -108.547870</coordinates>
+          <location>
+            <name>Hopkins Field</name>
+            <code>KAIB</code>
+            <zone>COZ020</zone>
+            <radar>slc</radar>
+            <coordinates>38.239002 -108.562807</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Colorado in the United States -->
           <name>Pagosa Springs</name>
           <coordinates>37.269450 -107.009762</coordinates>
@@ -32616,6 +44531,13 @@
             <name>Pagosa Springs, Wolf Creek Pass</name>
             <code>KCPW</code>
             <coordinates>37.451389 -106.800278</coordinates>
+          </location>
+          <location>
+            <name>Stevens Field</name>
+            <code>KPSO</code>
+            <zone>COZ023</zone>
+            <radar>pub</radar>
+            <coordinates>37.286249 -107.056009</coordinates>
           </location>
         </city>
         <city>
@@ -32659,6 +44581,13 @@
             <code>KMYP</code>
             <coordinates>38.484444 -106.316944</coordinates>
           </location>
+          <location>
+            <name>Salida/Harriett Alexander Field</name>
+            <code>KANK</code>
+            <zone>COZ062</zone>
+            <radar>den</radar>
+            <coordinates>38.538278 -106.048639</coordinates>
+          </location>
         </city>
         <city>
           <!-- A city in Colorado in the United States -->
@@ -32678,6 +44607,25 @@
             <name>Mount Werner</name>
             <code>K3MW</code>
             <coordinates>40.450000 -106.750000</coordinates>
+          </location>
+          <location>
+            <name>Steamboat Springs/Bob Adams Field</name>
+            <code>KSBS</code>
+            <zone>COZ004</zone>
+            <radar>den</radar>
+            <coordinates>40.516261 -106.866302</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Colorado in United States -->
+          <name>Sterling</name>
+          <coordinates>40.625540 -103.207710</coordinates>
+          <location>
+            <name>Sterling Municipal Airport</name>
+            <code>KSTK</code>
+            <zone>COZ048</zone>
+            <radar>den</radar>
+            <coordinates>40.614298 -103.264261</coordinates>
           </location>
         </city>
         <city>
@@ -32713,6 +44661,18 @@
           </location>
         </city>
         <city>
+          <!-- A city in Colorado in United States -->
+          <name>Vail</name>
+          <coordinates>39.640260 -106.374200</coordinates>
+          <location>
+            <name>Copper Mountain</name>
+            <code>KCCU</code>
+            <zone>COZ058</zone>
+            <radar>den</radar>
+            <coordinates>39.467000 -106.150000</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Colorado in the United States -->
           <name>Westminster</name>
           <coordinates>39.836653 -105.037205</coordinates>
@@ -32740,6 +44700,18 @@
             <zone>CTZ009</zone>
             <radar>nyc</radar>
             <coordinates>41.158333 -73.128889</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Connecticut in United States -->
+          <name>Chester</name>
+          <coordinates>41.383709 -72.505787</coordinates>
+          <location>
+            <name>Chester Airport</name>
+            <code>KSNC</code>
+            <zone>CTZ011</zone>
+            <radar>nyc</radar>
+            <coordinates>41.383709 -72.505787</coordinates>
           </location>
         </city>
         <city>
@@ -32837,6 +44809,18 @@
           </location>
         </city>
         <city>
+          <!-- A city in Connecticut in United States -->
+          <name>Willimantic</name>
+          <coordinates>41.710650 -72.208130</coordinates>
+          <location>
+            <name>Windham Airport</name>
+            <code>KIJD</code>
+            <zone>CTZ003</zone>
+            <radar>nyc</radar>
+            <coordinates>41.744028 -72.180222</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Connecticut in the United States -->
           <name>Windsor Locks</name>
           <coordinates>41.929264 -72.627312</coordinates>
@@ -32930,6 +44914,18 @@
           </location>
         </city>
         <city>
+          <!-- A city in Florida in United States -->
+          <name>Avon Park</name>
+          <coordinates>27.595870 -81.506190</coordinates>
+          <location>
+            <name>Macdill Afb Aux Field</name>
+            <code>KAGR</code>
+            <zone>FLZ057</zone>
+            <radar>tpa</radar>
+            <coordinates>27.647850 -81.341564</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Florida in the United States -->
           <name>Bartow</name>
           <coordinates>27.896415 -81.843137</coordinates>
@@ -32951,6 +44947,19 @@
           </location>
         </city>
         <city>
+          <!-- A city in Florida in United States -->
+          <name>Bonifay</name>
+          <coordinates>30.791860 -85.679650</coordinates>
+          <location>
+            <name>Tri-County Airport</name>
+            <code>KBCR</code>
+            <tz-hint>America/Chicago</tz-hint>
+            <zone>FLZ009</zone>
+            <radar>tlh</radar>
+            <coordinates>30.843886 -85.601749</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Florida in the United States -->
           <name>Brooksville</name>
           <coordinates>28.555272 -82.387871</coordinates>
@@ -32960,6 +44969,19 @@
             <zone>FLZ048</zone>
             <radar>tpa</radar>
             <coordinates>28.473611 -82.454444</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Florida in United States -->
+          <name>Callaway</name>
+          <coordinates>30.152980 -85.569930</coordinates>
+          <location>
+            <name>Tyndall Drone Runway</name>
+            <code>KTDR</code>
+            <tz-hint>America/Chicago</tz-hint>
+            <zone>FLZ112</zone>
+            <radar>tlh</radar>
+            <coordinates>30.033000 -85.533000</coordinates>
           </location>
         </city>
         <city>
@@ -32994,6 +45016,13 @@
             <zone>FLZ050</zone>
             <radar>tpa</radar>
             <coordinates>27.912222 -82.685556</coordinates>
+          </location>
+          <location>
+            <name>Clearwater Executive Airport</name>
+            <code>KCLW</code>
+            <zone>FLZ050</zone>
+            <radar>tpa</radar>
+            <coordinates>27.977214 -82.759057</coordinates>
           </location>
         </city>
         <city>
@@ -33042,6 +45071,18 @@
           </location>
         </city>
         <city>
+          <!-- A city in Florida in United States -->
+          <name>Crystal River</name>
+          <coordinates>28.902480 -82.592600</coordinates>
+          <location>
+            <name>Crystal River/Davis Field</name>
+            <code>KCGC</code>
+            <zone>FLZ142</zone>
+            <radar>tpa</radar>
+            <coordinates>28.867611 -82.574111</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Florida in the United States -->
           <name>Daytona Beach</name>
           <coordinates>29.210815 -81.022833</coordinates>
@@ -33054,6 +45095,18 @@
           </location>
         </city>
         <city>
+          <!-- A city in Florida in United States -->
+          <name>Deland</name>
+          <coordinates>29.028320 -81.303120</coordinates>
+          <location>
+            <name>Deland Municipal-Sidney H Taylor Field</name>
+            <code>KDED</code>
+            <zone>FLZ041</zone>
+            <radar>tpa</radar>
+            <coordinates>29.067031 -81.283757</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Florida in the United States -->
           <name>Destin</name>
           <coordinates>30.393534 -86.495783</coordinates>
@@ -33063,6 +45116,18 @@
             <tz-hint>America/Chicago</tz-hint>
             <radar>bix</radar>
             <coordinates>30.393333 -86.467500</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Florida in United States -->
+          <name>Fernandina Beach</name>
+          <coordinates>30.669680 -81.462590</coordinates>
+          <location>
+            <name>Fernandina Beach Municipal Airport</name>
+            <code>KFHB</code>
+            <zone>FLZ125</zone>
+            <radar>tlh</radar>
+            <coordinates>30.611833 -81.461194</coordinates>
           </location>
         </city>
         <city>
@@ -33124,6 +45189,14 @@
             <radar>bix</radar>
             <coordinates>30.416667 -86.683333</coordinates>
           </location>
+          <location>
+            <name>Hurlbert</name>
+            <code>KQHY</code>
+            <tz-hint>America/Chicago</tz-hint>
+            <zone>FLZ206</zone>
+            <radar>bix</radar>
+            <coordinates>30.400000 -86.650000</coordinates>
+          </location>
         </city>
         <city>
           <!-- A city in Florida in the United States -->
@@ -33172,6 +45245,18 @@
           </location>
         </city>
         <city>
+          <!-- A city in Florida in United States -->
+          <name>Inverness</name>
+          <coordinates>28.835820 -82.330370</coordinates>
+          <location>
+            <name>Inverness Airport</name>
+            <code>KINF</code>
+            <zone>FLZ142</zone>
+            <radar>tpa</radar>
+            <coordinates>28.803613 -82.318291</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Florida in the United States -->
           <name msgctxt="City in Florida, United States">Jacksonville</name>
           <coordinates>30.332184 -81.655651</coordinates>
@@ -33201,6 +45286,20 @@
             <code>KVQQ</code>
             <coordinates>30.218611 -81.876667</coordinates>
           </location>
+          <location>
+            <name>Herlong Recreational Airport</name>
+            <code>KHEG</code>
+            <zone>FLZ425</zone>
+            <radar>tlh</radar>
+            <coordinates>30.277786 -81.805946</coordinates>
+          </location>
+          <location>
+            <name>Whitehouse Nolf Airport</name>
+            <code>KNEN</code>
+            <zone>FLZ425</zone>
+            <radar>tlh</radar>
+            <coordinates>30.349495 -81.866989</coordinates>
+          </location>
         </city>
         <city>
           <!-- A city in Florida in the United States -->
@@ -33219,6 +45318,18 @@
             <zone>FLZ075</zone>
             <radar>mia</radar>
             <coordinates>24.579444 -81.683889</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Florida in United States -->
+          <name>Lake City</name>
+          <coordinates>30.189680 -82.639290</coordinates>
+          <location>
+            <name>Lake City Gateway Airport</name>
+            <code>KLCQ</code>
+            <zone>FLZ422</zone>
+            <radar>tlh</radar>
+            <coordinates>30.182056 -82.576861</coordinates>
           </location>
         </city>
         <city>
@@ -33336,6 +45447,14 @@
             <radar>bix</radar>
             <coordinates>30.724167 -87.021944</coordinates>
           </location>
+          <location>
+            <name>Choctaw Nolf Airport</name>
+            <code>KNFJ</code>
+            <tz-hint>America/Chicago</tz-hint>
+            <zone>FLZ204</zone>
+            <radar>bix</radar>
+            <coordinates>30.506944 -86.959722</coordinates>
+          </location>
         </city>
         <city>
           <!-- A city in Florida in the United States -->
@@ -33423,6 +45542,18 @@
           </location>
         </city>
         <city>
+          <!-- A city in Florida in United States -->
+          <name>Palm Coast</name>
+          <coordinates>29.584970 -81.207840</coordinates>
+          <location>
+            <name>Flagler Executive Airport</name>
+            <code>KFIN</code>
+            <zone>FLZ138</zone>
+            <radar>tpa</radar>
+            <coordinates>29.465151 -81.207648</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Florida in the United States -->
           <name>Panama City</name>
           <coordinates>30.158813 -85.660206</coordinates>
@@ -33433,6 +45564,19 @@
             <zone>FLZ012</zone>
             <radar>tlh</radar>
             <coordinates>30.207500 -85.685000</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Florida in United States -->
+          <name>Panama City Beach</name>
+          <coordinates>30.176590 -85.805490</coordinates>
+          <location>
+            <name>Northwest Florida Beaches International Airport</name>
+            <code>KECP</code>
+            <tz-hint>America/Chicago</tz-hint>
+            <zone>FLZ112</zone>
+            <radar>tlh</radar>
+            <coordinates>30.358241 -85.795602</coordinates>
           </location>
         </city>
         <city>
@@ -33476,6 +45620,25 @@
             <radar>tlh</radar>
             <coordinates>30.071944 -83.573611</coordinates>
           </location>
+          <location>
+            <name>Perry-Foley Airport</name>
+            <code>KFPY</code>
+            <zone>FLZ028</zone>
+            <radar>tlh</radar>
+            <coordinates>30.070812 -83.581544</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Florida in United States -->
+          <name>Plant City</name>
+          <coordinates>28.018880 -82.114690</coordinates>
+          <location>
+            <name>Plant City Airport</name>
+            <code>KPCM</code>
+            <zone>FLZ251</zone>
+            <radar>tpa</radar>
+            <coordinates>28.000167 -82.163306</coordinates>
+          </location>
         </city>
         <city>
           <!-- A city in Florida in the United States -->
@@ -33509,6 +45672,18 @@
             <zone>FLZ060</zone>
             <radar>tpa</radar>
             <coordinates>27.401389 -82.558611</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Florida in United States -->
+          <name>Sebring</name>
+          <coordinates>27.495590 -81.440910</coordinates>
+          <location>
+            <name>Sebring Regional Airport</name>
+            <code>KSEF</code>
+            <zone>FLZ057</zone>
+            <radar>tpa</radar>
+            <coordinates>27.456389 -81.342389</coordinates>
           </location>
         </city>
         <city>
@@ -33655,6 +45830,13 @@
             <radar>mia</radar>
             <coordinates>26.684722 -80.099444</coordinates>
           </location>
+          <location>
+            <name>Palm Beach County Park Airport</name>
+            <code>KLNA</code>
+            <zone>FLZ068</zone>
+            <radar>mia</radar>
+            <coordinates>26.593046 -80.085064</coordinates>
+          </location>
         </city>
         <city>
           <!-- A city in Florida in the United States -->
@@ -33665,6 +45847,18 @@
             <code>KGIF</code>
             <radar>tpa</radar>
             <coordinates>28.060556 -81.757500</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Florida in United States -->
+          <name>Zephyrhills</name>
+          <coordinates>28.233620 -82.181190</coordinates>
+          <location>
+            <name>Zephyrhills Municipal Airport</name>
+            <code>KZPH</code>
+            <zone>FLZ149</zone>
+            <radar>tpa</radar>
+            <coordinates>28.226669 -82.155645</coordinates>
           </location>
         </city>
       </state>
@@ -33695,6 +45889,18 @@
             <zone>GAZ134</zone>
             <radar>tlh</radar>
             <coordinates>31.536111 -82.506667</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in United States -->
+          <name>Americus</name>
+          <coordinates>32.072390 -84.232690</coordinates>
+          <location>
+            <name>Jimmy Carter Regional Airport</name>
+            <code>KACJ</code>
+            <zone>GAZ104</zone>
+            <radar>tlh</radar>
+            <coordinates>32.110806 -84.188861</coordinates>
           </location>
         </city>
         <city>
@@ -33741,6 +45947,27 @@
             <radar>atl</radar>
             <coordinates>33.355278 -84.566944</coordinates>
           </location>
+          <location>
+            <name>Atlanta Speedway Airport</name>
+            <code>KHMP</code>
+            <zone>GAZ056</zone>
+            <radar>atl</radar>
+            <coordinates>33.389902 -84.331037</coordinates>
+          </location>
+          <location>
+            <name>Covington Municipal Airport</name>
+            <code>KCVC</code>
+            <zone>GAZ048</zone>
+            <radar>atl</radar>
+            <coordinates>33.632247 -83.846619</coordinates>
+          </location>
+          <location>
+            <name>Paulding Northwest Atlanta Airport</name>
+            <code>KPUJ</code>
+            <zone>GAZ031</zone>
+            <radar>atl</radar>
+            <coordinates>33.912043 -84.940619</coordinates>
+          </location>
         </city>
         <city>
           <!-- A city in Georgia in the United States -->
@@ -33782,6 +46009,42 @@
           </location>
         </city>
         <city>
+          <!-- A city in United States -->
+          <name>Baxley</name>
+          <coordinates>31.778250 -82.348460</coordinates>
+          <location>
+            <name>Baxley Municipal Airport</name>
+            <code>KBHC</code>
+            <zone>GAZ135</zone>
+            <radar>tlh</radar>
+            <coordinates>31.713833 -82.393778</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in United States -->
+          <name>Blairsville</name>
+          <coordinates>34.876200 -83.958240</coordinates>
+          <location>
+            <name>Blairsville Airport</name>
+            <code>KDZJ</code>
+            <zone>GAZ008</zone>
+            <radar>atl</radar>
+            <coordinates>34.854431 -83.997320</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in United States -->
+          <name>Blakely</name>
+          <coordinates>31.377680 -84.934090</coordinates>
+          <location>
+            <name>Early County Airport</name>
+            <code>KBIJ</code>
+            <zone>GAZ142</zone>
+            <radar>tlh</radar>
+            <coordinates>31.397509 -84.894798</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Georgia in the United States -->
           <name msgctxt="City in Georgia, United States">Brunswick</name>
           <coordinates>31.149953 -81.491489</coordinates>
@@ -33799,6 +46062,30 @@
           </location>
         </city>
         <city>
+          <!-- A city in United States -->
+          <name>Calhoun</name>
+          <coordinates>34.502590 -84.951050</coordinates>
+          <location>
+            <name>Tom B David Field</name>
+            <code>KCZL</code>
+            <zone>GAZ012</zone>
+            <radar>atl</radar>
+            <coordinates>34.455402 -84.939155</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in United States -->
+          <name>Camilla</name>
+          <coordinates>31.231290 -84.210460</coordinates>
+          <location>
+            <name>Camilla-Mitchell County Airport</name>
+            <code>KCXU</code>
+            <zone>GAZ145</zone>
+            <radar>tlh</radar>
+            <coordinates>31.213167 -84.235222</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Georgia in the United States -->
           <name>Canton</name>
           <coordinates>34.236762 -84.490762</coordinates>
@@ -33806,6 +46093,25 @@
             <name>Cherokee County Airport</name>
             <code>K47A</code>
             <coordinates>34.310556 -84.423889</coordinates>
+          </location>
+          <location>
+            <name>Cherokee County Regional Airport</name>
+            <code>KCNI</code>
+            <zone>GAZ021</zone>
+            <radar>atl</radar>
+            <coordinates>34.312196 -84.422123</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in United States -->
+          <name>Carrollton</name>
+          <coordinates>33.580110 -85.076610</coordinates>
+          <location>
+            <name>West Georgia Regional/O V Gray Field</name>
+            <code>KCTJ</code>
+            <zone>GAZ042</zone>
+            <radar>atl</radar>
+            <coordinates>33.631696 -85.152265</coordinates>
           </location>
         </city>
         <city>
@@ -33819,6 +46125,18 @@
           </location>
         </city>
         <city>
+          <!-- A city in United States -->
+          <name>Claxton</name>
+          <coordinates>32.161580 -81.904000</coordinates>
+          <location>
+            <name>Claxton-Evans County Airport</name>
+            <code>KCWV</code>
+            <zone>GAZ115</zone>
+            <radar>tlh</radar>
+            <coordinates>32.195057 -81.869317</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Georgia in the United States -->
           <name msgctxt="City in Georgia, United States">Columbus</name>
           <coordinates>32.460976 -84.987709</coordinates>
@@ -33828,6 +46146,30 @@
             <zone>GAZ089</zone>
             <radar>bhm</radar>
             <coordinates>32.516111 -84.942222</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in United States -->
+          <name>Cordele</name>
+          <coordinates>31.963510 -83.782390</coordinates>
+          <location>
+            <name>Crisp County-Cordele Airport</name>
+            <code>KCKF</code>
+            <zone>GAZ106</zone>
+            <radar>tlh</radar>
+            <coordinates>31.988844 -83.773906</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in United States -->
+          <name>Cornelia</name>
+          <coordinates>34.511490 -83.527120</coordinates>
+          <location>
+            <name>Habersham County Airport</name>
+            <code>KAJR</code>
+            <zone>GAZ017</zone>
+            <radar>atl</radar>
+            <coordinates>34.499852 -83.556665</coordinates>
           </location>
         </city>
         <city>
@@ -33861,6 +46203,42 @@
           </location>
         </city>
         <city>
+          <!-- A city in United States -->
+          <name>Eastman</name>
+          <coordinates>32.197670 -83.177650</coordinates>
+          <location>
+            <name>Heart Of Georgia Regional Airport</name>
+            <code>KEZM</code>
+            <zone>GAZ109</zone>
+            <radar>atl</radar>
+            <coordinates>32.216389 -83.128667</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in United States -->
+          <name>Elberton</name>
+          <coordinates>34.111590 -82.868630</coordinates>
+          <location>
+            <name>Elbert County-Patz Field</name>
+            <code>KEBA</code>
+            <zone>GAZ029</zone>
+            <radar>atl</radar>
+            <coordinates>34.095402 -82.817493</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in United States -->
+          <name>Fitzgerald</name>
+          <coordinates>31.714910 -83.252650</coordinates>
+          <location>
+            <name>Fitzgerald Municipal Airport</name>
+            <code>KFZG</code>
+            <zone>GAZ131</zone>
+            <radar>tlh</radar>
+            <coordinates>31.683905 -83.270904</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Georgia in the United States -->
           <name>Fort Benning</name>
           <coordinates>32.352369 -84.968819</coordinates>
@@ -33891,6 +46269,25 @@
             <code>K3J7</code>
             <coordinates>33.597500 -83.138889</coordinates>
           </location>
+          <location>
+            <name>Greene County Regional Airport</name>
+            <code>KCPP</code>
+            <zone>GAZ050</zone>
+            <radar>atl</radar>
+            <coordinates>33.597970 -83.138260</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in United States -->
+          <name>Hazlehurst</name>
+          <coordinates>31.869630 -82.594300</coordinates>
+          <location>
+            <name>Hazlehurst Airport</name>
+            <code>KAZE</code>
+            <zone>GAZ133</zone>
+            <radar>tlh</radar>
+            <coordinates>31.885190 -82.647891</coordinates>
+          </location>
         </city>
         <city>
           <!-- A city in Georgia in the United States -->
@@ -33902,6 +46299,42 @@
             <zone>GAZ138</zone>
             <radar>tlh</radar>
             <coordinates>31.883333 -81.566667</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in United States -->
+          <name>Homerville</name>
+          <coordinates>31.036600 -82.747080</coordinates>
+          <location>
+            <name>Homerville Airport</name>
+            <code>KHOE</code>
+            <zone>GAZ163</zone>
+            <radar>tlh</radar>
+            <coordinates>31.056889 -82.775278</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in United States -->
+          <name>Jefferson</name>
+          <coordinates>34.117050 -83.572390</coordinates>
+          <location>
+            <name>Jackson County Airport</name>
+            <code>KJCA</code>
+            <zone>GAZ025</zone>
+            <radar>atl</radar>
+            <coordinates>34.176139 -83.561694</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in United States -->
+          <name>Jesup</name>
+          <coordinates>31.607850 -81.886340</coordinates>
+          <location>
+            <name>Jesup-Wayne County Airport</name>
+            <code>KJES</code>
+            <zone>GAZ136</zone>
+            <radar>tlh</radar>
+            <coordinates>31.553963 -81.882518</coordinates>
           </location>
         </city>
         <city>
@@ -33954,6 +46387,30 @@
           </location>
         </city>
         <city>
+          <!-- A city in United States -->
+          <name>Mc Rae</name>
+          <coordinates>32.096996 -82.879412</coordinates>
+          <location>
+            <name>Telfair-Wheeler Airport</name>
+            <code>KMQW</code>
+            <zone>GAZ111</zone>
+            <radar>tlh</radar>
+            <coordinates>32.096996 -82.879412</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in United States -->
+          <name>Metter</name>
+          <coordinates>32.397120 -82.060120</coordinates>
+          <location>
+            <name>John Edwin Jones Sr Field/Metter Municipal Airport</name>
+            <code>KMHP</code>
+            <zone>GAZ099</zone>
+            <radar>tlh</radar>
+            <coordinates>32.373972 -82.081444</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Georgia in the United States -->
           <name>Milledgeville</name>
           <coordinates>33.080143 -83.232099</coordinates>
@@ -33982,6 +46439,42 @@
             <name>Newnan Coweta County Airport</name>
             <code>KCCO</code>
             <coordinates>33.312222 -84.770278</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in United States -->
+          <name>Perry</name>
+          <coordinates>32.458210 -83.731570</coordinates>
+          <location>
+            <name>Perry-Houston County Airport</name>
+            <code>KPXE</code>
+            <zone>GAZ094</zone>
+            <radar>atl</radar>
+            <coordinates>32.510581 -83.767346</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in United States -->
+          <name>Pine Mountain</name>
+          <coordinates>32.864850 -84.854100</coordinates>
+          <location>
+            <name>Harris County Airport</name>
+            <code>KPIM</code>
+            <zone>GAZ078</zone>
+            <radar>bhm</radar>
+            <coordinates>32.840694 -84.882444</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in United States -->
+          <name>Reidsville</name>
+          <coordinates>32.086860 -82.117900</coordinates>
+          <location>
+            <name>Swinton Smith Field At Reidsville Municipal Airport</name>
+            <code>KRVJ</code>
+            <zone>GAZ114</zone>
+            <radar>tlh</radar>
+            <coordinates>32.059487 -82.153577</coordinates>
           </location>
         </city>
         <city>
@@ -34026,6 +46519,18 @@
           </location>
         </city>
         <city>
+          <!-- A city in United States -->
+          <name>Swainsboro</name>
+          <coordinates>32.597390 -82.333740</coordinates>
+          <location>
+            <name>East Georgia Regional Airport</name>
+            <code>KSBO</code>
+            <zone>GAZ086</zone>
+            <radar>atl</radar>
+            <coordinates>32.609139 -82.369944</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Georgia in the United States -->
           <name>Sylvania</name>
           <coordinates>32.750444 -81.636776</coordinates>
@@ -34046,6 +46551,18 @@
           </location>
         </city>
         <city>
+          <!-- A city in United States -->
+          <name>Thomasville</name>
+          <coordinates>30.836580 -83.978780</coordinates>
+          <location>
+            <name>Thomasville Regional Airport</name>
+            <code>KTVI</code>
+            <zone>GAZ158</zone>
+            <radar>tlh</radar>
+            <coordinates>30.901472 -83.881444</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Georgia in the United States -->
           <name>Thomson</name>
           <coordinates>33.470693 -82.504573</coordinates>
@@ -34053,6 +46570,30 @@
             <name>Thomson-McDuffie County Airport</name>
             <code>KHQU</code>
             <coordinates>33.529444 -82.516389</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in United States -->
+          <name>Tifton</name>
+          <coordinates>31.450460 -83.508500</coordinates>
+          <location>
+            <name>Henry Tift Myers Airport</name>
+            <code>KTMA</code>
+            <zone>GAZ129</zone>
+            <radar>tlh</radar>
+            <coordinates>31.429556 -83.489222</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in United States -->
+          <name>Toccoa</name>
+          <coordinates>34.577320 -83.332390</coordinates>
+          <location>
+            <name>Toccoa Rg Letourneau Field</name>
+            <code>KTOC</code>
+            <zone>GAZ018</zone>
+            <radar>atl</radar>
+            <coordinates>34.592812 -83.296372</coordinates>
           </location>
         </city>
         <city>
@@ -34087,6 +46628,18 @@
             <zone>GAZ095</zone>
             <radar>atl</radar>
             <coordinates>32.633333 -83.600000</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in United States -->
+          <name>Washington</name>
+          <coordinates>33.736790 -82.739310</coordinates>
+          <location>
+            <name>Washington/Wilkes County Airport</name>
+            <code>KIIY</code>
+            <zone>GAZ039</zone>
+            <radar>atl</radar>
+            <coordinates>33.778598 -82.814497</coordinates>
           </location>
         </city>
         <city>
@@ -34323,6 +46876,45 @@
           </location>
         </city>
         <city>
+          <!-- A city in Idaho in United States -->
+          <name>Driggs</name>
+          <coordinates>43.723250 -111.111330</coordinates>
+          <location>
+            <name>Driggs/Reed Memorial Airport</name>
+            <code>KDIJ</code>
+            <tz-hint>America/Boise</tz-hint>
+            <zone>IDZ065</zone>
+            <radar>boi</radar>
+            <coordinates>43.746257 -111.091300</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Idaho in United States -->
+          <name>Gooding</name>
+          <coordinates>42.938790 -114.713110</coordinates>
+          <location>
+            <name>Gooding Municipal Airport</name>
+            <code>KGNG</code>
+            <tz-hint>America/Boise</tz-hint>
+            <zone>IDZ016</zone>
+            <radar>boi</radar>
+            <coordinates>42.917081 -114.766338</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Idaho in United States -->
+          <name>Grangeville</name>
+          <coordinates>45.926550 -116.122370</coordinates>
+          <location>
+            <name>Idaho County Airport</name>
+            <code>KGIC</code>
+            <tz-hint>America/Los_Angeles</tz-hint>
+            <zone>IDZ007</zone>
+            <radar>geg</radar>
+            <coordinates>45.942667 -116.123028</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Idaho in the United States -->
           <name>Hailey</name>
           <coordinates>43.519629 -114.315325</coordinates>
@@ -34439,6 +47031,19 @@
             <code>KMLP</code>
             <tz-hint>America/Los_Angeles</tz-hint>
             <coordinates>47.454167 -115.669722</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Idaho in United States -->
+          <name>Nampa</name>
+          <coordinates>43.540720 -116.563460</coordinates>
+          <location>
+            <name>Nampa Municipal Airport</name>
+            <code>KMAN</code>
+            <tz-hint>America/Boise</tz-hint>
+            <zone>IDZ012</zone>
+            <radar>boi</radar>
+            <coordinates>43.581341 -116.523063</coordinates>
           </location>
         </city>
         <city>
@@ -34680,6 +47285,18 @@
             <zone>ILZ103</zone>
             <radar>ord</radar>
             <coordinates>42.120833 -87.904722</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Illinois in United States -->
+          <name>Chicago/Romeoville</name>
+          <coordinates>41.850030 -87.650050</coordinates>
+          <location>
+            <name>Lewis University Airport</name>
+            <code>KLOT</code>
+            <zone>ILZ106</zone>
+            <radar>ord</radar>
+            <coordinates>41.608097 -88.096390</coordinates>
           </location>
         </city>
         <city>
@@ -35178,6 +47795,45 @@
           </location>
         </city>
         <city>
+          <!-- A city in United States -->
+          <name>Auburn</name>
+          <coordinates>41.366990 -85.058860</coordinates>
+          <location>
+            <name>Auburn/Dekalb Executive Airport</name>
+            <code>KGWB</code>
+            <tz-hint>America/Indiana/Indianapolis</tz-hint>
+            <zone>INZ009</zone>
+            <radar>dtw</radar>
+            <coordinates>41.307198 -85.060517</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in United States -->
+          <name>Batesville</name>
+          <coordinates>39.300050 -85.222180</coordinates>
+          <location>
+            <name>Batesville Airport</name>
+            <code>KHLB</code>
+            <tz-hint>America/Indiana/Indianapolis</tz-hint>
+            <zone>INZ066</zone>
+            <radar>ind</radar>
+            <coordinates>39.343111 -85.258417</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in United States -->
+          <name>Bedford</name>
+          <coordinates>38.861160 -86.487210</coordinates>
+          <location>
+            <name>Virgil I Grissom Municipal Airport</name>
+            <code>KBFR</code>
+            <tz-hint>America/Indiana/Indianapolis</tz-hint>
+            <zone>INZ070</zone>
+            <radar>ind</radar>
+            <coordinates>38.840028 -86.445361</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Indiana in the United States -->
           <name msgctxt="City in Indiana, United States">Bloomington</name>
           <coordinates>39.165325 -86.526386</coordinates>
@@ -35197,6 +47853,19 @@
             <name>Columbus / Bakalar</name>
             <code>KBAK</code>
             <coordinates>39.266667 -85.900000</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in United States -->
+          <name>Crawfordsville</name>
+          <coordinates>40.041150 -86.874450</coordinates>
+          <location>
+            <name>Crawfordsville Regional Airport</name>
+            <code>KCFJ</code>
+            <tz-hint>America/Indiana/Indianapolis</tz-hint>
+            <zone>INZ036</zone>
+            <radar>ind</radar>
+            <coordinates>39.974625 -86.921075</coordinates>
           </location>
         </city>
         <city>
@@ -35235,6 +47904,39 @@
             <radar>dtw</radar>
             <coordinates>40.978333 -85.195278</coordinates>
           </location>
+          <location>
+            <name>Smith Field</name>
+            <code>KSMD</code>
+            <zone>INZ018</zone>
+            <radar>dtw</radar>
+            <coordinates>41.143361 -85.152778</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in United States -->
+          <name>Frankfort</name>
+          <coordinates>40.279480 -86.510840</coordinates>
+          <location>
+            <name>Frankfort Clinton County Regional Airport</name>
+            <code>KFKR</code>
+            <tz-hint>America/Indiana/Indianapolis</tz-hint>
+            <zone>INZ030</zone>
+            <radar>ind</radar>
+            <coordinates>40.273431 -86.562170</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in United States -->
+          <name>French Lick</name>
+          <coordinates>38.548940 -86.619990</coordinates>
+          <location>
+            <name>French Lick Municipal Airport</name>
+            <code>KFRH</code>
+            <tz-hint>America/Indiana/Indianapolis</tz-hint>
+            <zone>INZ076</zone>
+            <radar>ind</radar>
+            <coordinates>38.506222 -86.636944</coordinates>
+          </location>
         </city>
         <city>
           <!-- A city in Indiana in the United States -->
@@ -35260,6 +47962,45 @@
           </location>
         </city>
         <city>
+          <!-- A city in United States -->
+          <name>Greencastle</name>
+          <coordinates>39.644490 -86.864730</coordinates>
+          <location>
+            <name>Putnam County Regional Airport</name>
+            <code>KGPC</code>
+            <tz-hint>America/Indiana/Indianapolis</tz-hint>
+            <zone>INZ045</zone>
+            <radar>ind</radar>
+            <coordinates>39.633528 -86.813806</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in United States -->
+          <name>Huntingburg</name>
+          <coordinates>38.298940 -86.955000</coordinates>
+          <location>
+            <name>Huntingburg Airport</name>
+            <code>KHNB</code>
+            <tz-hint>America/Indiana/Vincennes</tz-hint>
+            <zone>INZ083</zone>
+            <radar>lex</radar>
+            <coordinates>38.249017 -86.952819</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in United States -->
+          <name>Huntington</name>
+          <coordinates>40.883100 -85.497480</coordinates>
+          <location>
+            <name>Huntington Municipal Airport</name>
+            <code>KHHG</code>
+            <tz-hint>America/Indiana/Indianapolis</tz-hint>
+            <zone>INZ025</zone>
+            <radar>dtw</radar>
+            <coordinates>40.852917 -85.457056</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Indiana in the United States -->
           <name>Indianapolis</name>
           <coordinates>39.768377 -86.158042</coordinates>
@@ -35275,6 +48016,63 @@
             <code>KEYE</code>
             <coordinates>39.825000 -86.295833</coordinates>
           </location>
+          <location>
+            <name>Indianapolis Executive Airport</name>
+            <code>KTYQ</code>
+            <tz-hint>America/Indiana/Indianapolis</tz-hint>
+            <zone>INZ039</zone>
+            <radar>ind</radar>
+            <coordinates>40.028609 -86.251406</coordinates>
+          </location>
+          <location>
+            <name>Indianapolis Metro Airport</name>
+            <code>KUMP</code>
+            <zone>INZ039</zone>
+            <radar>ind</radar>
+            <coordinates>39.935398 -86.045068</coordinates>
+          </location>
+          <location>
+            <name>Indianapolis Regional Airport</name>
+            <code>KMQJ</code>
+            <tz-hint>America/Indiana/Indianapolis</tz-hint>
+            <zone>INZ048</zone>
+            <radar>ind</radar>
+            <coordinates>39.843138 -85.897736</coordinates>
+          </location>
+          <location>
+            <name>Indy South Greenwood Airport</name>
+            <code>KHFY</code>
+            <tz-hint>America/Indiana/Indianapolis</tz-hint>
+            <zone>INZ055</zone>
+            <radar>ind</radar>
+            <coordinates>39.627611 -86.088028</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in United States -->
+          <name>Jeffersonville</name>
+          <coordinates>38.277570 -85.737180</coordinates>
+          <location>
+            <name>Clark Regional Airport</name>
+            <code>KJVY</code>
+            <tz-hint>America/Kentucky/Louisville</tz-hint>
+            <zone>INZ092</zone>
+            <radar>ind</radar>
+            <coordinates>38.366618 -85.738145</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in United States -->
+          <name>Knox</name>
+          <coordinates>41.295880 -86.625010</coordinates>
+          <location>
+            <name>Starke County Airport</name>
+            <code>KOXI</code>
+            <tz-hint>America/Indiana/Knox</tz-hint>
+            <zone>INZ012</zone>
+            <radar>ord</radar>
+            <coordinates>41.329702 -86.664609</coordinates>
+          </location>
         </city>
         <city>
           <!-- A city in Indiana in the United States -->
@@ -35284,6 +48082,19 @@
             <name>Kokomo Municipal Airport</name>
             <code>KOKK</code>
             <coordinates>40.533333 -86.066667</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in United States -->
+          <name>La Porte</name>
+          <coordinates>41.607740 -86.713890</coordinates>
+          <location>
+            <name>La Porte Municipal Airport</name>
+            <code>KPPO</code>
+            <tz-hint>America/Chicago</tz-hint>
+            <zone>INZ103</zone>
+            <radar>ord</radar>
+            <coordinates>41.572467 -86.734528</coordinates>
           </location>
         </city>
         <city>
@@ -35299,6 +48110,71 @@
           </location>
         </city>
         <city>
+          <!-- A city in United States -->
+          <name>Logansport</name>
+          <coordinates>40.754480 -86.356670</coordinates>
+          <location>
+            <name>Logansport/Cass County Airport</name>
+            <code>KGGP</code>
+            <tz-hint>America/Indiana/Indianapolis</tz-hint>
+            <zone>INZ022</zone>
+            <radar>ind</radar>
+            <coordinates>40.711264 -86.372705</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in United States -->
+          <name>Madison</name>
+          <coordinates>38.735890 -85.379960</coordinates>
+          <location>
+            <name>Madison Regional Airport</name>
+            <code>KIMS</code>
+            <tz-hint>America/Indiana/Indianapolis</tz-hint>
+            <zone>INZ079</zone>
+            <radar>ind</radar>
+            <coordinates>38.759917 -85.464694</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in United States -->
+          <name>Marion</name>
+          <coordinates>40.558370 -85.659140</coordinates>
+          <location>
+            <name>Marion Municipal - Mckinney Field</name>
+            <code>KMZZ</code>
+            <tz-hint>America/Indiana/Indianapolis</tz-hint>
+            <zone>INZ032</zone>
+            <radar>ind</radar>
+            <coordinates>40.489917 -85.679778</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in United States -->
+          <name>Michigan City</name>
+          <coordinates>41.707540 -86.895030</coordinates>
+          <location>
+            <name>Michigan City Municipal-Phillips Field</name>
+            <code>KMGC</code>
+            <tz-hint>America/Chicago</tz-hint>
+            <zone>INZ103</zone>
+            <radar>ord</radar>
+            <coordinates>41.703315 -86.821240</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in United States -->
+          <name>Monticello</name>
+          <coordinates>40.745320 -86.764730</coordinates>
+          <location>
+            <name>White County Airport</name>
+            <code>KMCX</code>
+            <tz-hint>America/Indiana/Indianapolis</tz-hint>
+            <zone>INZ020</zone>
+            <radar>ind</radar>
+            <coordinates>40.710194 -86.766794</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Indiana in the United States -->
           <name>Muncie</name>
           <coordinates>40.193377 -85.386360</coordinates>
@@ -35311,6 +48187,19 @@
           </location>
         </city>
         <city>
+          <!-- A city in United States -->
+          <name>New Castle</name>
+          <coordinates>39.928940 -85.370250</coordinates>
+          <location>
+            <name>New Castle Henry County Marlatt Field</name>
+            <code>KUWL</code>
+            <tz-hint>America/Indiana/Indianapolis</tz-hint>
+            <zone>INZ049</zone>
+            <radar>ind</radar>
+            <coordinates>39.876732 -85.325287</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Indiana in the United States -->
           <name msgctxt="City in Indiana, United States">Peru</name>
           <coordinates>40.753653 -86.068881</coordinates>
@@ -35320,6 +48209,57 @@
             <zone>INZ023</zone>
             <radar>ind</radar>
             <coordinates>40.650000 -86.150000</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in United States -->
+          <name>Portland</name>
+          <coordinates>40.434490 -84.977750</coordinates>
+          <location>
+            <name>Portland Municipal Airport</name>
+            <code>KPLD</code>
+            <tz-hint>America/Indiana/Indianapolis</tz-hint>
+            <zone>INZ034</zone>
+            <radar>ind</radar>
+            <coordinates>40.451518 -84.991718</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in United States -->
+          <name>Rensselaer</name>
+          <coordinates>40.936700 -87.150860</coordinates>
+          <location>
+            <name>Jasper County Airport</name>
+            <code>KRZL</code>
+            <tz-hint>America/Chicago</tz-hint>
+            <zone>INZ011</zone>
+            <radar>ind</radar>
+            <coordinates>40.947823 -87.182648</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in United States -->
+          <name>Richmond</name>
+          <coordinates>39.828940 -84.890240</coordinates>
+          <location>
+            <name>Richmond Municipal Airport</name>
+            <code>KRID</code>
+            <zone>INZ059</zone>
+            <radar>ind</radar>
+            <coordinates>39.756083 -84.842694</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in United States -->
+          <name>Rochester</name>
+          <coordinates>41.064760 -86.215830</coordinates>
+          <location>
+            <name>Fulton County Airport</name>
+            <code>KRCR</code>
+            <tz-hint>America/Indiana/Indianapolis</tz-hint>
+            <zone>INZ015</zone>
+            <radar>ind</radar>
+            <coordinates>41.065548 -86.181703</coordinates>
           </location>
         </city>
         <city>
@@ -35377,12 +48317,37 @@
             <coordinates>41.274444 -85.840000</coordinates>
           </location>
         </city>
+        <city>
+          <!-- A city in United States -->
+          <name>Washington</name>
+          <coordinates>38.659220 -87.172790</coordinates>
+          <location>
+            <name>Daviess County Airport</name>
+            <code>KDCY</code>
+            <tz-hint>America/Indiana/Vincennes</tz-hint>
+            <zone>INZ068</zone>
+            <radar>ind</radar>
+            <coordinates>38.700767 -87.131290</coordinates>
+          </location>
+        </city>
       </state>
       <state>
         <!-- A state/province/territory in United States -->
         <name>Iowa</name>
         <fips-code>US19</fips-code>
         <tz-hint>America/Chicago</tz-hint>
+        <city>
+          <!-- A city in Iowa in United States -->
+          <name>Algona</name>
+          <coordinates>43.069970 -94.233020</coordinates>
+          <location>
+            <name>Algona Municipal Airport</name>
+            <code>KAXA</code>
+            <zone>IAZ005</zone>
+            <radar>fsd</radar>
+            <coordinates>43.077798 -94.271774</coordinates>
+          </location>
+        </city>
         <city>
           <!-- A city in Iowa in the United States -->
           <name>Ames</name>
@@ -35473,6 +48438,18 @@
             <zone>IAZ052</zone>
             <radar>dsm</radar>
             <coordinates>41.884444 -91.710556</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Iowa in United States -->
+          <name>Centerville</name>
+          <coordinates>40.734180 -92.874090</coordinates>
+          <location>
+            <name>Centerville Municipal Airport</name>
+            <code>KTVK</code>
+            <zone>IAZ096</zone>
+            <radar>oma</radar>
+            <coordinates>40.684429 -92.900994</coordinates>
           </location>
         </city>
         <city>
@@ -35654,6 +48631,18 @@
           </location>
         </city>
         <city>
+          <!-- A city in Iowa in United States -->
+          <name>Forest City</name>
+          <coordinates>43.262460 -93.637160</coordinates>
+          <location>
+            <name>Forest City Municipal/Trimble Field</name>
+            <code>KFXY</code>
+            <zone>IAZ006</zone>
+            <radar>fsd</radar>
+            <coordinates>43.234757 -93.624104</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Iowa in the United States -->
           <name>Fort Dodge</name>
           <coordinates>42.497469 -94.168016</coordinates>
@@ -35678,6 +48667,30 @@
           </location>
         </city>
         <city>
+          <!-- A city in Iowa in United States -->
+          <name>Grinnell</name>
+          <coordinates>41.743050 -92.722410</coordinates>
+          <location>
+            <name>Grinnell Regional Airport</name>
+            <code>KGGI</code>
+            <zone>IAZ062</zone>
+            <radar>dsm</radar>
+            <coordinates>41.709889 -92.735972</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Iowa in United States -->
+          <name>Hampton</name>
+          <coordinates>42.741920 -93.202420</coordinates>
+          <location>
+            <name>Hampton Municipal Airport</name>
+            <code>KHPT</code>
+            <zone>IAZ026</zone>
+            <radar>dsm</radar>
+            <coordinates>42.723694 -93.226333</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Iowa in the United States -->
           <name>Harlan</name>
           <coordinates>41.653044 -95.325554</coordinates>
@@ -35685,6 +48698,18 @@
             <name>Harlan Municipal Airport</name>
             <code>KHNR</code>
             <coordinates>41.584444 -95.339722</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Iowa in United States -->
+          <name>Independence</name>
+          <coordinates>42.468600 -91.889340</coordinates>
+          <location>
+            <name>James H Connell Field At Independence Municipal Airport</name>
+            <code>KIIB</code>
+            <zone>IAZ040</zone>
+            <radar>dsm</radar>
+            <coordinates>42.456889 -91.947667</coordinates>
           </location>
         </city>
         <city>
@@ -35697,6 +48722,18 @@
             <zone>IAZ064</zone>
             <radar>dsm</radar>
             <coordinates>41.632778 -91.543056</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Iowa in United States -->
+          <name>Iowa Falls</name>
+          <coordinates>42.522480 -93.251310</coordinates>
+          <location>
+            <name>Iowa Falls Municipal Airport</name>
+            <code>KIFA</code>
+            <zone>IAZ037</zone>
+            <radar>dsm</radar>
+            <coordinates>42.471356 -93.270723</coordinates>
           </location>
         </city>
         <city>
@@ -35769,6 +48806,18 @@
           </location>
         </city>
         <city>
+          <!-- A city in Iowa in United States -->
+          <name>Maurice</name>
+          <coordinates>42.985827 -96.161400</coordinates>
+          <location>
+            <name>Sioux County Regional Airport</name>
+            <code>KSXK</code>
+            <zone>IAZ012</zone>
+            <radar>fsd</radar>
+            <coordinates>42.985827 -96.161400</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Iowa in the United States -->
           <name msgctxt="City in Iowa, United States">Monticello</name>
           <coordinates>42.238335 -91.187094</coordinates>
@@ -35800,6 +48849,18 @@
             <zone>IAZ067</zone>
             <radar>dsm</radar>
             <coordinates>41.366667 -91.150000</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Iowa in United States -->
+          <name>Newton</name>
+          <coordinates>41.699710 -93.047980</coordinates>
+          <location>
+            <name>Newton Municipal-Earl Johnson Field</name>
+            <code>KTNU</code>
+            <zone>IAZ061</zone>
+            <radar>dsm</radar>
+            <coordinates>41.674430 -93.021728</coordinates>
           </location>
         </city>
         <city>
@@ -35856,6 +48917,18 @@
             <name>Pella Municipal Airport</name>
             <code>KPEA</code>
             <coordinates>41.400000 -92.933333</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Iowa in United States -->
+          <name>Perry</name>
+          <coordinates>41.838600 -94.107180</coordinates>
+          <location>
+            <name>Perry Municipal Airport</name>
+            <code>KPRO</code>
+            <zone>IAZ059</zone>
+            <radar>dsm</radar>
+            <coordinates>41.826444 -94.159556</coordinates>
           </location>
         </city>
         <city>
@@ -35980,6 +49053,42 @@
         <fips-code>US20</fips-code>
         <tz-hint>America/Chicago</tz-hint>
         <city>
+          <!-- A city in Kansas in United States -->
+          <name>Anthony</name>
+          <coordinates>37.153360 -98.031170</coordinates>
+          <location>
+            <name>Anthony Municipal Airport</name>
+            <code>KANY</code>
+            <zone>KSZ091</zone>
+            <radar>ddc</radar>
+            <coordinates>37.159889 -98.079528</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Kansas in United States -->
+          <name>Atwood</name>
+          <coordinates>39.806670 -101.042100</coordinates>
+          <location>
+            <name>Atwood-Rawlins County City-County Airport</name>
+            <code>KADT</code>
+            <zone>KSZ002</zone>
+            <radar>ddc</radar>
+            <coordinates>39.840339 -101.042483</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Kansas in United States -->
+          <name>Burlington</name>
+          <coordinates>38.194470 -95.742760</coordinates>
+          <location>
+            <name>Coffey County Airport</name>
+            <code>KUKL</code>
+            <zone>KSZ058</zone>
+            <radar>mkc</radar>
+            <coordinates>38.302482 -95.724958</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Kansas in the United States -->
           <name>Chanute</name>
           <coordinates>37.679214 -95.457203</coordinates>
@@ -35999,6 +49108,18 @@
             <name>Coffeyville Municipal Airport</name>
             <code>KCFV</code>
             <coordinates>37.091111 -95.566389</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Kansas in United States -->
+          <name>Colby</name>
+          <coordinates>39.395840 -101.052380</coordinates>
+          <location>
+            <name>Shalz Field</name>
+            <code>KCBK</code>
+            <zone>KSZ014</zone>
+            <radar>ddc</radar>
+            <coordinates>39.427459 -101.046620</coordinates>
           </location>
         </city>
         <city>
@@ -36023,6 +49144,18 @@
             <zone>KSZ078</zone>
             <radar>ddc</radar>
             <coordinates>37.772778 -99.969722</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Kansas in United States -->
+          <name>El Dorado</name>
+          <coordinates>37.817240 -96.862250</coordinates>
+          <location>
+            <name>El Dorado/Capt Jack Thomas Memorial Airport</name>
+            <code>KEQA</code>
+            <zone>KSZ069</zone>
+            <radar>ddc</radar>
+            <coordinates>37.774111 -96.817722</coordinates>
           </location>
         </city>
         <city>
@@ -36057,6 +49190,18 @@
             <zone>KSZ054</zone>
             <radar>mkc</radar>
             <coordinates>38.328889 -96.193889</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Kansas in United States -->
+          <name>Fort Scott</name>
+          <coordinates>37.839760 -94.708300</coordinates>
+          <location>
+            <name>Fort Scott Municipal Airport</name>
+            <code>KFSK</code>
+            <zone>KSZ073</zone>
+            <radar>mkc</radar>
+            <coordinates>37.798361 -94.769361</coordinates>
           </location>
         </city>
         <city>
@@ -36119,6 +49264,18 @@
           </location>
         </city>
         <city>
+          <!-- A city in Kansas in United States -->
+          <name>Hugoton</name>
+          <coordinates>37.175300 -101.349600</coordinates>
+          <location>
+            <name>Hugoton Municipal Airport</name>
+            <code>KHQG</code>
+            <zone>KSZ085</zone>
+            <radar>ddc</radar>
+            <coordinates>37.163358 -101.370677</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Kansas in the United States -->
           <name msgctxt="City in Kansas, United States">Hutchinson</name>
           <coordinates>38.060845 -97.929774</coordinates>
@@ -36128,6 +49285,30 @@
             <zone>KSZ067</zone>
             <radar>ddc</radar>
             <coordinates>38.068056 -97.860556</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Kansas in United States -->
+          <name>Independence</name>
+          <coordinates>37.224240 -95.708310</coordinates>
+          <location>
+            <name>Independence Municipal Airport</name>
+            <code>KIDP</code>
+            <zone>KSZ099</zone>
+            <radar>mkc</radar>
+            <coordinates>37.157926 -95.778950</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Kansas in United States -->
+          <name>Johnson City</name>
+          <coordinates>37.570570 -101.751000</coordinates>
+          <location>
+            <name>Stanton County Municipal Airport</name>
+            <code>KJHN</code>
+            <zone>KSZ074</zone>
+            <radar>ddc</radar>
+            <coordinates>37.585390 -101.732303</coordinates>
           </location>
         </city>
         <city>
@@ -36160,6 +49341,18 @@
           </location>
         </city>
         <city>
+          <!-- A city in Kansas in United States -->
+          <name>Larned</name>
+          <coordinates>38.180570 -99.098710</coordinates>
+          <location>
+            <name>Larned-Pawnee County Airport</name>
+            <code>KLQR</code>
+            <zone>KSZ065</zone>
+            <radar>ddc</radar>
+            <coordinates>38.208604 -99.085914</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Kansas in the United States -->
           <name msgctxt="City in Kansas, United States">Lawrence</name>
           <coordinates>38.971669 -95.235250</coordinates>
@@ -36182,6 +49375,18 @@
           </location>
         </city>
         <city>
+          <!-- A city in Kansas in United States -->
+          <name>Lyons</name>
+          <coordinates>38.345010 -98.201730</coordinates>
+          <location>
+            <name>Lyons-Rice County Municipal Airport</name>
+            <code>KLYO</code>
+            <zone>KSZ050</zone>
+            <radar>ddc</radar>
+            <coordinates>38.340250 -98.228556</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Kansas in the United States -->
           <name>Manhattan</name>
           <coordinates>39.183608 -96.571669</coordinates>
@@ -36191,6 +49396,30 @@
             <zone>KSZ022</zone>
             <radar>mkc</radar>
             <coordinates>39.135278 -96.677778</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Kansas in United States -->
+          <name>Marysville</name>
+          <coordinates>39.841110 -96.647240</coordinates>
+          <location>
+            <name>Marysville Municipal Airport</name>
+            <code>KMYZ</code>
+            <zone>KSZ010</zone>
+            <radar>mkc</radar>
+            <coordinates>39.856429 -96.630713</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Kansas in United States -->
+          <name>Mc Pherson</name>
+          <coordinates>38.352394 -97.691298</coordinates>
+          <location>
+            <name>Mc Pherson Airport</name>
+            <code>KMPR</code>
+            <zone>KSZ051</zone>
+            <radar>ddc</radar>
+            <coordinates>38.352394 -97.691298</coordinates>
           </location>
         </city>
         <city>
@@ -36216,6 +49445,42 @@
           </location>
         </city>
         <city>
+          <!-- A city in Kansas in United States -->
+          <name>Norton</name>
+          <coordinates>39.833890 -99.891510</coordinates>
+          <location>
+            <name>Norton Municipal Airport</name>
+            <code>KNRN</code>
+            <zone>KSZ004</zone>
+            <radar>ddc</radar>
+            <coordinates>39.850472 -99.894694</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Kansas in United States -->
+          <name>Oakley</name>
+          <coordinates>39.133340 -100.863760</coordinates>
+          <location>
+            <name>Oakley Municipal Airport</name>
+            <code>KOEL</code>
+            <zone>KSZ014</zone>
+            <radar>ddc</radar>
+            <coordinates>39.111750 -100.816750</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Kansas in United States -->
+          <name>Oberlin</name>
+          <coordinates>39.818340 -100.528200</coordinates>
+          <location>
+            <name>Oberlin Municipal Airport</name>
+            <code>KOIN</code>
+            <zone>KSZ003</zone>
+            <radar>ddc</radar>
+            <coordinates>39.834384 -100.539834</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Kansas in the United States -->
           <name>Olathe</name>
           <coordinates>38.881396 -94.819129</coordinates>
@@ -36232,6 +49497,18 @@
             <zone>KSZ105</zone>
             <radar>mkc</radar>
             <coordinates>38.824444 -94.886944</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Kansas in United States -->
+          <name>Ottawa</name>
+          <coordinates>38.615570 -95.267750</coordinates>
+          <location>
+            <name>Ottawa Municipal Airport</name>
+            <code>KOWI</code>
+            <zone>KSZ056</zone>
+            <radar>mkc</radar>
+            <coordinates>38.539174 -95.253185</coordinates>
           </location>
         </city>
         <city>
@@ -36254,6 +49531,30 @@
             <name>Tri-City Airport</name>
             <code>KPPF</code>
             <coordinates>37.327778 -95.504167</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Kansas in United States -->
+          <name>Phillipsburg</name>
+          <coordinates>39.756120 -99.323990</coordinates>
+          <location>
+            <name>Phillipsburg Municipal Airport</name>
+            <code>KPHG</code>
+            <zone>KSZ005</zone>
+            <radar>ddc</radar>
+            <coordinates>39.735679 -99.317530</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Kansas in United States -->
+          <name>Pittsburg</name>
+          <coordinates>37.410880 -94.704960</coordinates>
+          <location>
+            <name>Atkinson Municipal Airport</name>
+            <code>KPTS</code>
+            <zone>KSZ097</zone>
+            <radar>mkc</radar>
+            <coordinates>37.450056 -94.731222</coordinates>
           </location>
         </city>
         <city>
@@ -36291,6 +49592,30 @@
           </location>
         </city>
         <city>
+          <!-- A city in Kansas in United States -->
+          <name>Scott City</name>
+          <coordinates>38.482520 -100.907090</coordinates>
+          <location>
+            <name>Scott City Municipal Airport</name>
+            <code>KTQK</code>
+            <zone>KSZ043</zone>
+            <radar>ddc</radar>
+            <coordinates>38.475023 -100.884439</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Kansas in United States -->
+          <name>St Francis</name>
+          <coordinates>39.759167 -101.794666</coordinates>
+          <location>
+            <name>Cheyenne County Municipal Airport</name>
+            <code>KSYF</code>
+            <zone>KSZ001</zone>
+            <radar>ddc</radar>
+            <coordinates>39.759167 -101.794666</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Kansas in the United States -->
           <name>Topeka</name>
           <coordinates>39.048334 -95.678037</coordinates>
@@ -36307,6 +49632,30 @@
             <zone>KSZ039</zone>
             <radar>mkc</radar>
             <coordinates>38.941389 -95.650556</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Kansas in United States -->
+          <name>Ulysses</name>
+          <coordinates>37.581410 -101.355170</coordinates>
+          <location>
+            <name>Ulysses Airport</name>
+            <code>KULS</code>
+            <zone>KSZ075</zone>
+            <radar>ddc</radar>
+            <coordinates>37.604000 -101.373556</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Kansas in United States -->
+          <name>Wellington</name>
+          <coordinates>37.265300 -97.371710</coordinates>
+          <location>
+            <name>Wellington Municipal Airport</name>
+            <code>KEGT</code>
+            <zone>KSZ092</zone>
+            <radar>ddc</radar>
+            <coordinates>37.324996 -97.388356</coordinates>
           </location>
         </city>
         <city>
@@ -36332,6 +49681,13 @@
             <code>KAAO</code>
             <coordinates>37.749722 -97.218889</coordinates>
           </location>
+          <location>
+            <name>Beech Factory Airport</name>
+            <code>KBEC</code>
+            <zone>KSZ083</zone>
+            <radar>ddc</radar>
+            <coordinates>37.693917 -97.214917</coordinates>
+          </location>
         </city>
         <city>
           <!-- A city in Kansas in the United States -->
@@ -36350,6 +49706,30 @@
         <fips-code>US21</fips-code>
         <tz-hint>America/New_York</tz-hint>
         <city>
+          <!-- A city in Kentucky in United States -->
+          <name>Ashland</name>
+          <coordinates>38.478410 -82.637940</coordinates>
+          <location>
+            <name>Ashland Regional Airport</name>
+            <code>KDWU</code>
+            <zone>KYZ101</zone>
+            <radar>lex</radar>
+            <coordinates>38.554461 -82.737662</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Kentucky in United States -->
+          <name>Bardstown</name>
+          <coordinates>37.809230 -85.466900</coordinates>
+          <location>
+            <name>Samuels Field</name>
+            <code>KBRY</code>
+            <zone>KYZ045</zone>
+            <radar>lex</radar>
+            <coordinates>37.814333 -85.499639</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Kentucky in the United States -->
           <name>Bowling Green</name>
           <coordinates>36.990320 -86.443602</coordinates>
@@ -36360,6 +49740,54 @@
             <zone>KYZ071</zone>
             <radar>lex</radar>
             <coordinates>36.964444 -86.419444</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Kentucky in United States -->
+          <name>Campbellsville</name>
+          <coordinates>37.343400 -85.341910</coordinates>
+          <location>
+            <name>Taylor County Airport</name>
+            <code>KAAS</code>
+            <zone>KYZ065</zone>
+            <radar>lex</radar>
+            <coordinates>37.358278 -85.309417</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Kentucky in United States -->
+          <name>Danville</name>
+          <coordinates>37.645630 -84.772170</coordinates>
+          <location>
+            <name>Stuart Powell Field</name>
+            <code>KDVK</code>
+            <zone>KYZ055</zone>
+            <radar>lex</radar>
+            <coordinates>37.577561 -84.769488</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Kentucky in United States -->
+          <name>Elizabethtown</name>
+          <coordinates>37.693950 -85.859130</coordinates>
+          <location>
+            <name>Addington Field</name>
+            <code>KEKX</code>
+            <zone>KYZ028</zone>
+            <radar>lex</radar>
+            <coordinates>37.686000 -85.925028</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Kentucky in United States -->
+          <name>Flemingsburg</name>
+          <coordinates>38.422300 -83.733810</coordinates>
+          <location>
+            <name>Fleming-Mason Airport</name>
+            <code>KFGX</code>
+            <zone>KYZ099</zone>
+            <radar>lex</radar>
+            <coordinates>38.541606 -83.744019</coordinates>
           </location>
         </city>
         <city>
@@ -36386,6 +49814,18 @@
           </location>
         </city>
         <city>
+          <!-- A city in Kentucky in United States -->
+          <name>Hazard</name>
+          <coordinates>37.249540 -83.193230</coordinates>
+          <location>
+            <name>Wendell H Ford Airport</name>
+            <code>KCPF</code>
+            <zone>KYZ112</zone>
+            <radar>lex</radar>
+            <coordinates>37.387364 -83.261599</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Kentucky in the United States -->
           <name msgctxt="City in Kentucky, United States">Henderson</name>
           <coordinates>37.836154 -87.590013</coordinates>
@@ -36396,6 +49836,19 @@
             <zone>KYZ018</zone>
             <radar>lex</radar>
             <coordinates>37.816667 -87.683333</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Kentucky in United States -->
+          <name>Hopkinsville</name>
+          <coordinates>36.865610 -87.491170</coordinates>
+          <location>
+            <name>Hopkinsville-Christian County Airport</name>
+            <code>KHVC</code>
+            <tz-hint>America/Chicago</tz-hint>
+            <zone>KYZ017</zone>
+            <radar>lex</radar>
+            <coordinates>36.856969 -87.455079</coordinates>
           </location>
         </city>
         <city>
@@ -36453,6 +49906,19 @@
           </location>
         </city>
         <city>
+          <!-- A city in Kentucky in United States -->
+          <name>Marion</name>
+          <coordinates>37.332830 -88.081130</coordinates>
+          <location>
+            <name>Marion-Crittenden County James C Johnson Regional Airport</name>
+            <code>KGDA</code>
+            <tz-hint>America/Chicago</tz-hint>
+            <zone>KYZ010</zone>
+            <radar>lex</radar>
+            <coordinates>37.335939 -88.110671</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Kentucky in the United States -->
           <name>Middlesboro</name>
           <coordinates>36.608415 -83.716582</coordinates>
@@ -36460,6 +49926,43 @@
             <name>Middlesboro-Bell County Airport</name>
             <code>K1A6</code>
             <coordinates>36.610556 -83.737222</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Kentucky in United States -->
+          <name>Monticello</name>
+          <coordinates>36.829790 -84.849110</coordinates>
+          <location>
+            <name>Wayne County Airport</name>
+            <code>KEKQ</code>
+            <tz-hint>America/Kentucky/Monticello</tz-hint>
+            <zone>KYZ083</zone>
+            <radar>lex</radar>
+            <coordinates>36.855278 -84.856139</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Kentucky in United States -->
+          <name>Morehead</name>
+          <coordinates>38.183970 -83.432680</coordinates>
+          <location>
+            <name>Morehead-Rowan County Clyde A Thomas Regional Airport</name>
+            <code>KSYM</code>
+            <zone>KYZ052</zone>
+            <radar>lex</radar>
+            <coordinates>38.215000 -83.587611</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Kentucky in United States -->
+          <name>Mount Sterling</name>
+          <coordinates>38.056470 -83.943260</coordinates>
+          <location>
+            <name>Mount Sterling/Montgomery County Airport</name>
+            <code>KIOB</code>
+            <zone>KYZ050</zone>
+            <radar>lex</radar>
+            <coordinates>38.058135 -83.979573</coordinates>
           </location>
         </city>
         <city>
@@ -36472,6 +49975,19 @@
             <zone>KYZ028</zone>
             <radar>lex</radar>
             <coordinates>37.900000 -85.966667</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Kentucky in United States -->
+          <name>Murray</name>
+          <coordinates>36.610330 -88.314760</coordinates>
+          <location>
+            <name>Kyle-Oakley Field</name>
+            <code>KCEY</code>
+            <tz-hint>America/Chicago</tz-hint>
+            <zone>KYZ009</zone>
+            <radar>stl</radar>
+            <coordinates>36.664581 -88.372776</coordinates>
           </location>
         </city>
         <city>
@@ -36501,6 +50017,42 @@
           </location>
         </city>
         <city>
+          <!-- A city in Kentucky in United States -->
+          <name>Pikeville</name>
+          <coordinates>37.479270 -82.518760</coordinates>
+          <location>
+            <name>Pike County/Hatcher Field</name>
+            <code>KPBX</code>
+            <zone>KYZ110</zone>
+            <radar>lex</radar>
+            <coordinates>37.561811 -82.566432</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Kentucky in United States -->
+          <name>Prestonsburg</name>
+          <coordinates>37.665650 -82.771550</coordinates>
+          <location>
+            <name>Big Sandy Regional Airport</name>
+            <code>KSJS</code>
+            <zone>KYZ119</zone>
+            <radar>lex</radar>
+            <coordinates>37.750960 -82.636732</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Kentucky in United States -->
+          <name>Richmond</name>
+          <coordinates>37.747860 -84.294650</coordinates>
+          <location>
+            <name>Central Kentucky Regional Airport</name>
+            <code>KRGA</code>
+            <zone>KYZ057</zone>
+            <radar>lex</radar>
+            <coordinates>37.631534 -84.332440</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Kentucky in the United States -->
           <name>Somerset</name>
           <coordinates>37.092022 -84.604108</coordinates>
@@ -36510,12 +50062,49 @@
             <coordinates>37.054167 -84.615000</coordinates>
           </location>
         </city>
+        <city>
+          <!-- A city in Kentucky in United States -->
+          <name>Sturgis</name>
+          <coordinates>37.546710 -87.983910</coordinates>
+          <location>
+            <name>Sturgis Municipal Airport</name>
+            <code>KTWT</code>
+            <tz-hint>America/Chicago</tz-hint>
+            <zone>KYZ014</zone>
+            <radar>lex</radar>
+            <coordinates>37.541778 -87.954361</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Kentucky in United States -->
+          <name>Williamsburg</name>
+          <coordinates>36.743420 -84.159660</coordinates>
+          <location>
+            <name>Williamsburg-Whitley County Airport</name>
+            <code>KBYL</code>
+            <zone>KYZ085</zone>
+            <radar>lex</radar>
+            <coordinates>36.794999 -84.199517</coordinates>
+          </location>
+        </city>
       </state>
       <state>
         <!-- A state/province/territory in United States -->
         <name>Louisiana</name>
         <fips-code>US22</fips-code>
         <tz-hint>America/Chicago</tz-hint>
+        <city>
+          <!-- A city in Louisiana in United States -->
+          <name>Abbeville</name>
+          <coordinates>29.974650 -92.134290</coordinates>
+          <location>
+            <name>Abbeville Chris Crusta Memorial Airport</name>
+            <code>KIYA</code>
+            <zone>LAZ152</zone>
+            <radar>gls</radar>
+            <coordinates>29.975778 -92.084222</coordinates>
+          </location>
+        </city>
         <city>
           <!-- A city in Louisiana in the United States -->
           <name msgctxt="City in Louisiana, United States">Alexandria</name>
@@ -36547,6 +50136,18 @@
           </location>
         </city>
         <city>
+          <!-- A city in Louisiana in United States -->
+          <name>Bastrop</name>
+          <coordinates>32.778280 -91.911440</coordinates>
+          <location>
+            <name>Morehouse Memorial Airport</name>
+            <code>KBQP</code>
+            <zone>LAZ007</zone>
+            <radar>shv</radar>
+            <coordinates>32.756083 -91.880583</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Louisiana in the United States -->
           <name>Baton Rouge</name>
           <coordinates>30.450746 -91.154551</coordinates>
@@ -36556,6 +50157,18 @@
             <zone>LAZ048</zone>
             <radar>jan</radar>
             <coordinates>30.537222 -91.146944</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Louisiana in United States -->
+          <name>Bogalusa</name>
+          <coordinates>30.791020 -89.848690</coordinates>
+          <location>
+            <name>George R Carr Memorial Air Field</name>
+            <code>KBXA</code>
+            <zone>LAZ039</zone>
+            <radar>bix</radar>
+            <coordinates>30.813686 -89.864964</coordinates>
           </location>
         </city>
         <city>
@@ -36591,6 +50204,18 @@
           </location>
         </city>
         <city>
+          <!-- A city in Louisiana in United States -->
+          <name>Fort Polk South</name>
+          <coordinates>31.051100 -93.215780</coordinates>
+          <location>
+            <name>Fullerton Landing Strip</name>
+            <code>KBKB</code>
+            <zone>LAZ027</zone>
+            <radar>gls</radar>
+            <coordinates>31.022000 -92.911000</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Louisiana in the United States -->
           <name>Galliano</name>
           <coordinates>29.442165 -90.299246</coordinates>
@@ -36609,6 +50234,18 @@
             <code>KP92</code>
             <radar>gls</radar>
             <coordinates>29.562222 -91.525556</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Louisiana in United States -->
+          <name>Gonzales</name>
+          <coordinates>30.238530 -90.920100</coordinates>
+          <location>
+            <name>Louisiana Regional Airport</name>
+            <code>KREG</code>
+            <zone>LAZ085</zone>
+            <radar>jan</radar>
+            <coordinates>30.171366 -90.940393</coordinates>
           </location>
         </city>
         <city>
@@ -36699,6 +50336,30 @@
           </location>
         </city>
         <city>
+          <!-- A city in Louisiana in United States -->
+          <name>Marksville</name>
+          <coordinates>31.127970 -92.066240</coordinates>
+          <location>
+            <name>Marksville Municipal Airport</name>
+            <code>KMKV</code>
+            <zone>LAZ029</zone>
+            <radar>shv</radar>
+            <coordinates>31.094653 -92.069059</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Louisiana in United States -->
+          <name>Minden</name>
+          <coordinates>32.615430 -93.286840</coordinates>
+          <location>
+            <name>Minden Airport</name>
+            <code>KMNE</code>
+            <zone>LAZ003</zone>
+            <radar>shv</radar>
+            <coordinates>32.646028 -93.298083</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Louisiana in the United States -->
           <name msgctxt="City in Louisiana, United States">Monroe</name>
           <coordinates>32.509311 -92.119301</coordinates>
@@ -36767,6 +50428,18 @@
           </location>
         </city>
         <city>
+          <!-- A city in Louisiana in United States -->
+          <name>Opelousas</name>
+          <coordinates>30.533530 -92.081510</coordinates>
+          <location>
+            <name>St Landry Parish Airport</name>
+            <code>KOPL</code>
+            <zone>LAZ033</zone>
+            <radar>gls</radar>
+            <coordinates>30.558400 -92.099376</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Louisiana in the United States -->
           <name>Patterson</name>
           <coordinates>29.693264 -91.302050</coordinates>
@@ -36784,6 +50457,18 @@
             <name>Ft. Polk, Peason Ridge</name>
             <code>KAQV</code>
             <coordinates>31.666667 -93.450000</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Louisiana in United States -->
+          <name>Reserve</name>
+          <coordinates>30.053810 -90.551750</coordinates>
+          <location>
+            <name>Port Of South Louisiana Executive Regional Airport</name>
+            <code>KAPS</code>
+            <zone>LAZ058</zone>
+            <radar>bix</radar>
+            <coordinates>30.087472 -90.582833</coordinates>
           </location>
         </city>
         <city>
@@ -36829,6 +50514,18 @@
             <name>Slidell Airport</name>
             <code>KASD</code>
             <coordinates>30.343056 -89.821944</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Louisiana in United States -->
+          <name>Sulphur</name>
+          <coordinates>30.236590 -93.377380</coordinates>
+          <location>
+            <name>Southland Field</name>
+            <code>KUXL</code>
+            <zone>LAZ241</zone>
+            <radar>gls</radar>
+            <coordinates>30.131444 -93.376167</coordinates>
           </location>
         </city>
       </state>
@@ -36895,6 +50592,13 @@
             <zone>MEZ024</zone>
             <radar>btv</radar>
             <coordinates>43.900278 -69.935000</coordinates>
+          </location>
+          <location>
+            <name>Brunswick Executive Airport</name>
+            <code>KBXM</code>
+            <zone>MEZ025</zone>
+            <radar>btv</radar>
+            <coordinates>43.892355 -69.938830</coordinates>
           </location>
         </city>
         <city>
@@ -37045,6 +50749,18 @@
         <fips-code>US24</fips-code>
         <tz-hint>America/New_York</tz-hint>
         <city>
+          <!-- A city in Maryland in United States -->
+          <name>Aberdeen</name>
+          <coordinates>39.509560 -76.164120</coordinates>
+          <location>
+            <name>Phillips Army Air Field</name>
+            <code>KAPG</code>
+            <zone>MDZ008</zone>
+            <radar>dca</radar>
+            <coordinates>39.465465 -76.168292</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Maryland in the United States -->
           <name>Annapolis</name>
           <coordinates>38.978445 -76.492183</coordinates>
@@ -37088,6 +50804,18 @@
           </location>
         </city>
         <city>
+          <!-- A city in Maryland in United States -->
+          <name>Cambridge</name>
+          <coordinates>38.563170 -76.078830</coordinates>
+          <location>
+            <name>Cambridge-Dorchester Regional Airport</name>
+            <code>KCGE</code>
+            <zone>MDZ021</zone>
+            <radar>ric</radar>
+            <coordinates>38.539321 -76.030395</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Maryland in the United States -->
           <name>Camp Springs</name>
           <coordinates>38.804003 -76.906640</coordinates>
@@ -37095,6 +50823,18 @@
             <name>Camp Springs / Andrews Air Force Base</name>
             <code>KADW</code>
             <coordinates>38.816667 -76.850000</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Maryland in United States -->
+          <name>College Park</name>
+          <coordinates>38.980670 -76.936920</coordinates>
+          <location>
+            <name>College Park Airport</name>
+            <code>KCGS</code>
+            <zone>DCZ001</zone>
+            <radar>dca</radar>
+            <coordinates>38.980478 -76.922169</coordinates>
           </location>
         </city>
         <city>
@@ -37126,6 +50866,18 @@
             <name>Frederick Municipal Airport</name>
             <code>KFDK</code>
             <coordinates>39.417500 -77.374444</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Maryland in United States -->
+          <name>Gaithersburg</name>
+          <coordinates>39.143440 -77.201370</coordinates>
+          <location>
+            <name>Montgomery County Airpark</name>
+            <code>KGAI</code>
+            <zone>MDZ504</zone>
+            <radar>dca</radar>
+            <coordinates>39.168333 -77.166000</coordinates>
           </location>
         </city>
         <city>
@@ -37182,6 +50934,30 @@
             <zone>MDZ022</zone>
             <radar>dca</radar>
             <coordinates>38.340556 -75.510278</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Maryland in United States -->
+          <name>Thurmont</name>
+          <coordinates>39.623710 -77.410820</coordinates>
+          <location>
+            <name>Camp David</name>
+            <code>KRSP</code>
+            <zone>MDZ004</zone>
+            <radar>dca</radar>
+            <coordinates>39.645000 -77.468000</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Maryland in United States -->
+          <name>Westminster</name>
+          <coordinates>39.575380 -76.995810</coordinates>
+          <location>
+            <name>Carroll County Regional/Jack B Poage Field</name>
+            <code>KDMW</code>
+            <zone>MDZ005</zone>
+            <radar>dca</radar>
+            <coordinates>39.608278 -77.007667</coordinates>
           </location>
         </city>
       </state>
@@ -37319,6 +51095,18 @@
           </location>
         </city>
         <city>
+          <!-- A city in Massachusetts in United States -->
+          <name>Marshfield</name>
+          <coordinates>42.091770 -70.705590</coordinates>
+          <location>
+            <name>Marshfield Municipal - George Harlow Field</name>
+            <code>KGHG</code>
+            <zone>MAZ019</zone>
+            <radar>bos</radar>
+            <coordinates>42.097499 -70.673020</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Massachusetts in the United States -->
           <name>Nantucket</name>
           <coordinates>41.283456 -70.099461</coordinates>
@@ -37429,6 +51217,18 @@
             <code>KCEF</code>
             <radar>bos</radar>
             <coordinates>42.200000 -72.533333</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Massachusetts in United States -->
+          <name>Taunton</name>
+          <coordinates>41.900100 -71.089770</coordinates>
+          <location>
+            <name>Taunton Municipal/King Field</name>
+            <code>KTAN</code>
+            <zone>MAZ018</zone>
+            <radar>bos</radar>
+            <coordinates>41.874080 -71.015233</coordinates>
           </location>
         </city>
         <city>
@@ -37571,6 +51371,19 @@
           </location>
         </city>
         <city>
+          <!-- A city in Michigan in United States -->
+          <name>Boyne Falls</name>
+          <coordinates>45.165842 -84.924114</coordinates>
+          <location>
+            <name>Boyne Mountain Airport</name>
+            <code>KBFA</code>
+            <tz-hint>America/Detroit</tz-hint>
+            <zone>MIZ099</zone>
+            <radar>htl</radar>
+            <coordinates>45.165842 -84.924114</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Michigan in the United States -->
           <name>Cadillac</name>
           <coordinates>44.251953 -85.401162</coordinates>
@@ -37674,6 +51487,18 @@
           </location>
         </city>
         <city>
+          <!-- A city in Michigan in United States -->
+          <name>Drummond Island</name>
+          <coordinates>46.009311 -83.743934</coordinates>
+          <location>
+            <name>Drummond Island Airport</name>
+            <code>KDRM</code>
+            <zone>MIZ088</zone>
+            <radar>htl</radar>
+            <coordinates>46.009311 -83.743934</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Michigan in the United States -->
           <name>Escanaba</name>
           <coordinates>45.745247 -87.064580</coordinates>
@@ -37705,6 +51530,19 @@
             <name>Frankfort Dow Memorial Field Airport</name>
             <code>KFKS</code>
             <coordinates>44.625000 -86.200556</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Michigan in United States -->
+          <name>Fremont</name>
+          <coordinates>43.467520 -85.942000</coordinates>
+          <location>
+            <name>Fremont Municipal Airport</name>
+            <code>KFFX</code>
+            <tz-hint>America/Detroit</tz-hint>
+            <zone>MIZ044</zone>
+            <radar>mkg</radar>
+            <coordinates>43.439306 -85.994889</coordinates>
           </location>
         </city>
         <city>
@@ -37996,6 +51834,19 @@
           </location>
         </city>
         <city>
+          <!-- A city in Michigan in United States -->
+          <name>Midland</name>
+          <coordinates>43.615580 -84.247210</coordinates>
+          <location>
+            <name>Jack Barstow Airport</name>
+            <code>KIKW</code>
+            <tz-hint>America/Detroit</tz-hint>
+            <zone>MIZ047</zone>
+            <radar>mkg</radar>
+            <coordinates>43.662926 -84.261313</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Michigan in the United States -->
           <name msgctxt="City in Michigan, United States">Monroe</name>
           <coordinates>41.916434 -83.397710</coordinates>
@@ -38187,6 +52038,19 @@
           </location>
         </city>
         <city>
+          <!-- A city in Michigan in United States -->
+          <name>Three Rivers</name>
+          <coordinates>41.943940 -85.632490</coordinates>
+          <location>
+            <name>Three Rivers Municipal/Dr Haines Airport</name>
+            <code>KHAI</code>
+            <tz-hint>America/Detroit</tz-hint>
+            <zone>MIZ079</zone>
+            <radar>mkg</radar>
+            <coordinates>41.959740 -85.593062</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Michigan in the United States -->
           <name>Traverse City</name>
           <coordinates>44.763057 -85.620632</coordinates>
@@ -38360,6 +52224,30 @@
             <name>Cambridge Municipal</name>
             <code>KCBG</code>
             <coordinates>45.566667 -93.266667</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Minnesota in United States -->
+          <name>Camp Ripley</name>
+          <coordinates>46.090658 -94.360486</coordinates>
+          <location>
+            <name>Ray S Miller Army Air Field</name>
+            <code>KRYM</code>
+            <zone>MNZ043</zone>
+            <radar>msp</radar>
+            <coordinates>46.090658 -94.360486</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Minnesota in United States -->
+          <name>Canby</name>
+          <coordinates>44.708850 -96.276430</coordinates>
+          <location>
+            <name>Myers Field</name>
+            <code>KCNB</code>
+            <zone>MNZ054</zone>
+            <radar>fsd</radar>
+            <coordinates>44.729500 -96.266028</coordinates>
           </location>
         </city>
         <city>
@@ -39138,6 +53026,18 @@
           </location>
         </city>
         <city>
+          <!-- A city in Minnesota in United States -->
+          <name>Willmar</name>
+          <coordinates>45.121910 -95.043340</coordinates>
+          <location>
+            <name>Willmar Municipal/John L Rice Field</name>
+            <code>KBDH</code>
+            <zone>MNZ057</zone>
+            <radar>msp</radar>
+            <coordinates>45.117028 -95.129333</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Minnesota in the United States -->
           <name>Windom</name>
           <coordinates>43.866346 -95.116937</coordinates>
@@ -39176,6 +53076,30 @@
         <fips-code>US28</fips-code>
         <tz-hint>America/Chicago</tz-hint>
         <city>
+          <!-- A city in Mississippi in United States -->
+          <name>Batesville</name>
+          <coordinates>34.311500 -89.944260</coordinates>
+          <location>
+            <name>Panola County Airport</name>
+            <code>KPMU</code>
+            <zone>MSZ012</zone>
+            <radar>shv</radar>
+            <coordinates>34.363500 -89.892889</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Mississippi in United States -->
+          <name>Bay St Louis</name>
+          <coordinates>30.367805 -89.454612</coordinates>
+          <location>
+            <name>Stennis International Airport</name>
+            <code>KHSA</code>
+            <zone>MSZ086</zone>
+            <radar>bix</radar>
+            <coordinates>30.367805 -89.454612</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Mississippi in the United States -->
           <name>Biloxi</name>
           <coordinates>30.396032 -88.885308</coordinates>
@@ -39183,6 +53107,30 @@
             <name>Keesler Air Force Base / Biloxi</name>
             <code>KBIX</code>
             <coordinates>30.416667 -88.916667</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Mississippi in United States -->
+          <name>Clarksdale</name>
+          <coordinates>34.200110 -90.570930</coordinates>
+          <location>
+            <name>Fletcher Field</name>
+            <code>KCKM</code>
+            <zone>MSZ010</zone>
+            <radar>shv</radar>
+            <coordinates>34.299722 -90.512306</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Mississippi in United States -->
+          <name>Cleveland</name>
+          <coordinates>33.744000 -90.724820</coordinates>
+          <location>
+            <name>Cleveland Municipal Airport</name>
+            <code>KRNV</code>
+            <zone>MSZ018</zone>
+            <radar>shv</radar>
+            <coordinates>33.762528 -90.757944</coordinates>
           </location>
         </city>
         <city>
@@ -39202,6 +53150,18 @@
             <zone>MSZ031</zone>
             <radar>bhm</radar>
             <coordinates>33.650000 -88.450000</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Mississippi in United States -->
+          <name>Corinth</name>
+          <coordinates>34.934250 -88.522270</coordinates>
+          <location>
+            <name>Roscoe Turner Airport</name>
+            <code>KCRX</code>
+            <zone>MSZ005</zone>
+            <radar>tup</radar>
+            <coordinates>34.914967 -88.603484</coordinates>
           </location>
         </city>
         <city>
@@ -39274,6 +53234,42 @@
           </location>
         </city>
         <city>
+          <!-- A city in Mississippi in United States -->
+          <name>Laurel</name>
+          <coordinates>31.694050 -89.130610</coordinates>
+          <location>
+            <name>Hesler/Noble Field</name>
+            <code>KLUL</code>
+            <zone>MSZ066</zone>
+            <radar>jan</radar>
+            <coordinates>31.673028 -89.172806</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Mississippi in United States -->
+          <name>Louisville</name>
+          <coordinates>33.123740 -89.055060</coordinates>
+          <location>
+            <name>Louisville/Winston County Airport</name>
+            <code>KLMS</code>
+            <zone>MSZ038</zone>
+            <radar>bhm</radar>
+            <coordinates>33.145988 -89.062448</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Mississippi in United States -->
+          <name>Madison</name>
+          <coordinates>32.461810 -90.115360</coordinates>
+          <location>
+            <name>Bruce Campbell Field</name>
+            <code>KMBO</code>
+            <zone>MSZ043</zone>
+            <radar>jan</radar>
+            <coordinates>32.438667 -90.103111</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Mississippi in the United States -->
           <name>McComb</name>
           <coordinates>31.243787 -90.453154</coordinates>
@@ -39302,6 +53298,13 @@
             <zone>MSZ052</zone>
             <radar>jan</radar>
             <coordinates>32.551944 -88.555278</coordinates>
+          </location>
+          <location>
+            <name>Joe Williams Nolf Airport</name>
+            <code>KNJW</code>
+            <zone>MSZ046</zone>
+            <radar>jan</radar>
+            <coordinates>32.798927 -88.834529</coordinates>
           </location>
         </city>
         <city>
@@ -39347,6 +53350,42 @@
           </location>
         </city>
         <city>
+          <!-- A city in Mississippi in United States -->
+          <name>Picayune</name>
+          <coordinates>30.525560 -89.677880</coordinates>
+          <location>
+            <name>Picayune Municipal Airport</name>
+            <code>KMJD</code>
+            <zone>MSZ083</zone>
+            <radar>bix</radar>
+            <coordinates>30.487472 -89.651194</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Mississippi in United States -->
+          <name>Raymond</name>
+          <coordinates>32.259310 -90.422600</coordinates>
+          <location>
+            <name>John Bell Williams Airport</name>
+            <code>KJVW</code>
+            <zone>MSZ048</zone>
+            <radar>jan</radar>
+            <coordinates>32.304472 -90.410528</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Mississippi in United States -->
+          <name>Starkville</name>
+          <coordinates>33.450490 -88.819610</coordinates>
+          <location>
+            <name>George M Bryan Airport</name>
+            <code>KSTF</code>
+            <zone>MSZ033</zone>
+            <radar>bhm</radar>
+            <coordinates>33.433111 -88.848611</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Mississippi in the United States -->
           <name>Tunica</name>
           <coordinates>34.684545 -90.382877</coordinates>
@@ -39379,6 +53418,13 @@
             <radar>shv</radar>
             <coordinates>32.348056 -91.030000</coordinates>
           </location>
+          <location>
+            <name>Vicksburg Municipal Airport</name>
+            <code>KVKS</code>
+            <zone>MSZ047</zone>
+            <radar>shv</radar>
+            <coordinates>32.239145 -90.928195</coordinates>
+          </location>
         </city>
       </state>
       <state>
@@ -39386,6 +53432,78 @@
         <name>Missouri</name>
         <fips-code>US29</fips-code>
         <tz-hint>America/Chicago</tz-hint>
+        <city>
+          <!-- A city in Missouri in United States -->
+          <name>Belton</name>
+          <coordinates>38.811950 -94.531900</coordinates>
+          <location>
+            <name>Richard Gebaur</name>
+            <code>KGVW</code>
+            <zone>KSZ105</zone>
+            <radar>mkc</radar>
+            <coordinates>38.844000 -94.560000</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Missouri in United States -->
+          <name>Boonville</name>
+          <coordinates>38.973640 -92.743240</coordinates>
+          <location>
+            <name>Jesse Viertel Memorial Airport</name>
+            <code>KVER</code>
+            <zone>MOZ046</zone>
+            <radar>stl</radar>
+            <coordinates>38.946722 -92.682667</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Missouri in United States -->
+          <name>Branson</name>
+          <coordinates>36.643670 -93.218510</coordinates>
+          <location>
+            <name>Branson Airport</name>
+            <code>KBBG</code>
+            <zone>MOZ104</zone>
+            <radar>lit</radar>
+            <coordinates>36.532083 -93.200544</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Missouri in United States -->
+          <name>Branson West</name>
+          <coordinates>36.698500 -93.402250</coordinates>
+          <location>
+            <name>Branson West Municipal/Emerson Field</name>
+            <code>KFWB</code>
+            <zone>MOZ103</zone>
+            <radar>lit</radar>
+            <coordinates>36.698500 -93.402250</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Missouri in United States -->
+          <name>Camdenton</name>
+          <coordinates>38.008090 -92.744630</coordinates>
+          <location>
+            <name>Camdenton Memorial-Lake Regional Airport</name>
+            <code>KOZS</code>
+            <zone>MOZ069</zone>
+            <radar>stl</radar>
+            <coordinates>37.972723 -92.690459</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Missouri in United States -->
+          <name>Cameron</name>
+          <coordinates>39.740280 -94.241060</coordinates>
+          <location>
+            <name>Cameron Memorial Airport</name>
+            <code>KEZZ</code>
+            <zone>MOZ021</zone>
+            <radar>mkc</radar>
+            <coordinates>39.727556 -94.276389</coordinates>
+          </location>
+        </city>
         <city>
           <!-- A city in Missouri in the United States -->
           <name>Cape Girardeau</name>
@@ -39422,6 +53540,18 @@
           </location>
         </city>
         <city>
+          <!-- A city in Missouri in United States -->
+          <name>Clinton</name>
+          <coordinates>38.368630 -93.778270</coordinates>
+          <location>
+            <name>Clinton Regional Airport</name>
+            <code>KGLY</code>
+            <zone>MOZ054</zone>
+            <radar>mkc</radar>
+            <coordinates>38.354700 -93.679187</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Missouri in the United States -->
           <name msgctxt="City in Missouri, United States">Columbia</name>
           <coordinates>38.951705 -92.334072</coordinates>
@@ -39442,6 +53572,30 @@
             <code>KFAM</code>
             <zone>MOZ074</zone>
             <coordinates>37.766667 -90.433333</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Missouri in United States -->
+          <name>Hannibal</name>
+          <coordinates>39.708380 -91.358480</coordinates>
+          <location>
+            <name>Hannibal Regional Airport</name>
+            <code>KHAE</code>
+            <zone>MOZ027</zone>
+            <radar>oma</radar>
+            <coordinates>39.725167 -91.443861</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Missouri in United States -->
+          <name>Harrisonville</name>
+          <coordinates>38.653340 -94.348840</coordinates>
+          <location>
+            <name>Lawrence Smith Memorial Airport</name>
+            <code>KLRY</code>
+            <zone>MOZ043</zone>
+            <radar>mkc</radar>
+            <coordinates>38.610194 -94.343528</coordinates>
           </location>
         </city>
         <city>
@@ -39503,6 +53657,18 @@
           </location>
         </city>
         <city>
+          <!-- A city in Missouri in United States -->
+          <name>Kennett</name>
+          <coordinates>36.236180 -90.055650</coordinates>
+          <location>
+            <name>Kennett Memorial Airport</name>
+            <code>KTKX</code>
+            <zone>MOZ113</zone>
+            <radar>stl</radar>
+            <coordinates>36.225862 -90.036641</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Missouri in the United States -->
           <name>Kirksville</name>
           <coordinates>40.194754 -92.583250</coordinates>
@@ -39527,6 +53693,114 @@
           </location>
         </city>
         <city>
+          <!-- A city in Missouri in United States -->
+          <name>Lebanon</name>
+          <coordinates>37.680600 -92.663790</coordinates>
+          <location>
+            <name>Floyd W Jones Lebanon Airport</name>
+            <code>KLBO</code>
+            <zone>MOZ081</zone>
+            <radar>stl</radar>
+            <coordinates>37.648322 -92.652431</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Missouri in United States -->
+          <name>Malden</name>
+          <coordinates>36.557000 -89.966480</coordinates>
+          <location>
+            <name>Malden Regional Airport</name>
+            <code>KMAW</code>
+            <zone>MOZ110</zone>
+            <radar>stl</radar>
+            <coordinates>36.598204 -89.992549</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Missouri in United States -->
+          <name>Marshall</name>
+          <coordinates>39.123080 -93.196870</coordinates>
+          <location>
+            <name>Marshall Memorial Municipal Airport</name>
+            <code>KMHL</code>
+            <zone>MOZ039</zone>
+            <radar>mkc</radar>
+            <coordinates>39.095478 -93.203000</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Missouri in United States -->
+          <name>Maryville</name>
+          <coordinates>40.346100 -94.872470</coordinates>
+          <location>
+            <name>Northwest Missouri Regional Airport</name>
+            <code>KEVU</code>
+            <zone>MOZ002</zone>
+            <radar>mkc</radar>
+            <coordinates>40.353291 -94.916635</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Missouri in United States -->
+          <name>Mexico</name>
+          <coordinates>39.169760 -91.882950</coordinates>
+          <location>
+            <name>Mexico Memorial Airport</name>
+            <code>KMYJ</code>
+            <zone>MOZ042</zone>
+            <radar>stl</radar>
+            <coordinates>39.157511 -91.818264</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Missouri in United States -->
+          <name>Moberly</name>
+          <coordinates>39.418370 -92.438240</coordinates>
+          <location>
+            <name>Omar N Bradley Airport</name>
+            <code>KMBY</code>
+            <zone>MOZ033</zone>
+            <radar>oma</radar>
+            <coordinates>39.463170 -92.425890</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Missouri in United States -->
+          <name>Monett</name>
+          <coordinates>36.928950 -93.927710</coordinates>
+          <location>
+            <name>Monett Regional Airport</name>
+            <code>KHFJ</code>
+            <zone>MOZ102</zone>
+            <radar>okc</radar>
+            <coordinates>36.905129 -94.014166</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Missouri in United States -->
+          <name>Mosby</name>
+          <coordinates>39.332508 -94.309648</coordinates>
+          <location>
+            <name>Midwest Ntl Air Center Airport</name>
+            <code>KGPH</code>
+            <zone>MOZ029</zone>
+            <radar>mkc</radar>
+            <coordinates>39.332508 -94.309648</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Missouri in United States -->
+          <name>Perryville</name>
+          <coordinates>37.724220 -89.861220</coordinates>
+          <location>
+            <name>Perryville Regional Airport</name>
+            <code>KPCD</code>
+            <zone>MOZ076</zone>
+            <radar>stl</radar>
+            <coordinates>37.869348 -89.861873</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Missouri in the United States -->
           <name>Poplar Bluff</name>
           <coordinates>36.756999 -90.392888</coordinates>
@@ -39544,6 +53818,18 @@
             <name>Sedalia Memorial Airport</name>
             <code>KDMO</code>
             <coordinates>38.712222 -93.174444</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Missouri in United States -->
+          <name>Sikeston</name>
+          <coordinates>36.876720 -89.587860</coordinates>
+          <location>
+            <name>Sikeston Memorial Municipal Airport</name>
+            <code>KSIK</code>
+            <zone>MOZ111</zone>
+            <radar>stl</radar>
+            <coordinates>36.898889 -89.561750</coordinates>
           </location>
         </city>
         <city>
@@ -39571,6 +53857,18 @@
           </location>
         </city>
         <city>
+          <!-- A city in Missouri in United States -->
+          <name>Sullivan</name>
+          <coordinates>38.208100 -91.160420</coordinates>
+          <location>
+            <name>Sullivan Regional Airport</name>
+            <code>KUUV</code>
+            <zone>MOZ062</zone>
+            <radar>stl</radar>
+            <coordinates>38.233472 -91.164278</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Missouri in the United States -->
           <name>Unity Village</name>
           <coordinates>38.951396 -94.401618</coordinates>
@@ -39591,6 +53889,42 @@
             <zone>MOZ058</zone>
             <radar>stl</radar>
             <coordinates>38.131944 -91.765278</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Missouri in United States -->
+          <name>Warrensburg</name>
+          <coordinates>38.762790 -93.736050</coordinates>
+          <location>
+            <name>Skyhaven Airport</name>
+            <code>KRCM</code>
+            <zone>MOZ044</zone>
+            <radar>mkc</radar>
+            <coordinates>38.784171 -93.802854</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Missouri in United States -->
+          <name>Warsaw</name>
+          <coordinates>38.243080 -93.381870</coordinates>
+          <location>
+            <name>Warsaw Municipal Airport</name>
+            <code>KRAW</code>
+            <zone>MOZ055</zone>
+            <radar>mkc</radar>
+            <coordinates>38.347847 -93.345388</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Missouri in United States -->
+          <name>Washington</name>
+          <coordinates>38.558110 -91.012090</coordinates>
+          <location>
+            <name>Washington Regional Airport</name>
+            <code>KFYG</code>
+            <zone>MOZ062</zone>
+            <radar>stl</radar>
+            <coordinates>38.587583 -90.993806</coordinates>
           </location>
         </city>
         <city>
@@ -39727,6 +54061,18 @@
           </location>
         </city>
         <city>
+          <!-- A city in Montana in United States -->
+          <name>Ennis</name>
+          <coordinates>45.348820 -111.729700</coordinates>
+          <location>
+            <name>Ennis Big Sky Airport</name>
+            <code>KEKS</code>
+            <zone>MTZ325</zone>
+            <radar>bil</radar>
+            <coordinates>45.275725 -111.648916</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Montana in the United States -->
           <name msgctxt="City in Montana, United States">Glasgow</name>
           <coordinates>48.196964 -106.636713</coordinates>
@@ -39758,6 +54104,18 @@
             <name>Great Falls International Airport</name>
             <code>KGTF</code>
             <coordinates>47.473333 -111.382222</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Montana in United States -->
+          <name>Hamilton</name>
+          <coordinates>46.246870 -114.160370</coordinates>
+          <location>
+            <name>Ravalli County Airport</name>
+            <code>KHRF</code>
+            <zone>MTZ006</zone>
+            <radar>geg</radar>
+            <coordinates>46.257166 -114.123843</coordinates>
           </location>
         </city>
         <city>
@@ -39817,6 +54175,13 @@
             <radar>bil</radar>
             <coordinates>47.049167 -109.466389</coordinates>
           </location>
+          <location>
+            <name>Grass Range</name>
+            <code>KMVH</code>
+            <zone>MTZ318</zone>
+            <radar>bil</radar>
+            <coordinates>46.833333 -108.933333</coordinates>
+          </location>
         </city>
         <city>
           <!-- A city in Montana in the United States -->
@@ -39855,6 +54220,30 @@
           </location>
         </city>
         <city>
+          <!-- A city in Montana in United States -->
+          <name>Plentywood</name>
+          <coordinates>48.774750 -104.562460</coordinates>
+          <location>
+            <name>Sher-Wood Airport</name>
+            <code>KPWD</code>
+            <zone>MTZ019</zone>
+            <radar>bil</radar>
+            <coordinates>48.790516 -104.523738</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Montana in United States -->
+          <name>Shelby</name>
+          <coordinates>48.505260 -111.856970</coordinates>
+          <location>
+            <name>Shelby Airport</name>
+            <code>KSBX</code>
+            <zone>MTZ303</zone>
+            <radar>bil</radar>
+            <coordinates>48.540694 -111.871250</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Montana in the United States -->
           <name msgctxt="City in Montana, United States">Sidney</name>
           <coordinates>47.716684 -104.156325</coordinates>
@@ -39864,6 +54253,18 @@
             <zone>MTZ024</zone>
             <radar>bis</radar>
             <coordinates>47.700000 -104.200000</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Montana in United States -->
+          <name>Twin Bridges</name>
+          <coordinates>45.535417 -112.302278</coordinates>
+          <location>
+            <name>Ruby Valley Field</name>
+            <code>KRVF</code>
+            <zone>MTZ328</zone>
+            <radar>bil</radar>
+            <coordinates>45.535417 -112.302278</coordinates>
           </location>
         </city>
         <city>
@@ -39942,6 +54343,18 @@
           </location>
         </city>
         <city>
+          <!-- A city in Nebraska in United States -->
+          <name>Blair</name>
+          <coordinates>41.544440 -96.125020</coordinates>
+          <location>
+            <name>Blair Executive Airport</name>
+            <code>KBTA</code>
+            <zone>NEZ052</zone>
+            <radar>oma</radar>
+            <coordinates>41.414806 -96.108972</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Nebraska in the United States -->
           <name>Broken Bow</name>
           <coordinates>41.401951 -99.639279</coordinates>
@@ -39951,6 +54364,18 @@
             <zone>NEZ038</zone>
             <radar>lbf</radar>
             <coordinates>41.433333 -99.650000</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Nebraska in United States -->
+          <name>Cambridge</name>
+          <coordinates>40.281950 -100.165690</coordinates>
+          <location>
+            <name>Cambridge Municipal Airport</name>
+            <code>KCSB</code>
+            <zone>NEZ082</zone>
+            <radar>lbf</radar>
+            <coordinates>40.306582 -100.162072</coordinates>
           </location>
         </city>
         <city>
@@ -40001,6 +54426,19 @@
           </location>
         </city>
         <city>
+          <!-- A city in Nebraska in United States -->
+          <name>Gordon</name>
+          <coordinates>42.804720 -102.203220</coordinates>
+          <location>
+            <name>Gordon Municipal Airport</name>
+            <code>KGRN</code>
+            <tz-hint>America/Denver</tz-hint>
+            <zone>NEZ004</zone>
+            <radar>cpr</radar>
+            <coordinates>42.805978 -102.175250</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Nebraska in the United States -->
           <name>Grand Island</name>
           <coordinates>40.925012 -98.342007</coordinates>
@@ -40010,6 +54448,19 @@
             <zone>NEZ062</zone>
             <radar>lbr</radar>
             <coordinates>40.958333 -98.312500</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Nebraska in United States -->
+          <name>Grant</name>
+          <coordinates>40.841940 -101.725170</coordinates>
+          <location>
+            <name>Grant Municipal Airport</name>
+            <code>KGGF</code>
+            <tz-hint>America/Denver</tz-hint>
+            <zone>NEZ058</zone>
+            <radar>lbf</radar>
+            <coordinates>40.870663 -101.733879</coordinates>
           </location>
         </city>
         <city>
@@ -40278,6 +54729,18 @@
           </location>
         </city>
         <city>
+          <!-- A city in Nebraska in United States -->
+          <name>Wahoo</name>
+          <coordinates>41.211390 -96.620300</coordinates>
+          <location>
+            <name>Wahoo Municipal Airport</name>
+            <code>KAHQ</code>
+            <zone>NEZ051</zone>
+            <radar>oma</radar>
+            <coordinates>41.240605 -96.594549</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Nebraska in the United States -->
           <name>Wayne</name>
           <coordinates>42.230559 -97.017824</coordinates>
@@ -40303,6 +54766,54 @@
         <name>Nevada</name>
         <fips-code>US32</fips-code>
         <tz-hint>America/Los_Angeles</tz-hint>
+        <city>
+          <!-- A city in Nevada in United States -->
+          <name>Austin</name>
+          <coordinates>39.467943 -117.197454</coordinates>
+          <location>
+            <name>Austin Airport</name>
+            <code>KTMT</code>
+            <zone>NVZ037</zone>
+            <radar>rno</radar>
+            <coordinates>39.467943 -117.197454</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Nevada in United States -->
+          <name>Battle Mountain</name>
+          <coordinates>40.642130 -116.934270</coordinates>
+          <location>
+            <name>Battle Mountain Airport</name>
+            <code>KBAM</code>
+            <zone>NVZ036</zone>
+            <radar>rbl</radar>
+            <coordinates>40.599056 -116.874333</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Nevada in United States -->
+          <name>Boulder City</name>
+          <coordinates>35.978590 -114.832490</coordinates>
+          <location>
+            <name>Boulder City Municipal Airport</name>
+            <code>KBVU</code>
+            <zone>NVZ020</zone>
+            <radar>las</radar>
+            <coordinates>35.947308 -114.861084</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Nevada in United States -->
+          <name>Carson City</name>
+          <coordinates>39.163800 -119.767400</coordinates>
+          <location>
+            <name>Carson City Airport</name>
+            <code>KCXP</code>
+            <zone>NVZ002</zone>
+            <radar>rno</radar>
+            <coordinates>39.192304 -119.732571</coordinates>
+          </location>
+        </city>
         <city>
           <!-- A city in Nevada in the United States -->
           <name>Elko</name>
@@ -40352,6 +54863,18 @@
           </location>
         </city>
         <city>
+          <!-- A city in Nevada in United States -->
+          <name>Hawthorne</name>
+          <coordinates>38.524640 -118.624580</coordinates>
+          <location>
+            <name>Hawthorne Industrial Airport</name>
+            <code>KHTH</code>
+            <zone>NVZ001</zone>
+            <radar>rno</radar>
+            <coordinates>38.545077 -118.632403</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Nevada in the United States -->
           <name msgctxt="City in Nevada, United States">Henderson</name>
           <coordinates>36.039699 -114.981937</coordinates>
@@ -40361,6 +54884,18 @@
             <zone>NVZ020</zone>
             <radar>las</radar>
             <coordinates>35.972778 -115.134444</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Nevada in United States -->
+          <name>Indian Springs</name>
+          <coordinates>36.569680 -115.670580</coordinates>
+          <location>
+            <name>Creech Afb Airport</name>
+            <code>KINS</code>
+            <zone>NVZ017</zone>
+            <radar>las</radar>
+            <coordinates>36.586344 -115.677371</coordinates>
           </location>
         </city>
         <city>
@@ -40413,6 +54948,18 @@
           </location>
         </city>
         <city>
+          <!-- A city in Nevada in United States -->
+          <name>Minden</name>
+          <coordinates>38.954070 -119.765730</coordinates>
+          <location>
+            <name>Minden-Tahoe Airport</name>
+            <code>KMEV</code>
+            <zone>CAZ072</zone>
+            <radar>rno</radar>
+            <coordinates>39.000500 -119.751111</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Nevada in the United States -->
           <name>North Las Vegas</name>
           <coordinates>36.198859 -115.117501</coordinates>
@@ -40434,6 +54981,13 @@
             <zone>NVZ003</zone>
             <radar>rno</radar>
             <coordinates>39.483889 -119.771111</coordinates>
+          </location>
+          <location>
+            <name>Reno/Stead Airport</name>
+            <code>KRTS</code>
+            <zone>NVZ003</zone>
+            <radar>rno</radar>
+            <coordinates>39.668177 -119.876440</coordinates>
           </location>
         </city>
         <city>
@@ -40705,6 +55259,30 @@
           </location>
         </city>
         <city>
+          <!-- A city in New Jersey in United States -->
+          <name>Lakehurst</name>
+          <coordinates>40.014560 -74.311260</coordinates>
+          <location>
+            <name>Lakehurst Maxfield Field</name>
+            <code>KNEL</code>
+            <zone>NJZ020</zone>
+            <radar>har</radar>
+            <coordinates>40.035788 -74.351366</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in New Jersey in United States -->
+          <name>Linden</name>
+          <coordinates>40.622050 -74.244590</coordinates>
+          <location>
+            <name>Linden Airport</name>
+            <code>KLDJ</code>
+            <zone>NJZ108</zone>
+            <radar>har</radar>
+            <coordinates>40.617449 -74.244594</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in New Jersey in the United States -->
           <name>Millville</name>
           <coordinates>39.402060 -75.039344</coordinates>
@@ -40796,6 +55374,18 @@
           </location>
         </city>
         <city>
+          <!-- A city in New Jersey in United States -->
+          <name>Toms River</name>
+          <coordinates>39.953730 -74.197920</coordinates>
+          <location>
+            <name>Ocean County Airport</name>
+            <code>KMJX</code>
+            <zone>NJZ020</zone>
+            <radar>har</radar>
+            <coordinates>39.926042 -74.295535</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in New Jersey in the United States -->
           <name msgctxt="City in New Jersey, United States">Trenton</name>
           <coordinates>40.217053 -74.742938</coordinates>
@@ -40805,6 +55395,18 @@
             <zone>NJZ015</zone>
             <radar>har</radar>
             <coordinates>40.276389 -74.816389</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in New Jersey in United States -->
+          <name>Wildwood</name>
+          <coordinates>38.991780 -74.814890</coordinates>
+          <location>
+            <name>Cape May County Airport</name>
+            <code>KWWD</code>
+            <zone>NJZ024</zone>
+            <radar>dca</radar>
+            <coordinates>39.008369 -74.908509</coordinates>
           </location>
         </city>
       </state>
@@ -40850,6 +55452,18 @@
           </location>
         </city>
         <city>
+          <!-- A city in New Mexico in United States -->
+          <name>Angel Fire</name>
+          <coordinates>36.393090 -105.285010</coordinates>
+          <location>
+            <name>Angel Fire Airport</name>
+            <code>KAXX</code>
+            <zone>NMZ215</zone>
+            <radar>abq</radar>
+            <coordinates>36.422000 -105.289905</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in New Mexico in the United States -->
           <name>Artesia</name>
           <coordinates>32.842334 -104.403296</coordinates>
@@ -40857,6 +55471,18 @@
             <name>Artesia Municipal Airport</name>
             <code>KATS</code>
             <coordinates>32.852500 -104.467500</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in New Mexico in United States -->
+          <name>Belen</name>
+          <coordinates>34.662840 -106.776420</coordinates>
+          <location>
+            <name>Belen Regional Airport</name>
+            <code>KBRG</code>
+            <zone>NMZ219</zone>
+            <radar>abq</radar>
+            <coordinates>34.645862 -106.836340</coordinates>
           </location>
         </city>
         <city>
@@ -41017,6 +55643,18 @@
           </location>
         </city>
         <city>
+          <!-- A city in New Mexico in United States -->
+          <name>Lordsburg</name>
+          <coordinates>32.350360 -108.708660</coordinates>
+          <location>
+            <name>Lordsburg Municipal Airport</name>
+            <code>KLSB</code>
+            <zone>NMZ405</zone>
+            <radar>abq</radar>
+            <coordinates>32.333657 -108.691860</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in New Mexico in the United States -->
           <name>Los Alamos</name>
           <coordinates>35.888080 -106.306972</coordinates>
@@ -41085,6 +55723,30 @@
           </location>
         </city>
         <city>
+          <!-- A city in New Mexico in United States -->
+          <name>Santa Rosa</name>
+          <coordinates>34.938670 -104.682490</coordinates>
+          <location>
+            <name>Santa Rosa Route 66 Airport</name>
+            <code>KSXU</code>
+            <zone>NMZ233</zone>
+            <radar>abq</radar>
+            <coordinates>34.935672 -104.642564</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in New Mexico in United States -->
+          <name>Santa Teresa</name>
+          <coordinates>31.855940 -106.639160</coordinates>
+          <location>
+            <name>Dona Ana County International Jetport Airport</name>
+            <code>KDNA</code>
+            <zone>TXZ418</zone>
+            <radar>abq</radar>
+            <coordinates>31.880444 -106.703250</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in New Mexico in the United States -->
           <name>Silver City</name>
           <coordinates>32.770075 -108.280326</coordinates>
@@ -41094,6 +55756,18 @@
             <zone>NMZ022</zone>
             <radar>abq</radar>
             <coordinates>32.633333 -108.150000</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in New Mexico in United States -->
+          <name>Socorro</name>
+          <coordinates>34.058400 -106.891420</coordinates>
+          <location>
+            <name>Socorro Municipal Airport</name>
+            <code>KONM</code>
+            <zone>NMZ220</zone>
+            <radar>abq</radar>
+            <coordinates>34.022472 -106.903139</coordinates>
           </location>
         </city>
         <city>
@@ -41142,6 +55816,18 @@
             <coordinates>35.182778 -103.603056</coordinates>
           </location>
         </city>
+        <city>
+          <!-- A city in New Mexico in United States -->
+          <name>Zuni</name>
+          <coordinates>35.072530 -108.850640</coordinates>
+          <location>
+            <name>Andrew Othole Memorial Airport</name>
+            <code>KXNI</code>
+            <zone>NMZ205</zone>
+            <radar>abq</radar>
+            <coordinates>35.060675 -108.937599</coordinates>
+          </location>
+        </city>
       </state>
       <state>
         <!-- A state/province/territory in United States -->
@@ -41158,6 +55844,18 @@
             <zone>NYZ052</zone>
             <radar>roc</radar>
             <coordinates>42.748056 -73.801667</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in United States -->
+          <name>Batavia</name>
+          <coordinates>42.998120 -78.187520</coordinates>
+          <location>
+            <name>Genesee County Airport</name>
+            <code>KGVQ</code>
+            <zone>NYZ011</zone>
+            <radar>roc</radar>
+            <coordinates>43.031750 -78.169667</coordinates>
           </location>
         </city>
         <city>
@@ -41197,6 +55895,18 @@
           </location>
         </city>
         <city>
+          <!-- A city in United States -->
+          <name>Canandaigua</name>
+          <coordinates>42.874230 -77.288040</coordinates>
+          <location>
+            <name>Canandaigua Airport</name>
+            <code>KIUA</code>
+            <zone>NYZ014</zone>
+            <radar>roc</radar>
+            <coordinates>42.908902 -77.325226</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in New York in the United States -->
           <name>Dansville</name>
           <coordinates>42.560900 -77.696106</coordinates>
@@ -41225,6 +55935,13 @@
             <code>KHTO</code>
             <coordinates>40.959444 -72.251944</coordinates>
           </location>
+          <location>
+            <name>East Hampton Town Airport</name>
+            <code>KJPX</code>
+            <zone>NYZ081</zone>
+            <radar>nyc</radar>
+            <coordinates>40.959417 -72.251667</coordinates>
+          </location>
         </city>
         <city>
           <!-- A city in New York in the United States -->
@@ -41251,6 +55968,18 @@
           </location>
         </city>
         <city>
+          <!-- A city in United States -->
+          <name>Financial District</name>
+          <coordinates>40.707890 -74.008570</coordinates>
+          <location>
+            <name>Port Authority Downtown Manhattan/Wall Street Heliport</name>
+            <code>KJRB</code>
+            <zone>NJZ006</zone>
+            <radar>nyc</radar>
+            <coordinates>40.701000 -74.009000</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in New York in the United States -->
           <name>Fulton</name>
           <coordinates>43.322846 -76.417158</coordinates>
@@ -41270,6 +55999,18 @@
             <zone>NYZ042</zone>
             <radar>bos</radar>
             <coordinates>43.341111 -73.610556</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in United States -->
+          <name>Hamilton</name>
+          <coordinates>42.827010 -75.544620</coordinates>
+          <location>
+            <name>Hamilton Municipal Airport</name>
+            <code>KVGC</code>
+            <zone>NYZ036</zone>
+            <radar>roc</radar>
+            <coordinates>42.843444 -75.561194</coordinates>
           </location>
         </city>
         <city>
@@ -41306,6 +56047,18 @@
             <zone>NYZ019</zone>
             <radar>pit</radar>
             <coordinates>42.150000 -79.266667</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in United States -->
+          <name>Lake Placid</name>
+          <coordinates>44.279620 -73.981980</coordinates>
+          <location>
+            <name>Lake Placid Airport</name>
+            <code>KLKP</code>
+            <zone>NYZ034</zone>
+            <radar>roc</radar>
+            <coordinates>44.264478 -73.961869</coordinates>
           </location>
         </city>
         <city>
@@ -41405,6 +56158,42 @@
           </location>
         </city>
         <city>
+          <!-- A city in United States -->
+          <name>Norwich</name>
+          <coordinates>42.531180 -75.523510</coordinates>
+          <location>
+            <name>Lt Warren Eaton Airport</name>
+            <code>KOIC</code>
+            <zone>NYZ045</zone>
+            <radar>roc</radar>
+            <coordinates>42.566556 -75.524111</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in United States -->
+          <name>Ogdensburg</name>
+          <coordinates>44.694230 -75.486340</coordinates>
+          <location>
+            <name>Ogdensburg International Airport</name>
+            <code>KOGS</code>
+            <zone>NYZ087</zone>
+            <radar>roc</radar>
+            <coordinates>44.682250 -75.463250</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in United States -->
+          <name>Olean</name>
+          <coordinates>42.077560 -78.429740</coordinates>
+          <location>
+            <name>Cattaraugus County-Olean Airport</name>
+            <code>KOLE</code>
+            <zone>NYZ020</zone>
+            <radar>pit</radar>
+            <coordinates>42.241194 -78.371361</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in New York in the United States -->
           <name>Penn Yan</name>
           <coordinates>42.660903 -77.053858</coordinates>
@@ -41423,6 +56212,18 @@
             <name>Plattsburgh Air Force Base</name>
             <code>KPBG</code>
             <coordinates>44.650000 -73.466667</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in United States -->
+          <name>Potsdam</name>
+          <coordinates>44.669780 -74.981310</coordinates>
+          <location>
+            <name>Potsdam Municipal/Damon Field</name>
+            <code>KPTD</code>
+            <zone>NYZ026</zone>
+            <radar>roc</radar>
+            <coordinates>44.676667 -74.948444</coordinates>
           </location>
         </city>
         <city>
@@ -41469,6 +56270,18 @@
             <zone>NYZ027</zone>
             <radar>roc</radar>
             <coordinates>44.393056 -74.202778</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in United States -->
+          <name>Schenectady</name>
+          <coordinates>42.814240 -73.939570</coordinates>
+          <location>
+            <name>Schenectady County Airport</name>
+            <code>KSCH</code>
+            <zone>NYZ049</zone>
+            <radar>roc</radar>
+            <coordinates>42.852718 -73.929564</coordinates>
           </location>
         </city>
         <city>
@@ -41537,6 +56350,18 @@
             <zone>NYZ070</zone>
             <radar>nyc</radar>
             <coordinates>41.066944 -73.707500</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in United States -->
+          <name>Williamson/Sodus</name>
+          <coordinates>43.223950 -77.186090</coordinates>
+          <location>
+            <name>Williamson/Sodus Airport</name>
+            <code>KSDC</code>
+            <zone>NYZ004</zone>
+            <radar>roc</radar>
+            <coordinates>43.234597 -77.119464</coordinates>
           </location>
         </city>
         <city>
@@ -41946,6 +56771,18 @@
           </location>
         </city>
         <city>
+          <!-- A city in North Carolina in United States -->
+          <name>Lincolnton</name>
+          <coordinates>35.473750 -81.254530</coordinates>
+          <location>
+            <name>Lincoln County Regional Airport</name>
+            <code>KIPJ</code>
+            <zone>NCZ069</zone>
+            <radar>avl</radar>
+            <coordinates>35.483142 -81.161506</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in North Carolina in the United States -->
           <name>Louisburg</name>
           <coordinates>36.099039 -78.301106</coordinates>
@@ -41993,6 +56830,18 @@
             <name>Monroe Airport</name>
             <code>KEQY</code>
             <coordinates>35.016944 -80.620556</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in North Carolina in United States -->
+          <name>Morganton</name>
+          <coordinates>35.745410 -81.684820</coordinates>
+          <location>
+            <name>Foothills Regional Airport</name>
+            <code>KMRN</code>
+            <zone>NCZ504</zone>
+            <radar>avl</radar>
+            <coordinates>35.820222 -81.611417</coordinates>
           </location>
         </city>
         <city>
@@ -42070,6 +56919,30 @@
           </location>
         </city>
         <city>
+          <!-- A city in North Carolina in United States -->
+          <name>Reidsville</name>
+          <coordinates>36.354860 -79.664470</coordinates>
+          <location>
+            <name>Rockingham County Nc Shiloh Airport</name>
+            <code>KSIF</code>
+            <zone>NCZ005</zone>
+            <radar>clt</radar>
+            <coordinates>36.437216 -79.851010</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in North Carolina in United States -->
+          <name>Richlands</name>
+          <coordinates>34.899330 -77.546630</coordinates>
+          <location>
+            <name>Albert J Ellis Airport</name>
+            <code>KOAJ</code>
+            <zone>NCZ198</zone>
+            <radar>clt</radar>
+            <coordinates>34.829167 -77.612139</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in North Carolina in the United States -->
           <name>Roanoke Rapids</name>
           <coordinates>36.461540 -77.654146</coordinates>
@@ -42077,6 +56950,25 @@
             <name>Halifax County Airport</name>
             <code>KRZZ</code>
             <coordinates>36.439444 -77.709722</coordinates>
+          </location>
+          <location>
+            <name>Halifax/Northampton Regional Airport</name>
+            <code>KIXA</code>
+            <zone>NCZ011</zone>
+            <radar>clt</radar>
+            <coordinates>36.329792 -77.635231</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in North Carolina in United States -->
+          <name>Rockingham</name>
+          <coordinates>34.939320 -79.773950</coordinates>
+          <location>
+            <name>Richmond County Airport</name>
+            <code>KRCZ</code>
+            <zone>NCZ084</zone>
+            <radar>clt</radar>
+            <coordinates>34.891303 -79.759598</coordinates>
           </location>
         </city>
         <city>
@@ -42112,6 +57004,18 @@
           </location>
         </city>
         <city>
+          <!-- A city in North Carolina in United States -->
+          <name>Rutherfordton</name>
+          <coordinates>35.369290 -81.956770</coordinates>
+          <location>
+            <name>Rutherford County/Marchman Field</name>
+            <code>KFQD</code>
+            <zone>NCZ508</zone>
+            <radar>avl</radar>
+            <coordinates>35.428222 -81.935078</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in North Carolina in the United States -->
           <name msgctxt="City in North Carolina, United States">Salisbury</name>
           <coordinates>35.670973 -80.474226</coordinates>
@@ -42142,6 +57046,18 @@
           </location>
         </city>
         <city>
+          <!-- A city in North Carolina in United States -->
+          <name>Siler City</name>
+          <coordinates>35.723470 -79.462240</coordinates>
+          <location>
+            <name>Siler City Municipal Airport</name>
+            <code>KSCR</code>
+            <zone>NCZ040</zone>
+            <radar>clt</radar>
+            <coordinates>35.704274 -79.504298</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in North Carolina in the United States -->
           <name>Smithfield</name>
           <coordinates>35.508494 -78.339445</coordinates>
@@ -42162,6 +57078,18 @@
           </location>
         </city>
         <city>
+          <!-- A city in North Carolina in United States -->
+          <name>Tarboro</name>
+          <coordinates>35.896820 -77.535800</coordinates>
+          <location>
+            <name>Tarboro-Edgecombe Airport</name>
+            <code>KETC</code>
+            <zone>NCZ028</zone>
+            <radar>clt</radar>
+            <coordinates>35.937263 -77.546480</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in North Carolina in the United States -->
           <name>Wadesboro</name>
           <coordinates>34.968210 -80.076727</coordinates>
@@ -42172,6 +57100,18 @@
           </location>
         </city>
         <city>
+          <!-- A city in North Carolina in United States -->
+          <name>Wallace</name>
+          <coordinates>34.735720 -77.995260</coordinates>
+          <location>
+            <name>Wallace-Pender Airport</name>
+            <code>KACZ</code>
+            <zone>NCZ105</zone>
+            <radar>chs</radar>
+            <coordinates>34.717867 -78.003880</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in North Carolina in the United States -->
           <name msgctxt="City in North Carolina, United States">Washington</name>
           <coordinates>35.546552 -77.052174</coordinates>
@@ -42179,6 +57119,30 @@
             <name>Warren Field Airport</name>
             <code>KOCW</code>
             <coordinates>35.570556 -77.049722</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in North Carolina in United States -->
+          <name>Whiteville</name>
+          <coordinates>34.338780 -78.703070</coordinates>
+          <location>
+            <name>Columbus County Regional Airport</name>
+            <code>KCPC</code>
+            <zone>NCZ099</zone>
+            <radar>chs</radar>
+            <coordinates>34.272871 -78.714987</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in North Carolina in United States -->
+          <name>Williamston</name>
+          <coordinates>35.854600 -77.055510</coordinates>
+          <location>
+            <name>Martin County Airport</name>
+            <code>KMCZ</code>
+            <zone>NCZ029</zone>
+            <radar>clt</radar>
+            <coordinates>35.862193 -77.178201</coordinates>
           </location>
         </city>
         <city>
@@ -42242,6 +57206,14 @@
             <code>KBPP</code>
             <coordinates>46.186944 -103.428056</coordinates>
           </location>
+          <location>
+            <name>Bowman Regional Airport</name>
+            <code>KBWW</code>
+            <tz-hint>America/Denver</tz-hint>
+            <zone>NDZ043</zone>
+            <radar>bis</radar>
+            <coordinates>46.165519 -103.300743</coordinates>
+          </location>
         </city>
         <city>
           <!-- A city in North Dakota in the United States -->
@@ -42291,6 +57263,18 @@
           </location>
         </city>
         <city>
+          <!-- A city in North Dakota in United States -->
+          <name>Grafton</name>
+          <coordinates>48.412210 -97.410630</coordinates>
+          <location>
+            <name>Hutson Field</name>
+            <code>KGAF</code>
+            <zone>NDZ016</zone>
+            <radar>bis</radar>
+            <coordinates>48.404716 -97.370957</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in North Dakota in the United States -->
           <name>Grand Forks</name>
           <coordinates>47.925257 -97.032855</coordinates>
@@ -42307,6 +57291,31 @@
             <zone>NDZ027</zone>
             <radar>bis</radar>
             <coordinates>47.966667 -97.400000</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in North Dakota in United States -->
+          <name>Gwinner</name>
+          <coordinates>46.225800 -97.662600</coordinates>
+          <location>
+            <name>Gwinner/Roger Melroe Field</name>
+            <code>KGWR</code>
+            <zone>NDZ052</zone>
+            <radar>bis</radar>
+            <coordinates>46.218278 -97.643361</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in North Dakota in United States -->
+          <name>Hazen</name>
+          <coordinates>47.294450 -101.622660</coordinates>
+          <location>
+            <name>Mercer County Regional Airport</name>
+            <code>KHZE</code>
+            <tz-hint>America/North_Dakota/New_Salem</tz-hint>
+            <zone>NDZ019</zone>
+            <radar>bis</radar>
+            <coordinates>47.289935 -101.580978</coordinates>
           </location>
         </city>
         <city>
@@ -42343,6 +57352,37 @@
             <radar>bis</radar>
             <coordinates>48.259444 -101.280278</coordinates>
           </location>
+          <location>
+            <name>Minot Afb Airport</name>
+            <code>KMIB</code>
+            <zone>NDZ056</zone>
+            <radar>bis</radar>
+            <coordinates>48.415768 -101.358041</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in North Dakota in United States -->
+          <name>Rugby</name>
+          <coordinates>48.368890 -99.996250</coordinates>
+          <location>
+            <name>Rugby Municipal Airport</name>
+            <code>KRUG</code>
+            <zone>NDZ013</zone>
+            <radar>bis</radar>
+            <coordinates>48.390361 -100.024278</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in North Dakota in United States -->
+          <name>Valley City</name>
+          <coordinates>46.923310 -98.003150</coordinates>
+          <location>
+            <name>Barnes County Municipal Airport</name>
+            <code>KBAC</code>
+            <zone>NDZ038</zone>
+            <radar>bis</radar>
+            <coordinates>46.941192 -98.017931</coordinates>
+          </location>
         </city>
         <city>
           <!-- A city in North Dakota in the United States -->
@@ -42364,6 +57404,13 @@
             <zone>NDZ009</zone>
             <radar>bis</radar>
             <coordinates>48.173889 -103.636667</coordinates>
+          </location>
+          <location>
+            <name>Williston Basin International Airport</name>
+            <code>KXWA</code>
+            <zone>NDZ009</zone>
+            <radar>bis</radar>
+            <coordinates>48.259784 -103.750557</coordinates>
           </location>
         </city>
       </state>
@@ -42392,6 +57439,18 @@
           </location>
         </city>
         <city>
+          <!-- A city in Ohio in United States -->
+          <name>Albany</name>
+          <coordinates>39.227570 -82.202370</coordinates>
+          <location>
+            <name>Ohio University Airport</name>
+            <code>KUNI</code>
+            <zone>OHZ075</zone>
+            <radar>ind</radar>
+            <coordinates>39.211893 -82.229255</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Ohio in the United States -->
           <name>Ashtabula</name>
           <coordinates>41.865053 -80.789809</coordinates>
@@ -42399,6 +57458,30 @@
             <name>Ashtabula County Airport</name>
             <code>KHZY</code>
             <coordinates>41.779444 -80.696667</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Ohio in United States -->
+          <name>Cambridge</name>
+          <coordinates>40.031180 -81.588460</coordinates>
+          <location>
+            <name>Cambridge Municipal Airport</name>
+            <code>KCDI</code>
+            <zone>OHZ058</zone>
+            <radar>pit</radar>
+            <coordinates>39.975028 -81.577583</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Ohio in United States -->
+          <name>Chillicothe</name>
+          <coordinates>39.333120 -82.982400</coordinates>
+          <location>
+            <name>Ross County Airport</name>
+            <code>KRZT</code>
+            <zone>OHZ073</zone>
+            <radar>ind</radar>
+            <coordinates>39.440417 -83.023056</coordinates>
           </location>
         </city>
         <city>
@@ -42504,6 +57587,13 @@
             <radar>ind</radar>
             <coordinates>39.588889 -84.224722</coordinates>
           </location>
+          <location>
+            <name>Greene County/Lewis A Jackson Regional Airport</name>
+            <code>KGDK</code>
+            <zone>OHZ062</zone>
+            <radar>ind</radar>
+            <coordinates>39.690722 -83.992778</coordinates>
+          </location>
         </city>
         <city>
           <!-- A city in Ohio in the United States -->
@@ -42513,6 +57603,18 @@
             <name>Defiance Memorial Airport</name>
             <code>KDFI</code>
             <coordinates>41.336389 -84.429444</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Ohio in United States -->
+          <name>Delaware</name>
+          <coordinates>40.298670 -83.067970</coordinates>
+          <location>
+            <name>Delaware Municipal/Jim Moore Field</name>
+            <code>KDLZ</code>
+            <zone>OHZ046</zone>
+            <radar>ind</radar>
+            <coordinates>40.279542 -83.113384</coordinates>
           </location>
         </city>
         <city>
@@ -42550,6 +57652,18 @@
           </location>
         </city>
         <city>
+          <!-- A city in Ohio in United States -->
+          <name>Jackson</name>
+          <coordinates>39.052020 -82.636550</coordinates>
+          <location>
+            <name>James A Rhodes Airport</name>
+            <code>KJRO</code>
+            <zone>OHZ083</zone>
+            <radar>ind</radar>
+            <coordinates>38.981360 -82.577850</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Ohio in the United States -->
           <name msgctxt="City in Ohio, United States">Lancaster</name>
           <coordinates>39.713675 -82.599329</coordinates>
@@ -42569,6 +57683,18 @@
             <name>Lima Allen County Airport</name>
             <code>KAOH</code>
             <coordinates>40.708056 -84.021389</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Ohio in United States -->
+          <name>London</name>
+          <coordinates>39.886450 -83.448250</coordinates>
+          <location>
+            <name>Madison County Airport</name>
+            <code>KUYF</code>
+            <zone>OHZ054</zone>
+            <radar>ind</radar>
+            <coordinates>39.932722 -83.462000</coordinates>
           </location>
         </city>
         <city>
@@ -42594,6 +57720,30 @@
           </location>
         </city>
         <city>
+          <!-- A city in Ohio in United States -->
+          <name>Marysville</name>
+          <coordinates>40.236450 -83.367140</coordinates>
+          <location>
+            <name>Union County Airport</name>
+            <code>KMRT</code>
+            <zone>OHZ045</zone>
+            <radar>ind</radar>
+            <coordinates>40.224476 -83.351748</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Ohio in United States -->
+          <name>Middletown</name>
+          <coordinates>39.515060 -84.398280</coordinates>
+          <location>
+            <name>Middletown Regional/Hook Field</name>
+            <code>KMWO</code>
+            <zone>OHZ070</zone>
+            <radar>ind</radar>
+            <coordinates>39.531750 -84.396444</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Ohio in the United States -->
           <name>New Philadelphia</name>
           <coordinates>40.489787 -81.445671</coordinates>
@@ -42611,6 +57761,66 @@
             <name>Newark Heath Airport</name>
             <code>KVTA</code>
             <coordinates>40.022778 -82.462500</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Ohio in United States -->
+          <name>Ottawa</name>
+          <coordinates>41.019220 -84.047170</coordinates>
+          <location>
+            <name>Putnam County Airport</name>
+            <code>KOWX</code>
+            <zone>OHZ016</zone>
+            <radar>dtw</radar>
+            <coordinates>41.035595 -83.981894</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Ohio in United States -->
+          <name>Oxford</name>
+          <coordinates>39.507000 -84.745230</coordinates>
+          <location>
+            <name>Miami University Airport</name>
+            <code>KOXD</code>
+            <zone>INZ059</zone>
+            <radar>ind</radar>
+            <coordinates>39.502260 -84.784381</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Ohio in United States -->
+          <name>Port Clinton</name>
+          <coordinates>41.512000 -82.937690</coordinates>
+          <location>
+            <name>Erie-Ottawa International Airport</name>
+            <code>KPCW</code>
+            <zone>OHZ007</zone>
+            <radar>dtw</radar>
+            <coordinates>41.516271 -82.869487</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Ohio in United States -->
+          <name>Portsmouth</name>
+          <coordinates>38.731740 -82.997670</coordinates>
+          <location>
+            <name>Greater Portsmouth Regional Airport</name>
+            <code>KPMH</code>
+            <zone>OHZ088</zone>
+            <radar>ind</radar>
+            <coordinates>38.840472 -82.847309</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Ohio in United States -->
+          <name>Ravenna</name>
+          <coordinates>41.157560 -81.242050</coordinates>
+          <location>
+            <name>Portage County Airport</name>
+            <code>KPOV</code>
+            <zone>OHZ022</zone>
+            <radar>pit</radar>
+            <coordinates>41.210183 -81.251624</coordinates>
           </location>
         </city>
         <city>
@@ -42640,6 +57850,66 @@
             <zone>OHZ003</zone>
             <radar>dtw</radar>
             <coordinates>41.588611 -83.801389</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Ohio in United States -->
+          <name>Van Wert</name>
+          <coordinates>40.869490 -84.584120</coordinates>
+          <location>
+            <name>Van Wert County Airport</name>
+            <code>KVNW</code>
+            <zone>OHZ024</zone>
+            <radar>dtw</radar>
+            <coordinates>40.863940 -84.607964</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Ohio in United States -->
+          <name>Versailles</name>
+          <coordinates>40.222550 -84.484400</coordinates>
+          <location>
+            <name>Darke County Airport</name>
+            <code>KVES</code>
+            <zone>OHZ042</zone>
+            <radar>ind</radar>
+            <coordinates>40.204411 -84.532423</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Ohio in United States -->
+          <name>Wapakoneta</name>
+          <coordinates>40.567830 -84.193560</coordinates>
+          <location>
+            <name>Neil Armstrong Airport</name>
+            <code>KAXV</code>
+            <zone>OHZ035</zone>
+            <radar>ind</radar>
+            <coordinates>40.493548 -84.298074</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Ohio in United States -->
+          <name>Wauseon</name>
+          <coordinates>41.549220 -84.141610</coordinates>
+          <location>
+            <name>Fulton County Airport</name>
+            <code>KUSE</code>
+            <zone>OHZ002</zone>
+            <radar>dtw</radar>
+            <coordinates>41.609779 -84.127189</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Ohio in United States -->
+          <name>Willoughby</name>
+          <coordinates>41.639770 -81.406500</coordinates>
+          <location>
+            <name>Lake County Executive Airport</name>
+            <code>KLNN</code>
+            <zone>OHZ012</zone>
+            <radar>dtw</radar>
+            <coordinates>41.684028 -81.389750</coordinates>
           </location>
         </city>
         <city>
@@ -42775,6 +58045,18 @@
           </location>
         </city>
         <city>
+          <!-- A city in Oklahoma in United States -->
+          <name>Blackwell</name>
+          <coordinates>36.804480 -97.282820</coordinates>
+          <location>
+            <name>Blackwell-Tonkawa Municipal Airport</name>
+            <code>KBKN</code>
+            <zone>OKZ008</zone>
+            <radar>okc</radar>
+            <coordinates>36.745111 -97.349583</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Oklahoma in the United States -->
           <name msgctxt="City in Oklahoma, United States">Chandler</name>
           <coordinates>35.701731 -96.880858</coordinates>
@@ -42862,6 +58144,18 @@
           </location>
         </city>
         <city>
+          <!-- A city in Oklahoma in United States -->
+          <name>Elk City</name>
+          <coordinates>35.411990 -99.404260</coordinates>
+          <location>
+            <name>Elk City Regional Business Airport</name>
+            <code>KELK</code>
+            <zone>OKZ021</zone>
+            <radar>ama</radar>
+            <coordinates>35.430778 -99.394278</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Oklahoma in the United States -->
           <name>Enid</name>
           <coordinates>36.395589 -97.878391</coordinates>
@@ -42946,6 +58240,18 @@
           </location>
         </city>
         <city>
+          <!-- A city in Oklahoma in United States -->
+          <name>Hugo</name>
+          <coordinates>34.010660 -95.509680</coordinates>
+          <location>
+            <name>Stan Stamper Municipal Airport</name>
+            <code>KHHW</code>
+            <zone>OKZ053</zone>
+            <radar>okc</radar>
+            <coordinates>34.033639 -95.542056</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Oklahoma in the United States -->
           <name>Idabel</name>
           <coordinates>33.895665 -94.826328</coordinates>
@@ -42984,6 +58290,18 @@
             <zone>OKZ073</zone>
             <radar>okc</radar>
             <coordinates>34.882222 -95.783056</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Oklahoma in United States -->
+          <name>Miami</name>
+          <coordinates>36.874510 -94.877460</coordinates>
+          <location>
+            <name>Miami Regional Airport</name>
+            <code>KMIO</code>
+            <zone>OKZ058</zone>
+            <radar>okc</radar>
+            <coordinates>36.909222 -94.887500</coordinates>
           </location>
         </city>
         <city>
@@ -43030,6 +58348,20 @@
             <zone>OKZ025</zone>
             <radar>okc</radar>
             <coordinates>35.541111 -97.646667</coordinates>
+          </location>
+          <location>
+            <name>Clarence E Page Municipal Airport</name>
+            <code>KRCE</code>
+            <zone>OKZ024</zone>
+            <radar>okc</radar>
+            <coordinates>35.488083 -97.823556</coordinates>
+          </location>
+          <location>
+            <name>Sundance Airport</name>
+            <code>KHSD</code>
+            <zone>OKZ024</zone>
+            <radar>okc</radar>
+            <coordinates>35.601833 -97.706167</coordinates>
           </location>
         </city>
         <city>
@@ -43085,6 +58417,18 @@
           </location>
         </city>
         <city>
+          <!-- A city in Oklahoma in United States -->
+          <name>Sand Springs</name>
+          <coordinates>36.139810 -96.108890</coordinates>
+          <location>
+            <name>William R Pogue Municipal Airport</name>
+            <code>KOWP</code>
+            <zone>OKZ060</zone>
+            <radar>okc</radar>
+            <coordinates>36.175278 -96.151833</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Oklahoma in the United States -->
           <name msgctxt="City in Oklahoma, United States">Seminole</name>
           <coordinates>35.224520 -96.670573</coordinates>
@@ -43102,6 +58446,18 @@
             <name>Shawnee Municipal Airport</name>
             <code>KSNL</code>
             <coordinates>35.357222 -96.942778</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Oklahoma in United States -->
+          <name>Stigler</name>
+          <coordinates>35.253710 -95.123020</coordinates>
+          <location>
+            <name>Stigler Regional Airport</name>
+            <code>KGZL</code>
+            <zone>OKZ074</zone>
+            <radar>okc</radar>
+            <coordinates>35.288167 -95.093889</coordinates>
           </location>
         </city>
         <city>
@@ -43146,6 +58502,18 @@
           </location>
         </city>
         <city>
+          <!-- A city in Oklahoma in United States -->
+          <name>Watonga</name>
+          <coordinates>35.844770 -98.413130</coordinates>
+          <location>
+            <name>Watonga Regional Airport</name>
+            <code>KJWG</code>
+            <zone>OKZ017</zone>
+            <radar>ama</radar>
+            <coordinates>35.864564 -98.420757</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Oklahoma in the United States -->
           <name>Weatherford</name>
           <coordinates>35.526163 -98.707574</coordinates>
@@ -43153,6 +58521,18 @@
             <name>Thomas P Stafford Airport</name>
             <code>KOJA</code>
             <coordinates>35.544722 -98.668333</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Oklahoma in United States -->
+          <name>Woodward</name>
+          <coordinates>36.433650 -99.390390</coordinates>
+          <location>
+            <name>West Woodward Airport</name>
+            <code>KWWR</code>
+            <zone>OKZ010</zone>
+            <radar>ama</radar>
+            <coordinates>36.438000 -99.522667</coordinates>
           </location>
         </city>
       </state>
@@ -43195,6 +58575,18 @@
             <zone>ORZ020</zone>
             <radar>boi</radar>
             <coordinates>44.837222 -117.809167</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Oregon in United States -->
+          <name>Bend</name>
+          <coordinates>44.058170 -121.315310</coordinates>
+          <location>
+            <name>Bend Municipal Airport</name>
+            <code>KBDN</code>
+            <zone>ORZ509</zone>
+            <radar>pdx</radar>
+            <coordinates>44.094561 -121.200221</coordinates>
           </location>
         </city>
         <city>
@@ -43249,6 +58641,30 @@
             <name>Hermiston Municipal Airport</name>
             <code>KHRI</code>
             <coordinates>45.825833 -119.261111</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Oregon in United States -->
+          <name>John Day</name>
+          <coordinates>44.415990 -118.953010</coordinates>
+          <location>
+            <name>Grant County Regional/Ogilvie Field</name>
+            <code>KGCD</code>
+            <zone>ORZ503</zone>
+            <radar>boi</radar>
+            <coordinates>44.402983 -118.967655</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Oregon in United States -->
+          <name>Joseph</name>
+          <coordinates>45.354320 -117.229610</coordinates>
+          <location>
+            <name>Joseph State Airport</name>
+            <code>KJSY</code>
+            <zone>ORZ050</zone>
+            <radar>boi</radar>
+            <coordinates>45.359550 -117.253839</coordinates>
           </location>
         </city>
         <city>
@@ -43475,6 +58891,18 @@
             <coordinates>45.618611 -121.167222</coordinates>
           </location>
         </city>
+        <city>
+          <!-- A city in Oregon in United States -->
+          <name>Tillamook</name>
+          <coordinates>45.456400 -123.845530</coordinates>
+          <location>
+            <name>Tillamook Airport</name>
+            <code>KTMK</code>
+            <zone>ORZ102</zone>
+            <radar>pdx</radar>
+            <coordinates>45.418250 -123.814389</coordinates>
+          </location>
+        </city>
       </state>
       <state>
         <!-- A state/province/territory in United States -->
@@ -43491,6 +58919,13 @@
             <zone>PAZ061</zone>
             <radar>har</radar>
             <coordinates>40.650833 -75.449167</coordinates>
+          </location>
+          <location>
+            <name>Allentown Queen City Municipal Airport</name>
+            <code>KXLL</code>
+            <zone>PAZ061</zone>
+            <radar>har</radar>
+            <coordinates>40.570278 -75.488306</coordinates>
           </location>
         </city>
         <city>
@@ -43513,6 +58948,18 @@
             <name>Beaver Falls Airport</name>
             <code>KBVI</code>
             <coordinates>40.766667 -80.400000</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Pennsylvania in United States -->
+          <name>Bedford</name>
+          <coordinates>40.018690 -78.503910</coordinates>
+          <location>
+            <name>Bedford County Airport</name>
+            <code>KHMZ</code>
+            <zone>PAZ034</zone>
+            <radar>har</radar>
+            <coordinates>40.086125 -78.513498</coordinates>
           </location>
         </city>
         <city>
@@ -43545,6 +58992,30 @@
             <name>Clearfield-Lawrence Airport</name>
             <code>KFIG</code>
             <coordinates>41.046667 -78.411667</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Pennsylvania in United States -->
+          <name>Coatesville</name>
+          <coordinates>39.983160 -75.823840</coordinates>
+          <location>
+            <name>Chester County G O Carlson Airport</name>
+            <code>KMQS</code>
+            <zone>PAZ101</zone>
+            <radar>har</radar>
+            <coordinates>39.978972 -75.865472</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Pennsylvania in United States -->
+          <name>Connellsville</name>
+          <coordinates>40.017850 -79.589480</coordinates>
+          <location>
+            <name>Joseph A Hardy Connellsville Airport</name>
+            <code>KVVS</code>
+            <zone>PAZ075</zone>
+            <radar>har</radar>
+            <coordinates>39.959056 -79.657417</coordinates>
           </location>
         </city>
         <city>
@@ -43610,6 +59081,18 @@
             <zone>PAZ057</zone>
             <radar>har</radar>
             <coordinates>40.193611 -76.763333</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Pennsylvania in United States -->
+          <name>Hazleton</name>
+          <coordinates>40.958420 -75.974650</coordinates>
+          <location>
+            <name>Hazleton Regional Airport</name>
+            <code>KHZL</code>
+            <zone>PAZ047</zone>
+            <radar>har</radar>
+            <coordinates>40.986773 -75.994703</coordinates>
           </location>
         </city>
         <city>
@@ -43701,6 +59184,18 @@
           </location>
         </city>
         <city>
+          <!-- A city in Pennsylvania in United States -->
+          <name>Perkasie</name>
+          <coordinates>40.372050 -75.292680</coordinates>
+          <location>
+            <name>Pennridge Airport</name>
+            <code>KCKZ</code>
+            <zone>PAZ105</zone>
+            <radar>har</radar>
+            <coordinates>40.389194 -75.290472</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Pennsylvania in the United States -->
           <name>Philadelphia</name>
           <coordinates>39.952335 -75.163789</coordinates>
@@ -43754,6 +59249,18 @@
           </location>
         </city>
         <city>
+          <!-- A city in Pennsylvania in United States -->
+          <name>Pottsville</name>
+          <coordinates>40.685650 -76.195500</coordinates>
+          <location>
+            <name>Schuylkill County/Joe Zerbey Airport</name>
+            <code>KZER</code>
+            <zone>PAZ058</zone>
+            <radar>har</radar>
+            <coordinates>40.706751 -76.373750</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Pennsylvania in the United States -->
           <name>Quakertown</name>
           <coordinates>40.441768 -75.341567</coordinates>
@@ -43776,6 +59283,18 @@
           </location>
         </city>
         <city>
+          <!-- A city in Pennsylvania in United States -->
+          <name>Reedsville</name>
+          <coordinates>40.663960 -77.595830</coordinates>
+          <location>
+            <name>Mifflin County Airport</name>
+            <code>KRVL</code>
+            <zone>PAZ027</zone>
+            <radar>har</radar>
+            <coordinates>40.677389 -77.626833</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Pennsylvania in the United States -->
           <name>Selinsgrove</name>
           <coordinates>40.798974 -76.862194</coordinates>
@@ -43783,6 +59302,18 @@
             <name>Penn Valley Airport</name>
             <code>KSEG</code>
             <coordinates>40.819167 -76.866111</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Pennsylvania in United States -->
+          <name>St Marys</name>
+          <coordinates>41.412478 -78.502631</coordinates>
+          <location>
+            <name>St Marys Municipal Airport</name>
+            <code>KOYM</code>
+            <zone>PAZ010</zone>
+            <radar>har</radar>
+            <coordinates>41.412478 -78.502631</coordinates>
           </location>
         </city>
         <city>
@@ -43805,6 +59336,18 @@
             <name>Washington County Airport</name>
             <code>KAFJ</code>
             <coordinates>40.133333 -80.283333</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Pennsylvania in United States -->
+          <name>West Chester</name>
+          <coordinates>39.960970 -75.608040</coordinates>
+          <location>
+            <name>Brandywine Regional Airport</name>
+            <code>KOQN</code>
+            <zone>PAZ101</zone>
+            <radar>har</radar>
+            <coordinates>39.990117 -75.581902</coordinates>
           </location>
         </city>
         <city>
@@ -43851,12 +59394,36 @@
             <coordinates>39.919444 -76.876944</coordinates>
           </location>
         </city>
+        <city>
+          <!-- A city in Pennsylvania in United States -->
+          <name>Zelienople</name>
+          <coordinates>40.794510 -80.136730</coordinates>
+          <location>
+            <name>Zelienople Municipal Airport</name>
+            <code>KPJC</code>
+            <zone>PAZ020</zone>
+            <radar>har</radar>
+            <coordinates>40.802703 -80.161100</coordinates>
+          </location>
+        </city>
       </state>
       <state>
         <!-- A state/province/territory in United States -->
         <name>Rhode Island</name>
         <fips-code>US44</fips-code>
         <tz-hint>America/New_York</tz-hint>
+        <city>
+          <!-- A city in Rhode Island in United States -->
+          <name>Block Island</name>
+          <coordinates>41.172330 -71.557830</coordinates>
+          <location>
+            <name>Block Island State Airport</name>
+            <code>KBID</code>
+            <zone>RIZ008</zone>
+            <radar>bos</radar>
+            <coordinates>41.168111 -71.577833</coordinates>
+          </location>
+        </city>
         <city>
           <!-- A city in Rhode Island in the United States -->
           <name msgctxt="City in Rhode Island, United States">Newport</name>
@@ -43915,6 +59482,30 @@
         <fips-code>US45</fips-code>
         <tz-hint>America/New_York</tz-hint>
         <city>
+          <!-- A city in South Carolina in United States -->
+          <name>Aiken</name>
+          <coordinates>33.560420 -81.719550</coordinates>
+          <location>
+            <name>Aiken Regional Airport</name>
+            <code>KAIK</code>
+            <zone>SCZ030</zone>
+            <radar>chs</radar>
+            <coordinates>33.649389 -81.685028</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in South Carolina in United States -->
+          <name>Allendale</name>
+          <coordinates>33.007930 -81.308440</coordinates>
+          <location>
+            <name>Allendale County Airport</name>
+            <code>KAQX</code>
+            <zone>SCZ040</zone>
+            <radar>chs</radar>
+            <coordinates>32.995112 -81.270237</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in South Carolina in the United States -->
           <name msgctxt="City in South Carolina, United States">Anderson</name>
           <coordinates>34.503439 -82.650133</coordinates>
@@ -43924,6 +59515,18 @@
             <zone>SCZ010</zone>
             <radar>atl</radar>
             <coordinates>34.497778 -82.709722</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in South Carolina in United States -->
+          <name>Barnwell</name>
+          <coordinates>33.244870 -81.358720</coordinates>
+          <location>
+            <name>Barnwell Regional Airport</name>
+            <code>KBNL</code>
+            <zone>SCZ035</zone>
+            <radar>chs</radar>
+            <coordinates>33.257668 -81.388219</coordinates>
           </location>
         </city>
         <city>
@@ -43939,6 +59542,30 @@
           </location>
         </city>
         <city>
+          <!-- A city in South Carolina in United States -->
+          <name>Bennettsville</name>
+          <coordinates>34.617380 -79.684780</coordinates>
+          <location>
+            <name>Marlboro County Jetport/H E Avent Field</name>
+            <code>KBBP</code>
+            <zone>SCZ017</zone>
+            <radar>chs</radar>
+            <coordinates>34.621709 -79.734359</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in South Carolina in United States -->
+          <name>Camden</name>
+          <coordinates>34.246540 -80.607020</coordinates>
+          <location>
+            <name>Woodward Field</name>
+            <code>KCDN</code>
+            <zone>SCZ022</zone>
+            <radar>chs</radar>
+            <coordinates>34.283593 -80.564855</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in South Carolina in the United States -->
           <name msgctxt="City in South Carolina, United States">Charleston</name>
           <coordinates>32.776566 -79.930922</coordinates>
@@ -43948,6 +59575,37 @@
             <zone>SCZ050</zone>
             <radar>chs</radar>
             <coordinates>32.898889 -80.040556</coordinates>
+          </location>
+          <location>
+            <name>Charleston Executive Airport</name>
+            <code>KJZI</code>
+            <zone>SCZ150</zone>
+            <radar>chs</radar>
+            <coordinates>32.701028 -80.003250</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in South Carolina in United States -->
+          <name>Cheraw</name>
+          <coordinates>34.697660 -79.883400</coordinates>
+          <location>
+            <name>Cheraw Municipal/Lynch Bellinger Field</name>
+            <code>KCQW</code>
+            <zone>SCZ016</zone>
+            <radar>chs</radar>
+            <coordinates>34.712861 -79.957000</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in South Carolina in United States -->
+          <name>Chester</name>
+          <coordinates>34.704860 -81.214260</coordinates>
+          <location>
+            <name>Chester Catawba Regional Airport</name>
+            <code>KDCM</code>
+            <zone>SCZ014</zone>
+            <radar>chs</radar>
+            <coordinates>34.789333 -81.195778</coordinates>
           </location>
         </city>
         <city>
@@ -43987,6 +59645,18 @@
           </location>
         </city>
         <city>
+          <!-- A city in South Carolina in United States -->
+          <name>Conway</name>
+          <coordinates>33.836000 -79.047810</coordinates>
+          <location>
+            <name>Conway-Horry County Airport</name>
+            <code>KHYW</code>
+            <zone>SCZ058</zone>
+            <radar>chs</radar>
+            <coordinates>33.828488 -79.122176</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in South Carolina in the United States -->
           <name>Dalzell</name>
           <coordinates>34.016821 -80.430082</coordinates>
@@ -44021,6 +59691,18 @@
           </location>
         </city>
         <city>
+          <!-- A city in South Carolina in United States -->
+          <name>Georgetown</name>
+          <coordinates>33.376830 -79.294500</coordinates>
+          <location>
+            <name>Georgetown County Airport</name>
+            <code>KGGE</code>
+            <zone>SCZ056</zone>
+            <radar>chs</radar>
+            <coordinates>33.311417 -79.320306</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in South Carolina in the United States -->
           <name msgctxt="City in South Carolina, United States">Greenville</name>
           <coordinates>34.852618 -82.394010</coordinates>
@@ -44030,6 +59712,13 @@
             <zone>SCZ006</zone>
             <radar>avl</radar>
             <coordinates>34.846111 -82.346111</coordinates>
+          </location>
+          <location>
+            <name>Donaldson Field</name>
+            <code>KGYH</code>
+            <zone>SCZ107</zone>
+            <radar>avl</radar>
+            <coordinates>34.758313 -82.376414</coordinates>
           </location>
         </city>
         <city>
@@ -44055,6 +59744,18 @@
           </location>
         </city>
         <city>
+          <!-- A city in South Carolina in United States -->
+          <name>Hartsville</name>
+          <coordinates>34.374040 -80.073400</coordinates>
+          <location>
+            <name>Hartsville Regional Airport</name>
+            <code>KHVS</code>
+            <zone>SCZ023</zone>
+            <radar>chs</radar>
+            <coordinates>34.403083 -80.119222</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in South Carolina in the United States -->
           <name>Hilton Head Island</name>
           <coordinates>32.216316 -80.752608</coordinates>
@@ -44062,6 +59763,90 @@
             <name>Hilton Head Airport</name>
             <code>KHXD</code>
             <coordinates>32.216667 -80.700000</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in South Carolina in United States -->
+          <name>Kingstree</name>
+          <coordinates>33.667660 -79.830630</coordinates>
+          <location>
+            <name>Williamsburg Regional Airport</name>
+            <code>KCKI</code>
+            <zone>SCZ039</zone>
+            <radar>chs</radar>
+            <coordinates>33.717222 -79.856972</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in South Carolina in United States -->
+          <name>Lancaster</name>
+          <coordinates>34.720430 -80.770900</coordinates>
+          <location>
+            <name>Lancaster County-Mc Whirter Field</name>
+            <code>KLKR</code>
+            <zone>SCZ116</zone>
+            <radar>chs</radar>
+            <coordinates>34.722904 -80.854590</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in South Carolina in United States -->
+          <name>Laurens</name>
+          <coordinates>34.499010 -82.014260</coordinates>
+          <location>
+            <name>Laurens County Airport</name>
+            <code>KLUX</code>
+            <zone>SCZ012</zone>
+            <radar>avl</radar>
+            <coordinates>34.507111 -81.946944</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in South Carolina in United States -->
+          <name>Manning</name>
+          <coordinates>33.695160 -80.210910</coordinates>
+          <location>
+            <name>Santee Cooper Regional Airport</name>
+            <code>KMNI</code>
+            <zone>SCZ038</zone>
+            <radar>chs</radar>
+            <coordinates>33.587101 -80.208670</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in South Carolina in United States -->
+          <name>Marion</name>
+          <coordinates>34.178220 -79.400610</coordinates>
+          <location>
+            <name>Marion County Airport</name>
+            <code>KMAO</code>
+            <zone>SCZ033</zone>
+            <radar>chs</radar>
+            <coordinates>34.181166 -79.334720</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in South Carolina in United States -->
+          <name>Moncks Corner</name>
+          <coordinates>33.196320 -80.014290</coordinates>
+          <location>
+            <name>Berkeley County Airport</name>
+            <code>KMKS</code>
+            <zone>SCZ045</zone>
+            <radar>chs</radar>
+            <coordinates>33.184837 -80.036976</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in South Carolina in United States -->
+          <name>Mount Pleasant</name>
+          <coordinates>32.794070 -79.862590</coordinates>
+          <location>
+            <name>Mt Pleasant Regional-Faison Field</name>
+            <code>KLRO</code>
+            <zone>SCZ152</zone>
+            <radar>chs</radar>
+            <coordinates>32.897833 -79.782861</coordinates>
           </location>
         </city>
         <city>
@@ -44074,6 +59859,30 @@
             <zone>SCZ034</zone>
             <radar>chs</radar>
             <coordinates>33.683333 -78.933333</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in South Carolina in United States -->
+          <name>Newberry</name>
+          <coordinates>34.274580 -81.618720</coordinates>
+          <location>
+            <name>Newberry County Airport</name>
+            <code>KEOE</code>
+            <zone>SCZ020</zone>
+            <radar>chs</radar>
+            <coordinates>34.309333 -81.640667</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in South Carolina in United States -->
+          <name>North</name>
+          <coordinates>33.615710 -81.102040</coordinates>
+          <location>
+            <name>North Af Aux Airport</name>
+            <code>KXNO</code>
+            <zone>SCZ135</zone>
+            <radar>chs</radar>
+            <coordinates>33.609491 -81.081177</coordinates>
           </location>
         </city>
         <city>
@@ -44099,6 +59908,18 @@
           </location>
         </city>
         <city>
+          <!-- A city in South Carolina in United States -->
+          <name>Pickens</name>
+          <coordinates>34.883450 -82.707360</coordinates>
+          <location>
+            <name>Pickens County Airport</name>
+            <code>KLQK</code>
+            <zone>SCZ105</zone>
+            <radar>avl</radar>
+            <coordinates>34.809972 -82.702889</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in South Carolina in the United States -->
           <name>Rock Hill</name>
           <coordinates>34.924867 -81.025078</coordinates>
@@ -44106,6 +59927,66 @@
             <name>Rock Hill - York County Airport</name>
             <code>KUZA</code>
             <coordinates>34.983889 -81.055833</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in South Carolina in United States -->
+          <name>Spartanburg</name>
+          <coordinates>34.949570 -81.932050</coordinates>
+          <location>
+            <name>Spartanburg Downtown Memorial/Simpson Field</name>
+            <code>KSPA</code>
+            <zone>SCZ109</zone>
+            <radar>avl</radar>
+            <coordinates>34.916405 -81.955771</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in South Carolina in United States -->
+          <name>Summerville</name>
+          <coordinates>33.018500 -80.175650</coordinates>
+          <location>
+            <name>Summerville Airport</name>
+            <code>KDYB</code>
+            <zone>SCZ044</zone>
+            <radar>chs</radar>
+            <coordinates>33.062278 -80.280917</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in South Carolina in United States -->
+          <name>Sumter</name>
+          <coordinates>33.920440 -80.341470</coordinates>
+          <location>
+            <name>Sumter Airport</name>
+            <code>KSMS</code>
+            <zone>SCZ031</zone>
+            <radar>chs</radar>
+            <coordinates>33.995026 -80.361329</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in South Carolina in United States -->
+          <name>Walterboro</name>
+          <coordinates>32.905170 -80.666770</coordinates>
+          <location>
+            <name>Lowcountry Regional Airport</name>
+            <code>KRBW</code>
+            <zone>SCZ043</zone>
+            <radar>chs</radar>
+            <coordinates>32.921041 -80.640590</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in South Carolina in United States -->
+          <name>Winnsboro</name>
+          <coordinates>34.380700 -81.086480</coordinates>
+          <location>
+            <name>Fairfield County Airport</name>
+            <code>KFDW</code>
+            <zone>SCZ021</zone>
+            <radar>chs</radar>
+            <coordinates>34.315722 -81.108556</coordinates>
           </location>
         </city>
       </state>
@@ -44137,6 +60018,18 @@
             <zone>SDZ031</zone>
             <radar>rap</radar>
             <coordinates>44.150000 -103.100000</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in South Dakota in United States -->
+          <name>Britton</name>
+          <coordinates>45.791620 -97.750940</coordinates>
+          <location>
+            <name>Britton Municipal Airport</name>
+            <code>KBTN</code>
+            <zone>SDZ007</zone>
+            <radar>bis</radar>
+            <coordinates>45.815028 -97.742806</coordinates>
           </location>
         </city>
         <city>
@@ -44208,6 +60101,18 @@
             <zone>SDZ038</zone>
             <radar>fsd</radar>
             <coordinates>44.388056 -98.228333</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in South Dakota in United States -->
+          <name>Madison</name>
+          <coordinates>44.006080 -97.113950</coordinates>
+          <location>
+            <name>Madison Municipal Airport</name>
+            <code>KMDS</code>
+            <zone>SDZ055</zone>
+            <radar>fsd</radar>
+            <coordinates>44.016417 -97.085611</coordinates>
           </location>
         </city>
         <city>
@@ -44284,6 +60189,18 @@
           </location>
         </city>
         <city>
+          <!-- A city in South Dakota in United States -->
+          <name>Rosebud</name>
+          <coordinates>43.232780 -100.853480</coordinates>
+          <location>
+            <name>Rosebud Sioux Tribal Airport</name>
+            <code>KSUO</code>
+            <zone>SDZ047</zone>
+            <radar>fsd</radar>
+            <coordinates>43.258457 -100.859494</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in South Dakota in the United States -->
           <name>Sioux Falls</name>
           <coordinates>43.549975 -96.700327</coordinates>
@@ -44306,6 +60223,43 @@
           </location>
         </city>
         <city>
+          <!-- A city in South Dakota in United States -->
+          <name>Spearfish</name>
+          <coordinates>44.490820 -103.859370</coordinates>
+          <location>
+            <name>Black Hills-Clyde Ice Field</name>
+            <code>KSPF</code>
+            <tz-hint>America/Denver</tz-hint>
+            <zone>SDZ025</zone>
+            <radar>rap</radar>
+            <coordinates>44.481056 -103.786000</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in South Dakota in United States -->
+          <name>Vermillion</name>
+          <coordinates>42.779440 -96.929210</coordinates>
+          <location>
+            <name>Harold Davidson Field</name>
+            <code>KVMR</code>
+            <zone>SDZ070</zone>
+            <radar>fsd</radar>
+            <coordinates>42.765278 -96.934250</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in South Dakota in United States -->
+          <name>Wagner</name>
+          <coordinates>43.079720 -98.293130</coordinates>
+          <location>
+            <name>Wagner Municipal Airport</name>
+            <code>KAGZ</code>
+            <zone>SDZ063</zone>
+            <radar>fsd</radar>
+            <coordinates>43.064166 -98.296382</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in South Dakota in the United States -->
           <name msgctxt="City in South Dakota, United States">Watertown</name>
           <coordinates>44.899409 -97.115073</coordinates>
@@ -44315,6 +60269,18 @@
             <zone>SDZ020</zone>
             <radar>fsd</radar>
             <coordinates>44.904722 -97.149444</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in South Dakota in United States -->
+          <name>Winner</name>
+          <coordinates>43.376670 -99.859010</coordinates>
+          <location>
+            <name>Winner Regional Airport</name>
+            <code>KICR</code>
+            <zone>SDZ049</zone>
+            <radar>rap</radar>
+            <coordinates>43.389485 -99.841214</coordinates>
           </location>
         </city>
         <city>
@@ -44335,6 +60301,19 @@
         <name>Tennessee</name>
         <fips-code>US47</fips-code>
         <tz-hint>America/Chicago</tz-hint>
+        <city>
+          <!-- A city in Tennessee in United States -->
+          <name>Athens</name>
+          <coordinates>35.442850 -84.592990</coordinates>
+          <location>
+            <name>Mcminn County Airport</name>
+            <code>KMMI</code>
+            <tz-hint>America/New_York</tz-hint>
+            <zone>TNZ085</zone>
+            <radar>avl</radar>
+            <coordinates>35.399194 -84.561778</coordinates>
+          </location>
+        </city>
         <city>
           <!-- A city in Tennessee in the United States -->
           <name>Chattanooga</name>
@@ -44367,6 +60346,31 @@
           </location>
         </city>
         <city>
+          <!-- A city in Tennessee in United States -->
+          <name>Cleveland</name>
+          <coordinates>35.159520 -84.876610</coordinates>
+          <location>
+            <name>Cleveland Regional Jetport Airport</name>
+            <code>KRZR</code>
+            <tz-hint>America/New_York</tz-hint>
+            <zone>TNZ100</zone>
+            <radar>tup</radar>
+            <coordinates>35.212336 -84.799199</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Tennessee in United States -->
+          <name>Columbia/Mount Pleasant</name>
+          <coordinates>35.615070 -87.035280</coordinates>
+          <location>
+            <name>Maury County Regional Airport</name>
+            <code>KMRC</code>
+            <zone>TNZ060</zone>
+            <radar>tup</radar>
+            <coordinates>35.554339 -87.179140</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Tennessee in the United States -->
           <name>Crossville</name>
           <coordinates>35.948957 -85.026901</coordinates>
@@ -44388,6 +60392,80 @@
             <zone>TNZ019</zone>
             <radar>tup</radar>
             <coordinates>36.000000 -89.400000</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Tennessee in United States -->
+          <name>Fayetteville</name>
+          <coordinates>35.152030 -86.570550</coordinates>
+          <location>
+            <name>Fayetteville Municipal Airport</name>
+            <code>KFYM</code>
+            <zone>TNZ096</zone>
+            <radar>tup</radar>
+            <coordinates>35.059694 -86.564000</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Tennessee in United States -->
+          <name>Fort Campbell (Clarksville)</name>
+          <coordinates>36.567653 -87.481458</coordinates>
+          <location>
+            <name>Sabre Army Air Field (Fort Campbell) Airport</name>
+            <code>KEOD</code>
+            <zone>TNZ006</zone>
+            <radar>lex</radar>
+            <coordinates>36.567653 -87.481458</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Tennessee in United States -->
+          <name>Gallatin</name>
+          <coordinates>36.388380 -86.446660</coordinates>
+          <location>
+            <name>Music City Executive Airport</name>
+            <code>KXNX</code>
+            <zone>TNZ008</zone>
+            <radar>tup</radar>
+            <coordinates>36.375081 -86.408412</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Tennessee in United States -->
+          <name>Greeneville</name>
+          <coordinates>36.163160 -82.830990</coordinates>
+          <location>
+            <name>Greeneville Municipal Airport</name>
+            <code>KGCY</code>
+            <tz-hint>America/New_York</tz-hint>
+            <zone>TNZ042</zone>
+            <radar>avl</radar>
+            <coordinates>36.195722 -82.811361</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Tennessee in United States -->
+          <name>Huntingdon</name>
+          <coordinates>36.000620 -88.428110</coordinates>
+          <location>
+            <name>Sgt Lee Russell Carroll County Airport</name>
+            <code>KHZD</code>
+            <zone>TNZ021</zone>
+            <radar>tup</radar>
+            <coordinates>36.089297 -88.463299</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Tennessee in United States -->
+          <name>Jacksboro</name>
+          <coordinates>36.330080 -84.183820</coordinates>
+          <location>
+            <name>Colonel Tommy C Stiner Airfield</name>
+            <code>KJAU</code>
+            <tz-hint>America/New_York</tz-hint>
+            <zone>TNZ013</zone>
+            <radar>avl</radar>
+            <coordinates>36.334089 -84.162965</coordinates>
           </location>
         </city>
         <city>
@@ -44427,6 +60505,63 @@
             <radar>avl</radar>
             <coordinates>35.818056 -83.985833</coordinates>
           </location>
+          <location>
+            <name>Knoxville Downtown Island Airport</name>
+            <code>KDKX</code>
+            <tz-hint>America/New_York</tz-hint>
+            <zone>TNZ069</zone>
+            <radar>avl</radar>
+            <coordinates>35.963833 -83.873667</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Tennessee in United States -->
+          <name>Lewisburg</name>
+          <coordinates>35.449240 -86.788890</coordinates>
+          <location>
+            <name>Ellington Airport</name>
+            <code>KLUG</code>
+            <zone>TNZ061</zone>
+            <radar>tup</radar>
+            <coordinates>35.506974 -86.803888</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Tennessee in United States -->
+          <name>Lexington-Parsons</name>
+          <coordinates>35.650900 -88.393380</coordinates>
+          <location>
+            <name>Beech River Regional Airport</name>
+            <code>KPVE</code>
+            <zone>TNZ055</zone>
+            <radar>tup</radar>
+            <coordinates>35.656362 -88.195352</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Tennessee in United States -->
+          <name>Madisonville</name>
+          <coordinates>35.519800 -84.363530</coordinates>
+          <location>
+            <name>Monroe County Airport</name>
+            <code>KMNV</code>
+            <tz-hint>America/New_York</tz-hint>
+            <zone>TNZ086</zone>
+            <radar>avl</radar>
+            <coordinates>35.545231 -84.380400</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Tennessee in United States -->
+          <name>Mc Minnville</name>
+          <coordinates>35.698699 -85.843821</coordinates>
+          <location>
+            <name>Warren County Memorial Airport</name>
+            <code>KRNC</code>
+            <zone>TNZ078</zone>
+            <radar>tup</radar>
+            <coordinates>35.698699 -85.843821</coordinates>
+          </location>
         </city>
         <city>
           <!-- A city in Tennessee in the United States -->
@@ -44453,6 +60588,31 @@
           </location>
         </city>
         <city>
+          <!-- A city in Tennessee in United States -->
+          <name>Morristown</name>
+          <coordinates>36.213980 -83.294890</coordinates>
+          <location>
+            <name>Moore-Murrell Airport</name>
+            <code>KMOR</code>
+            <tz-hint>America/New_York</tz-hint>
+            <zone>TNZ039</zone>
+            <radar>avl</radar>
+            <coordinates>36.179383 -83.375452</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Tennessee in United States -->
+          <name>Murfreesboro</name>
+          <coordinates>35.845620 -86.390270</coordinates>
+          <location>
+            <name>Murfreesboro Municipal Airport</name>
+            <code>KMBT</code>
+            <zone>TNZ062</zone>
+            <radar>tup</radar>
+            <coordinates>35.878654 -86.377468</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Tennessee in the United States -->
           <name>Nashville</name>
           <coordinates>36.165890 -86.784443</coordinates>
@@ -44462,6 +60622,13 @@
             <zone>TNZ027</zone>
             <radar>tup</radar>
             <coordinates>36.118889 -86.689167</coordinates>
+          </location>
+          <location>
+            <name>John C Tune Airport</name>
+            <code>KJWN</code>
+            <zone>TNZ027</zone>
+            <radar>tup</radar>
+            <coordinates>36.183022 -86.886495</coordinates>
           </location>
         </city>
         <city>
@@ -44476,6 +60643,104 @@
           </location>
         </city>
         <city>
+          <!-- A city in Tennessee in United States -->
+          <name>Oneida</name>
+          <coordinates>36.498130 -84.512720</coordinates>
+          <location>
+            <name>Scott Municipal Airport</name>
+            <code>KSCX</code>
+            <tz-hint>America/New_York</tz-hint>
+            <zone>TNZ012</zone>
+            <radar>tup</radar>
+            <coordinates>36.455692 -84.585750</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Tennessee in United States -->
+          <name>Paris</name>
+          <coordinates>36.302000 -88.326710</coordinates>
+          <location>
+            <name>Henry County Airport</name>
+            <code>KPHT</code>
+            <zone>TNZ004</zone>
+            <radar>lex</radar>
+            <coordinates>36.335944 -88.384444</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Tennessee in United States -->
+          <name>Pulaski</name>
+          <coordinates>35.199800 -87.030840</coordinates>
+          <location>
+            <name>Abernathy Field</name>
+            <code>KGZS</code>
+            <zone>TNZ095</zone>
+            <radar>tup</radar>
+            <coordinates>35.154083 -87.057056</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Tennessee in United States -->
+          <name>Rockwood</name>
+          <coordinates>35.865630 -84.684940</coordinates>
+          <location>
+            <name>Rockwood Municipal Airport</name>
+            <code>KRKW</code>
+            <zone>TNZ067</zone>
+            <radar>tup</radar>
+            <coordinates>35.922333 -84.689778</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Tennessee in United States -->
+          <name>Savannah</name>
+          <coordinates>35.224800 -88.249200</coordinates>
+          <location>
+            <name>Savannah-Hardin County Airport</name>
+            <code>KSNH</code>
+            <zone>TNZ092</zone>
+            <radar>tup</radar>
+            <coordinates>35.170246 -88.216726</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Tennessee in United States -->
+          <name>Selmer</name>
+          <coordinates>35.170080 -88.592270</coordinates>
+          <location>
+            <name>Robert Sibley Airport</name>
+            <code>KSZY</code>
+            <zone>TNZ091</zone>
+            <radar>tup</radar>
+            <coordinates>35.202944 -88.498361</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Tennessee in United States -->
+          <name>Sevierville</name>
+          <coordinates>35.868150 -83.561840</coordinates>
+          <location>
+            <name>Gatlinburg-Pigeon Forge Airport</name>
+            <code>KGKT</code>
+            <tz-hint>America/New_York</tz-hint>
+            <zone>TNZ073</zone>
+            <radar>avl</radar>
+            <coordinates>35.857759 -83.528703</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Tennessee in United States -->
+          <name>Shelbyville</name>
+          <coordinates>35.483410 -86.460270</coordinates>
+          <location>
+            <name>Bomar Field/Shelbyville Municipal Airport</name>
+            <code>KSYI</code>
+            <zone>TNZ075</zone>
+            <radar>tup</radar>
+            <coordinates>35.559400 -86.442472</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Tennessee in the United States -->
           <name>Smyrna</name>
           <coordinates>35.982841 -86.518604</coordinates>
@@ -44485,6 +60750,66 @@
             <zone>TNZ062</zone>
             <radar>tup</radar>
             <coordinates>36.008889 -86.520000</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Tennessee in United States -->
+          <name>Somerville</name>
+          <coordinates>35.243700 -89.350070</coordinates>
+          <location>
+            <name>Fayette County Airport</name>
+            <code>KFYE</code>
+            <zone>TNZ089</zone>
+            <radar>lit</radar>
+            <coordinates>35.207694 -89.394444</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Tennessee in United States -->
+          <name>Sparta</name>
+          <coordinates>35.925900 -85.464140</coordinates>
+          <location>
+            <name>Upper Cumberland Regional Airport</name>
+            <code>KSRB</code>
+            <zone>TNZ032</zone>
+            <radar>tup</radar>
+            <coordinates>36.056738 -85.530106</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Tennessee in United States -->
+          <name>Tullahoma</name>
+          <coordinates>35.362020 -86.209430</coordinates>
+          <location>
+            <name>Tullahoma Regional/Wm Northern Field</name>
+            <code>KTHA</code>
+            <zone>TNZ076</zone>
+            <radar>tup</radar>
+            <coordinates>35.380125 -86.246778</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Tennessee in United States -->
+          <name>Union City</name>
+          <coordinates>36.424230 -89.057010</coordinates>
+          <location>
+            <name>Everett-Stewart Regional Airport</name>
+            <code>KUCY</code>
+            <zone>TNZ002</zone>
+            <radar>tup</radar>
+            <coordinates>36.379741 -88.985702</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Tennessee in United States -->
+          <name>Winchester</name>
+          <coordinates>35.185920 -86.112210</coordinates>
+          <location>
+            <name>Winchester Municipal Airport</name>
+            <code>KBGF</code>
+            <zone>TNZ097</zone>
+            <radar>tup</radar>
+            <coordinates>35.177534 -86.066166</coordinates>
           </location>
         </city>
       </state>
@@ -44587,6 +60912,13 @@
             <radar>sat</radar>
             <coordinates>30.194444 -97.670000</coordinates>
           </location>
+          <location>
+            <name>Austin Executive Airport</name>
+            <code>KEDC</code>
+            <zone>TXZ192</zone>
+            <radar>sat</radar>
+            <coordinates>30.397493 -97.566394</coordinates>
+          </location>
         </city>
         <city>
           <!-- A city in Texas in the United States -->
@@ -44596,6 +60928,13 @@
             <name>Bay City Municipal Airport</name>
             <code>KBYY</code>
             <coordinates>28.973056 -95.863333</coordinates>
+          </location>
+          <location>
+            <name>Brazos 451 Oil Platform</name>
+            <code>KBQX</code>
+            <zone>TXZ436</zone>
+            <radar>vct</radar>
+            <coordinates>28.500000 -95.716000</coordinates>
           </location>
         </city>
         <city>
@@ -44608,6 +60947,25 @@
             <zone>TXZ215</zone>
             <radar>gls</radar>
             <coordinates>29.950833 -94.020833</coordinates>
+          </location>
+          <location>
+            <name>Beaumont Municipal Airport</name>
+            <code>KBMT</code>
+            <zone>TXZ515</zone>
+            <radar>gls</radar>
+            <coordinates>30.070204 -94.215097</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Texas in United States -->
+          <name>Beeville</name>
+          <coordinates>28.400950 -97.749740</coordinates>
+          <location>
+            <name>Beeville Municipal Airport</name>
+            <code>KBEA</code>
+            <zone>TXZ232</zone>
+            <radar>bro</radar>
+            <coordinates>28.364222 -97.791944</coordinates>
           </location>
         </city>
         <city>
@@ -44643,6 +61001,18 @@
           </location>
         </city>
         <city>
+          <!-- A city in Texas in United States -->
+          <name>Breckenridge</name>
+          <coordinates>32.755680 -98.902290</coordinates>
+          <location>
+            <name>Stephens County Airport</name>
+            <code>KBKD</code>
+            <zone>TXZ115</zone>
+            <radar>maf</radar>
+            <coordinates>32.718756 -98.891596</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Texas in the United States -->
           <name>Brenham</name>
           <coordinates>30.166883 -96.397744</coordinates>
@@ -44650,6 +61020,18 @@
             <name>Brenham Municipal Airport</name>
             <code>K11R</code>
             <coordinates>30.218889 -96.374167</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Texas in United States -->
+          <name>Bridgeport</name>
+          <coordinates>33.210120 -97.754760</coordinates>
+          <location>
+            <name>Bridgeport Municipal Airport</name>
+            <code>KXBP</code>
+            <zone>TXZ102</zone>
+            <radar>maf</radar>
+            <coordinates>33.173960 -97.828427</coordinates>
           </location>
         </city>
         <city>
@@ -44672,6 +61054,18 @@
             <name>Brownwood Regional Airport</name>
             <code>KBWD</code>
             <coordinates>31.800000 -98.950000</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Texas in United States -->
+          <name>Bryan</name>
+          <coordinates>30.674360 -96.369960</coordinates>
+          <location>
+            <name>Coulter Field</name>
+            <code>KCFD</code>
+            <zone>TXZ196</zone>
+            <radar>sat</radar>
+            <coordinates>30.715694 -96.331361</coordinates>
           </location>
         </city>
         <city>
@@ -44706,6 +61100,25 @@
           </location>
         </city>
         <city>
+          <!-- A city in Texas in United States -->
+          <name>Carrizo Springs</name>
+          <coordinates>28.521930 -99.860610</coordinates>
+          <location>
+            <name>Dimmit County Airport</name>
+            <code>KCZT</code>
+            <zone>TXZ228</zone>
+            <radar>bro</radar>
+            <coordinates>28.522250 -99.823639</coordinates>
+          </location>
+          <location>
+            <name>Faith Ranch Airport</name>
+            <code>KFTN</code>
+            <zone>TXZ228</zone>
+            <radar>bro</radar>
+            <coordinates>28.209000 -100.019000</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Texas in the United States -->
           <name>Carrollton</name>
           <coordinates>32.953735 -96.890282</coordinates>
@@ -44715,6 +61128,18 @@
             <zone>TXZ119</zone>
             <radar>dfw</radar>
             <coordinates>32.966667 -96.833333</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Texas in United States -->
+          <name>Castroville</name>
+          <coordinates>29.355790 -98.878640</coordinates>
+          <location>
+            <name>Castroville Municipal Airport</name>
+            <code>KCVB</code>
+            <zone>TXZ204</zone>
+            <radar>sat</radar>
+            <coordinates>29.342389 -98.851222</coordinates>
           </location>
         </city>
         <city>
@@ -44730,6 +61155,18 @@
           </location>
         </city>
         <city>
+          <!-- A city in Texas in United States -->
+          <name>Cisco</name>
+          <coordinates>32.388190 -98.979230</coordinates>
+          <location>
+            <name>Gregory M Simmons Memorial Airport</name>
+            <code>KGZN</code>
+            <zone>TXZ129</zone>
+            <radar>maf</radar>
+            <coordinates>32.365833 -99.023694</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Texas in the United States -->
           <name msgctxt="City in Texas, United States">Clarksville</name>
           <coordinates>33.610665 -95.052722</coordinates>
@@ -44737,6 +61174,30 @@
             <name>Clarksville / Red River County-J D Trissell Field Airport</name>
             <code>KLBR</code>
             <coordinates>33.593056 -95.063333</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Texas in United States -->
+          <name>Cleburne</name>
+          <coordinates>32.347640 -97.386680</coordinates>
+          <location>
+            <name>Cleburne Regional Airport</name>
+            <code>KCPT</code>
+            <zone>TXZ133</zone>
+            <radar>dfw</radar>
+            <coordinates>32.353750 -97.433750</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Texas in United States -->
+          <name>Coleman</name>
+          <coordinates>31.827370 -99.426450</coordinates>
+          <location>
+            <name>Coleman Municipal Airport</name>
+            <code>KCOM</code>
+            <zone>TXZ139</zone>
+            <radar>maf</radar>
+            <coordinates>31.841139 -99.403611</coordinates>
           </location>
         </city>
         <city>
@@ -44749,6 +61210,18 @@
             <zone>TXZ196</zone>
             <radar>sat</radar>
             <coordinates>30.582222 -96.361667</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Texas in United States -->
+          <name>Comanche</name>
+          <coordinates>31.897370 -98.603660</coordinates>
+          <location>
+            <name>Comanche County-City Airport</name>
+            <code>KMKN</code>
+            <zone>TXZ141</zone>
+            <radar>maf</radar>
+            <coordinates>31.920306 -98.599194</coordinates>
           </location>
         </city>
         <city>
@@ -44779,6 +61252,13 @@
             <zone>TXZ243</zone>
             <radar>bro</radar>
             <coordinates>27.692500 -97.291111</coordinates>
+          </location>
+          <location>
+            <name>Cabaniss Field Nolf Airport</name>
+            <code>KNGW</code>
+            <zone>TXZ343</zone>
+            <radar>bro</radar>
+            <coordinates>27.702420 -97.438819</coordinates>
           </location>
         </city>
         <city>
@@ -44914,6 +61394,30 @@
           </location>
         </city>
         <city>
+          <!-- A city in Texas in United States -->
+          <name>Eagle Lake</name>
+          <coordinates>29.589680 -96.333580</coordinates>
+          <location>
+            <name>Eagle Lake Airport</name>
+            <code>KELA</code>
+            <zone>TXZ210</zone>
+            <radar>gls</radar>
+            <coordinates>29.600028 -96.321944</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Texas in United States -->
+          <name>Eastland</name>
+          <coordinates>32.401520 -98.817560</coordinates>
+          <location>
+            <name>Eastland Municipal Airport</name>
+            <code>KETN</code>
+            <zone>TXZ129</zone>
+            <radar>maf</radar>
+            <coordinates>32.414889 -98.809694</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Texas in the United States -->
           <name>Edinburg</name>
           <coordinates>26.301737 -98.163343</coordinates>
@@ -44944,6 +61448,19 @@
             <name>Brooks County Airport</name>
             <code>KBKS</code>
             <coordinates>27.206667 -98.121111</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Texas in United States -->
+          <name>Fort Bliss/El Paso</name>
+          <coordinates>31.813570 -106.412240</coordinates>
+          <location>
+            <name>Biggs Army Air Field (Fort Bliss) Airport</name>
+            <code>KBIF</code>
+            <tz-hint>America/Denver</tz-hint>
+            <zone>TXZ419</zone>
+            <radar>maf</radar>
+            <coordinates>31.849529 -106.380053</coordinates>
           </location>
         </city>
         <city>
@@ -45119,6 +61636,18 @@
           </location>
         </city>
         <city>
+          <!-- A city in Texas in United States -->
+          <name>Hamilton</name>
+          <coordinates>31.703770 -98.123920</coordinates>
+          <location>
+            <name>Hamilton Municipal Airport</name>
+            <code>KMNZ</code>
+            <zone>TXZ143</zone>
+            <radar>sat</radar>
+            <coordinates>31.665921 -98.148643</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Texas in the United States -->
           <name>Harlingen</name>
           <coordinates>26.190631 -97.696103</coordinates>
@@ -45151,6 +61680,30 @@
           </location>
         </city>
         <city>
+          <!-- A city in Texas in United States -->
+          <name>Henderson</name>
+          <coordinates>32.153220 -94.799380</coordinates>
+          <location>
+            <name>Rusk County Airport</name>
+            <code>KRFI</code>
+            <zone>TXZ150</zone>
+            <radar>dfw</radar>
+            <coordinates>32.141723 -94.851728</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Texas in United States -->
+          <name>Hereford</name>
+          <coordinates>34.815210 -102.399320</coordinates>
+          <location>
+            <name>Hereford Municipal Airport</name>
+            <code>KHRX</code>
+            <zone>TXZ016</zone>
+            <radar>ama</radar>
+            <coordinates>34.860699 -102.325883</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Texas in the United States -->
           <name>Hillsboro</name>
           <coordinates>32.010989 -97.130006</coordinates>
@@ -45170,6 +61723,18 @@
             <zone>TXZ204</zone>
             <radar>sat</radar>
             <coordinates>29.359444 -99.174167</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Texas in United States -->
+          <name>Horseshoe Bay</name>
+          <coordinates>30.544290 -98.373940</coordinates>
+          <location>
+            <name>Horseshoe Bay Resort Airport</name>
+            <code>KDZB</code>
+            <zone>TXZ190</zone>
+            <radar>sat</radar>
+            <coordinates>30.527051 -98.358757</coordinates>
           </location>
         </city>
         <city>
@@ -45217,6 +61782,20 @@
             <zone>TXZ213</zone>
             <radar>gls</radar>
             <coordinates>30.067500 -95.556111</coordinates>
+          </location>
+          <location>
+            <name>Houston Executive Airport</name>
+            <code>KTME</code>
+            <zone>TXZ212</zone>
+            <radar>gls</radar>
+            <coordinates>29.805028 -95.897889</coordinates>
+          </location>
+          <location>
+            <name>Houston/Southwest Airport</name>
+            <code>KAXH</code>
+            <zone>TXZ237</zone>
+            <radar>gls</radar>
+            <coordinates>29.506139 -95.476917</coordinates>
           </location>
         </city>
         <city>
@@ -45319,6 +61898,13 @@
             <radar>bro</radar>
             <coordinates>27.503056 -97.811667</coordinates>
           </location>
+          <location>
+            <name>Kleberg County Airport</name>
+            <code>KIKG</code>
+            <zone>TXZ241</zone>
+            <radar>bro</radar>
+            <coordinates>27.550861 -98.030917</coordinates>
+          </location>
         </city>
         <city>
           <!-- A city in Texas in the United States -->
@@ -45328,6 +61914,42 @@
             <name>Fayette Regional Air Center Airport</name>
             <code>K3T5</code>
             <coordinates>29.908056 -96.950000</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Texas in United States -->
+          <name>Lago Vista</name>
+          <coordinates>30.460200 -97.988350</coordinates>
+          <location>
+            <name>Lago Vista Tx/Rusty Allen Airport</name>
+            <code>KRYW</code>
+            <zone>TXZ192</zone>
+            <radar>sat</radar>
+            <coordinates>30.498583 -97.969472</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Texas in United States -->
+          <name>Lamesa</name>
+          <coordinates>32.737600 -101.950990</coordinates>
+          <location>
+            <name>Lamesa Municipal Airport</name>
+            <code>KLUV</code>
+            <zone>TXZ046</zone>
+            <radar>maf</radar>
+            <coordinates>32.756306 -101.920222</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Texas in United States -->
+          <name>Lampasas</name>
+          <coordinates>31.063780 -98.181700</coordinates>
+          <location>
+            <name>Lampasas Airport</name>
+            <code>KLZZ</code>
+            <zone>TXZ156</zone>
+            <radar>sat</radar>
+            <coordinates>31.106194 -98.195917</coordinates>
           </location>
         </city>
         <city>
@@ -45350,6 +61972,18 @@
             <zone>TXZ239</zone>
             <radar>bro</radar>
             <coordinates>27.543611 -99.461389</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Texas in United States -->
+          <name>Levelland</name>
+          <coordinates>33.587320 -102.377960</coordinates>
+          <location>
+            <name>Levelland Municipal Airport</name>
+            <code>KLLN</code>
+            <zone>TXZ034</zone>
+            <radar>maf</radar>
+            <coordinates>33.552528 -102.372528</coordinates>
           </location>
         </city>
         <city>
@@ -45409,6 +62043,18 @@
           </location>
         </city>
         <city>
+          <!-- A city in Texas in United States -->
+          <name>Marshall</name>
+          <coordinates>32.544870 -94.367420</coordinates>
+          <location>
+            <name>Harrison County Airport</name>
+            <code>KASL</code>
+            <zone>TXZ138</zone>
+            <radar>dfw</radar>
+            <coordinates>32.520500 -94.307778</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Texas in the United States -->
           <name>McAllen</name>
           <coordinates>26.203407 -98.230012</coordinates>
@@ -45441,6 +62087,18 @@
           </location>
         </city>
         <city>
+          <!-- A city in Texas in United States -->
+          <name>Mexia</name>
+          <coordinates>31.679890 -96.482200</coordinates>
+          <location>
+            <name>Mexia-Limestone County Airport</name>
+            <code>KLXY</code>
+            <zone>TXZ161</zone>
+            <radar>dfw</radar>
+            <coordinates>31.641178 -96.514459</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Texas in the United States -->
           <name>Midland</name>
           <coordinates>31.997346 -102.077915</coordinates>
@@ -45465,6 +62123,18 @@
             <name>Midlothian / Waxahachie, Mid-Way Regional Airport</name>
             <code>KJWY</code>
             <coordinates>32.455833 -96.912222</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Texas in United States -->
+          <name>Mineola/Quitman</name>
+          <coordinates>32.663190 -95.488290</coordinates>
+          <location>
+            <name>Wood County/Collins Field</name>
+            <code>KJDD</code>
+            <zone>TXZ124</zone>
+            <radar>dfw</radar>
+            <coordinates>32.742194 -95.496472</coordinates>
           </location>
         </city>
         <city>
@@ -45532,6 +62202,30 @@
           </location>
         </city>
         <city>
+          <!-- A city in Texas in United States -->
+          <name>Orange Grove</name>
+          <coordinates>27.956680 -97.936940</coordinates>
+          <location>
+            <name>Orange Grove Nalf Airport</name>
+            <code>KNOG</code>
+            <zone>TXZ241</zone>
+            <radar>bro</radar>
+            <coordinates>27.896818 -98.043557</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Texas in United States -->
+          <name>Ozona</name>
+          <coordinates>30.710170 -101.200670</coordinates>
+          <location>
+            <name>Ozona Municipal Airport</name>
+            <code>KOZA</code>
+            <zone>TXZ076</zone>
+            <radar>maf</radar>
+            <coordinates>30.735194 -101.202194</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Texas in the United States -->
           <name>Palacios</name>
           <coordinates>28.708046 -96.217467</coordinates>
@@ -45561,6 +62255,13 @@
             <name>Perry Lefors Field Airport</name>
             <code>KPPA</code>
             <coordinates>35.612778 -100.996111</coordinates>
+          </location>
+          <location>
+            <name>Pampa Mesa Vista Airport</name>
+            <code>KBPC</code>
+            <zone>TXZ009</zone>
+            <radar>ama</radar>
+            <coordinates>35.883000 -101.033000</coordinates>
           </location>
         </city>
         <city>
@@ -45642,6 +62343,18 @@
           </location>
         </city>
         <city>
+          <!-- A city in Texas in United States -->
+          <name>Pleasanton</name>
+          <coordinates>28.967190 -98.478630</coordinates>
+          <location>
+            <name>Pleasanton Municipal Airport</name>
+            <code>KPEZ</code>
+            <zone>TXZ220</zone>
+            <radar>sat</radar>
+            <coordinates>28.954194 -98.519972</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Texas in the United States -->
           <name>Port Aransas</name>
           <coordinates>27.833916 -97.061099</coordinates>
@@ -45669,6 +62382,30 @@
             <name>Calhoun County Airport</name>
             <code>KPKV</code>
             <coordinates>28.653889 -96.681111</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Texas in United States -->
+          <name>Presidio</name>
+          <coordinates>29.560740 -104.372150</coordinates>
+          <location>
+            <name>Presidio Lely International Airport</name>
+            <code>KPRS</code>
+            <zone>TXZ281</zone>
+            <radar>maf</radar>
+            <coordinates>29.634213 -104.361494</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Texas in United States -->
+          <name>Robstown</name>
+          <coordinates>27.790300 -97.668880</coordinates>
+          <location>
+            <name>Nueces County Airport</name>
+            <code>KRBO</code>
+            <zone>TXZ243</zone>
+            <radar>bro</radar>
+            <coordinates>27.778139 -97.690111</coordinates>
           </location>
         </city>
         <city>
@@ -45739,6 +62476,18 @@
             <name>San Marcos Municipal Airport</name>
             <code>KHYI</code>
             <coordinates>29.893611 -97.864722</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Texas in United States -->
+          <name>Seguin</name>
+          <coordinates>29.568840 -97.964730</coordinates>
+          <location>
+            <name>Randolph Afb Aux Airport</name>
+            <code>KSEQ</code>
+            <zone>TXZ207</zone>
+            <radar>dfw</radar>
+            <coordinates>29.565786 -97.908337</coordinates>
           </location>
         </city>
         <city>
@@ -45879,6 +62628,18 @@
           </location>
         </city>
         <city>
+          <!-- A city in Texas in United States -->
+          <name>Van Horn</name>
+          <coordinates>31.040290 -104.830730</coordinates>
+          <location>
+            <name>Culberson County Airport</name>
+            <code>KVHN</code>
+            <zone>TXZ272</zone>
+            <radar>maf</radar>
+            <coordinates>31.057833 -104.783806</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Texas in the United States -->
           <name msgctxt="City in Texas, United States">Vernon</name>
           <coordinates>34.154531 -99.265080</coordinates>
@@ -45917,6 +62678,13 @@
             <radar>dfw</radar>
             <coordinates>31.483333 -97.316667</coordinates>
           </location>
+          <location>
+            <name>Tstc Waco Airport</name>
+            <code>KCNW</code>
+            <zone>TXZ159</zone>
+            <radar>sat</radar>
+            <coordinates>31.637806 -97.074139</coordinates>
+          </location>
         </city>
         <city>
           <!-- A city in Texas in the United States -->
@@ -45926,6 +62694,25 @@
             <name>Mid Valley Airport</name>
             <code>KT65</code>
             <coordinates>26.177500 -97.973056</coordinates>
+          </location>
+          <location>
+            <name>Mid Valley Airport</name>
+            <code>KTXW</code>
+            <zone>TXZ253</zone>
+            <radar>bro</radar>
+            <coordinates>26.178708 -97.974006</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Texas in United States -->
+          <name>West University Place</name>
+          <coordinates>29.718010 -95.433830</coordinates>
+          <location>
+            <name>Houston Dunn Helistop</name>
+            <code>KMCJ</code>
+            <zone>TXZ213</zone>
+            <radar>gls</radar>
+            <coordinates>29.717000 -95.383000</coordinates>
           </location>
         </city>
         <city>
@@ -45949,6 +62736,13 @@
             <radar>ama</radar>
             <coordinates>33.978611 -98.492778</coordinates>
           </location>
+          <location>
+            <name>Kickapoo Downtown Airport</name>
+            <code>KCWC</code>
+            <zone>TXZ086</zone>
+            <radar>ama</radar>
+            <coordinates>33.860617 -98.490399</coordinates>
+          </location>
         </city>
         <city>
           <!-- A city in Texas in the United States -->
@@ -45962,12 +62756,36 @@
             <coordinates>31.779722 -103.201389</coordinates>
           </location>
         </city>
+        <city>
+          <!-- A city in Texas in United States -->
+          <name>Zapata</name>
+          <coordinates>26.907260 -99.271430</coordinates>
+          <location>
+            <name>Zapata County Airport</name>
+            <code>KAPY</code>
+            <zone>TXZ248</zone>
+            <radar>bro</radar>
+            <coordinates>26.968786 -99.248908</coordinates>
+          </location>
+        </city>
       </state>
       <state>
         <!-- A state/province/territory in United States -->
         <name>Utah</name>
         <fips-code>US49</fips-code>
         <tz-hint>America/Denver</tz-hint>
+        <city>
+          <!-- A city in Utah in United States -->
+          <name>Brigham City</name>
+          <coordinates>41.510210 -112.015500</coordinates>
+          <location>
+            <name>Brigham City Regional Airport</name>
+            <code>KBMC</code>
+            <zone>UTZ103</zone>
+            <radar>slc</radar>
+            <coordinates>41.554306 -112.062250</coordinates>
+          </location>
+        </city>
         <city>
           <!-- A city in Utah in the United States -->
           <name>Bryce Canyon</name>
@@ -46003,6 +62821,37 @@
             <radar>slc</radar>
             <coordinates>39.333333 -112.583333</coordinates>
           </location>
+          <location>
+            <name>Delta Municipal Airport</name>
+            <code>KDTA</code>
+            <zone>UTZ116</zone>
+            <radar>slc</radar>
+            <coordinates>39.382830 -112.502212</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Utah in United States -->
+          <name>Dugway Proving Ground</name>
+          <coordinates>40.197382 -112.935054</coordinates>
+          <location>
+            <name>Michael Army Air Field (Dugway Proving Ground) Airport</name>
+            <code>KDPG</code>
+            <zone>UTZ102</zone>
+            <radar>slc</radar>
+            <coordinates>40.197382 -112.935054</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Utah in United States -->
+          <name>Fillmore</name>
+          <coordinates>38.968850 -112.323550</coordinates>
+          <location>
+            <name>Fillmore Municipal Airport</name>
+            <code>KFOM</code>
+            <zone>UTZ116</zone>
+            <radar>slc</radar>
+            <coordinates>38.958139 -112.363139</coordinates>
+          </location>
         </city>
         <city>
           <!-- A city in Utah in the United States -->
@@ -46014,6 +62863,25 @@
             <zone>UTZ013</zone>
             <radar>slc</radar>
             <coordinates>38.366667 -110.716667</coordinates>
+          </location>
+          <location>
+            <name>Hanksville Airport</name>
+            <code>KHVE</code>
+            <zone>UTZ130</zone>
+            <radar>slc</radar>
+            <coordinates>38.419417 -110.702917</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Utah in United States -->
+          <name>Heber</name>
+          <coordinates>40.506900 -111.413240</coordinates>
+          <location>
+            <name>Heber Valley Airport</name>
+            <code>KHCR</code>
+            <zone>UTZ111</zone>
+            <radar>slc</radar>
+            <coordinates>40.481806 -111.428806</coordinates>
           </location>
         </city>
         <city>
@@ -46114,6 +62982,13 @@
             <radar>slc</radar>
             <coordinates>40.778056 -111.969444</coordinates>
           </location>
+          <location>
+            <name>South Valley Regional Airport</name>
+            <code>KSVR</code>
+            <zone>UTZ105</zone>
+            <radar>slc</radar>
+            <coordinates>40.619547 -111.992889</coordinates>
+          </location>
         </city>
         <city>
           <!-- A city in Utah in the United States -->
@@ -46125,6 +63000,30 @@
             <zone>UTZ019</zone>
             <radar>las</radar>
             <coordinates>37.083333 -113.600000</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Utah in United States -->
+          <name>Spanish Fork</name>
+          <coordinates>40.114960 -111.654920</coordinates>
+          <location>
+            <name>Spanish Fork Municipal/Woodhouse Field</name>
+            <code>KSPK</code>
+            <zone>UTZ111</zone>
+            <radar>slc</radar>
+            <coordinates>40.145028 -111.667694</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Utah in United States -->
+          <name>Tooele</name>
+          <coordinates>40.530780 -112.298280</coordinates>
+          <location>
+            <name>Bolinder Field/Tooele Valley Airport</name>
+            <code>KTVY</code>
+            <zone>UTZ102</zone>
+            <radar>slc</radar>
+            <coordinates>40.612553 -112.350778</coordinates>
           </location>
         </city>
         <city>
@@ -46204,6 +63103,30 @@
           </location>
         </city>
         <city>
+          <!-- A city in Vermont in United States -->
+          <name>Highgate</name>
+          <coordinates>44.940278 -73.097472</coordinates>
+          <location>
+            <name>Franklin County State Airport</name>
+            <code>KFSO</code>
+            <zone>VTZ002</zone>
+            <radar>btv</radar>
+            <coordinates>44.940278 -73.097472</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Vermont in United States -->
+          <name>Lyndonville</name>
+          <coordinates>44.533670 -72.003150</coordinates>
+          <location>
+            <name>Caledonia County Airport</name>
+            <code>KCDA</code>
+            <zone>VTZ007</zone>
+            <radar>btv</radar>
+            <coordinates>44.569114 -72.017979</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Vermont in the United States -->
           <name>Morrisville</name>
           <coordinates>44.561719 -72.598449</coordinates>
@@ -46211,6 +63134,18 @@
             <name>Morrisville-Stowe State Airport</name>
             <code>KMVL</code>
             <coordinates>44.536111 -72.616111</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Vermont in United States -->
+          <name>Newport</name>
+          <coordinates>44.936440 -72.205100</coordinates>
+          <location>
+            <name>Northeast Kingdom International Airport</name>
+            <code>KEFK</code>
+            <zone>VTZ003</zone>
+            <radar>btv</radar>
+            <coordinates>44.888176 -72.228635</coordinates>
           </location>
         </city>
         <city>
@@ -46304,6 +63239,30 @@
           </location>
         </city>
         <city>
+          <!-- A city in Virginia in United States -->
+          <name>Blackstone</name>
+          <coordinates>37.080430 -77.997230</coordinates>
+          <location>
+            <name>Allan C Perkinson/Blackstone Army Air Field</name>
+            <code>KBKT</code>
+            <zone>VAZ067</zone>
+            <radar>ric</radar>
+            <coordinates>37.074738 -77.951812</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Virginia in United States -->
+          <name>Bridgewater</name>
+          <coordinates>38.382070 -78.976700</coordinates>
+          <location>
+            <name>Bridgewater Air Park</name>
+            <code>KVBW</code>
+            <zone>VAZ026</zone>
+            <radar>crw</radar>
+            <coordinates>38.365315 -78.958965</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Virginia in the United States -->
           <name>Charlottesville</name>
           <coordinates>38.029306 -78.476678</coordinates>
@@ -46316,6 +63275,18 @@
           </location>
         </city>
         <city>
+          <!-- A city in Virginia in United States -->
+          <name>Chase City</name>
+          <coordinates>36.799310 -78.458330</coordinates>
+          <location>
+            <name>Chase City Municipal Airport</name>
+            <code>KCXE</code>
+            <zone>VAZ065</zone>
+            <radar>ric</radar>
+            <coordinates>36.788336 -78.501554</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Virginia in the United States -->
           <name>Chesapeake</name>
           <coordinates>36.819037 -76.274940</coordinates>
@@ -46323,6 +63294,13 @@
             <name>Chesapeake Municipal Airport</name>
             <code>KCPK</code>
             <coordinates>36.665556 -76.320556</coordinates>
+          </location>
+          <location>
+            <name>Hampton Roads Executive Airport</name>
+            <code>KPVG</code>
+            <zone>VAZ530</zone>
+            <radar>ric</radar>
+            <coordinates>36.780765 -76.451280</coordinates>
           </location>
         </city>
         <city>
@@ -46393,6 +63371,18 @@
           </location>
         </city>
         <city>
+          <!-- A city in Virginia in United States -->
+          <name>Fentress</name>
+          <coordinates>36.692036 -76.134564</coordinates>
+          <location>
+            <name>Fentress Nalf Airport</name>
+            <code>KNFE</code>
+            <zone>VAZ098</zone>
+            <radar>ric</radar>
+            <coordinates>36.692036 -76.134564</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Virginia in the United States -->
           <name msgctxt="City in Virginia, United States">Franklin</name>
           <coordinates>36.677651 -76.922461</coordinates>
@@ -46402,6 +63392,42 @@
             <zone>VAZ092</zone>
             <radar>ric</radar>
             <coordinates>36.700000 -76.900000</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Virginia in United States -->
+          <name>Fredericksburg</name>
+          <coordinates>38.303180 -77.460540</coordinates>
+          <location>
+            <name>Shannon Airport</name>
+            <code>KEZF</code>
+            <zone>VAZ055</zone>
+            <radar>dca</radar>
+            <coordinates>38.266895 -77.449240</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Virginia in United States -->
+          <name>Front Royal</name>
+          <coordinates>38.918170 -78.194440</coordinates>
+          <location>
+            <name>Front Royal-Warren County Airport</name>
+            <code>KFRR</code>
+            <zone>VAZ030</zone>
+            <radar>dca</radar>
+            <coordinates>38.917512 -78.253373</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Virginia in United States -->
+          <name>Gordonsville</name>
+          <coordinates>38.137360 -78.187780</coordinates>
+          <location>
+            <name>Gordonsville Municipal Airport</name>
+            <code>KGVE</code>
+            <zone>VAZ509</zone>
+            <radar>ric</radar>
+            <coordinates>38.155984 -78.165780</coordinates>
           </location>
         </city>
         <city>
@@ -46441,6 +63467,18 @@
           </location>
         </city>
         <city>
+          <!-- A city in Virginia in United States -->
+          <name>Lawrenceville</name>
+          <coordinates>36.757650 -77.846940</coordinates>
+          <location>
+            <name>Brunswick County Airport</name>
+            <code>KLVL</code>
+            <zone>VAZ079</zone>
+            <radar>ric</radar>
+            <coordinates>36.774629 -77.793782</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Virginia in the United States -->
           <name msgctxt="City in Virginia, United States">Leesburg</name>
           <coordinates>39.115662 -77.563602</coordinates>
@@ -46460,6 +63498,18 @@
             <name>Louisa County Airport / Freeman Field</name>
             <code>KLKU</code>
             <coordinates>38.009722 -77.970278</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Virginia in United States -->
+          <name>Luray</name>
+          <coordinates>38.665400 -78.459450</coordinates>
+          <location>
+            <name>Luray Caverns Airport</name>
+            <code>KLUA</code>
+            <zone>VAZ029</zone>
+            <radar>crw</radar>
+            <coordinates>38.666710 -78.500835</coordinates>
           </location>
         </city>
         <city>
@@ -46560,6 +63610,18 @@
           </location>
         </city>
         <city>
+          <!-- A city in Virginia in United States -->
+          <name>North Chesterfield</name>
+          <coordinates>37.406444 -77.524833</coordinates>
+          <location>
+            <name>Richmond Executive/Chesterfield County Airport</name>
+            <code>KFCI</code>
+            <zone>VAZ513</zone>
+            <radar>ric</radar>
+            <coordinates>37.406444 -77.524833</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Virginia in the United States -->
           <name msgctxt="City in Virginia, United States">Orange</name>
           <coordinates>38.245411 -78.110834</coordinates>
@@ -46615,6 +63677,18 @@
             <zone>VAZ052</zone>
             <radar>dca</radar>
             <coordinates>38.512500 -77.291667</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Virginia in United States -->
+          <name>Richlands</name>
+          <coordinates>37.093170 -81.793730</coordinates>
+          <location>
+            <name>Tazewell County Airport</name>
+            <code>KJFZ</code>
+            <zone>VAZ007</zone>
+            <radar>avl</radar>
+            <coordinates>37.063746 -81.798266</coordinates>
           </location>
         </city>
         <city>
@@ -46684,6 +63758,30 @@
           </location>
         </city>
         <city>
+          <!-- A city in Virginia in United States -->
+          <name>Tangier</name>
+          <coordinates>37.826240 -75.991600</coordinates>
+          <location>
+            <name>Tangier Island Airport</name>
+            <code>KTGI</code>
+            <zone>VAZ099</zone>
+            <radar>ric</radar>
+            <coordinates>37.825865 -75.997663</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Virginia in United States -->
+          <name>Tappahannock</name>
+          <coordinates>37.925410 -76.859130</coordinates>
+          <location>
+            <name>Tappahannock/Essex County Airport</name>
+            <code>KXSA</code>
+            <zone>VAZ521</zone>
+            <radar>ric</radar>
+            <coordinates>37.859609 -76.894119</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Virginia in the United States -->
           <name>Virginia Beach</name>
           <coordinates>36.852926 -75.977985</coordinates>
@@ -46705,6 +63803,18 @@
             <zone>VAZ088</zone>
             <radar>ric</radar>
             <coordinates>36.981389 -77.001111</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Virginia in United States -->
+          <name>Warrenton</name>
+          <coordinates>38.713450 -77.795270</coordinates>
+          <location>
+            <name>Warrenton/Fauquier Airport</name>
+            <code>KHWY</code>
+            <zone>VAZ502</zone>
+            <radar>dca</radar>
+            <coordinates>38.586285 -77.710631</coordinates>
           </location>
         </city>
         <city>
@@ -46813,6 +63923,30 @@
             <zone>WAZ506</zone>
             <radar>sea</radar>
             <coordinates>48.470833 -122.420833</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in United States -->
+          <name>Chehalis</name>
+          <coordinates>46.662050 -122.964020</coordinates>
+          <location>
+            <name>Chehalis-Centralia Airport</name>
+            <code>KCLS</code>
+            <zone>WAZ318</zone>
+            <radar>sea</radar>
+            <coordinates>46.677028 -122.982750</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in United States -->
+          <name>Coupeville</name>
+          <coordinates>48.219820 -122.686280</coordinates>
+          <location>
+            <name>Coupeville Nolf Airport</name>
+            <code>KNRA</code>
+            <zone>WAZ333</zone>
+            <radar>sea</radar>
+            <coordinates>48.183333 -122.633333</coordinates>
           </location>
         </city>
         <city>
@@ -46945,6 +64079,13 @@
             <radar>sea</radar>
             <coordinates>48.349167 -122.650556</coordinates>
           </location>
+          <location>
+            <name>Delaurentis Airport</name>
+            <code>KOKH</code>
+            <zone>WAZ333</zone>
+            <radar>sea</radar>
+            <coordinates>48.251528 -122.673667</coordinates>
+          </location>
         </city>
         <city>
           <!-- A city in Washington in the United States -->
@@ -46993,6 +64134,18 @@
           </location>
         </city>
         <city>
+          <!-- A city in United States -->
+          <name>Puyallup</name>
+          <coordinates>47.185380 -122.292900</coordinates>
+          <location>
+            <name>Pierce County/Thun Field</name>
+            <code>KPLU</code>
+            <zone>WAZ308</zone>
+            <radar>sea</radar>
+            <coordinates>47.103920 -122.287200</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Washington in the United States -->
           <name>Quillayute</name>
           <coordinates>47.943130 -124.542435</coordinates>
@@ -47013,6 +64166,18 @@
             <zone>WAZ508</zone>
             <radar>sea</radar>
             <coordinates>47.494444 -122.212778</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in United States -->
+          <name>Richland</name>
+          <coordinates>46.285690 -119.284460</coordinates>
+          <location>
+            <name>Richland Airport</name>
+            <code>KRLD</code>
+            <zone>WAZ028</zone>
+            <radar>sea</radar>
+            <coordinates>46.305639 -119.304189</coordinates>
           </location>
         </city>
         <city>
@@ -47385,6 +64550,18 @@
           </location>
         </city>
         <city>
+          <!-- A city in Wisconsin in United States -->
+          <name>Black River Falls</name>
+          <coordinates>44.294680 -90.851530</coordinates>
+          <location>
+            <name>Black River Falls Area Airport</name>
+            <code>KBCK</code>
+            <zone>WIZ034</zone>
+            <radar>rst</radar>
+            <coordinates>44.250739 -90.855280</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Wisconsin in the United States -->
           <name>Boscobel</name>
           <coordinates>43.134429 -90.705405</coordinates>
@@ -47425,6 +64602,18 @@
             <code>KCLI</code>
             <zone>WIZ037</zone>
             <coordinates>44.613889 -88.731389</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Wisconsin in United States -->
+          <name>Cumberland</name>
+          <coordinates>45.532180 -92.019350</coordinates>
+          <location>
+            <name>Cumberland Municipal Airport</name>
+            <code>KUBE</code>
+            <zone>WIZ015</zone>
+            <radar>msp</radar>
+            <coordinates>45.506100 -91.980802</coordinates>
           </location>
         </city>
         <city>
@@ -47690,6 +64879,18 @@
           </location>
         </city>
         <city>
+          <!-- A city in Wisconsin in United States -->
+          <name>Oconto</name>
+          <coordinates>44.887210 -87.864550</coordinates>
+          <location>
+            <name>Oconto/J Douglas Bake Municipal Airport</name>
+            <code>KOCQ</code>
+            <zone>WIZ074</zone>
+            <radar>htl</radar>
+            <coordinates>44.874056 -87.909770</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Wisconsin in the United States -->
           <name>Osceola</name>
           <coordinates>45.320520 -92.704930</coordinates>
@@ -47722,6 +64923,18 @@
             <zone>WIZ009</zone>
             <radar>msp</radar>
             <coordinates>45.700000 -90.400000</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Wisconsin in United States -->
+          <name>Platteville</name>
+          <coordinates>42.734160 -90.478460</coordinates>
+          <location>
+            <name>Platteville Municipal Airport</name>
+            <code>KPVB</code>
+            <zone>WIZ067</zone>
+            <radar>rst</radar>
+            <coordinates>42.689357 -90.444391</coordinates>
           </location>
         </city>
         <city>
@@ -47770,6 +64983,18 @@
           </location>
         </city>
         <city>
+          <!-- A city in Wisconsin in United States -->
+          <name>Shawano</name>
+          <coordinates>44.782210 -88.608990</coordinates>
+          <location>
+            <name>Shawano Municipal Airport</name>
+            <code>KEZS</code>
+            <zone>WIZ031</zone>
+            <radar>mkg</radar>
+            <coordinates>44.787306 -88.560012</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Wisconsin in the United States -->
           <name>Sheboygan</name>
           <coordinates>43.750828 -87.714530</coordinates>
@@ -47790,6 +65015,18 @@
             <code>KRZN</code>
             <zone>WIZ006</zone>
             <coordinates>45.822778 -92.372500</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Wisconsin in United States -->
+          <name>Solon Springs</name>
+          <coordinates>46.353270 -91.822410</coordinates>
+          <location>
+            <name>Solon Springs Municipal Airport</name>
+            <code>KOLG</code>
+            <zone>WIZ001</zone>
+            <radar>msp</radar>
+            <coordinates>46.314754 -91.816376</coordinates>
           </location>
         </city>
         <city>
@@ -47946,6 +65183,18 @@
         <fips-code>US56</fips-code>
         <tz-hint>America/Denver</tz-hint>
         <city>
+          <!-- A city in Wyoming in United States -->
+          <name>Afton</name>
+          <coordinates>42.724930 -110.931870</coordinates>
+          <location>
+            <name>Afton Lincoln County/General Boyd L Eddins Field</name>
+            <code>KAFO</code>
+            <zone>WYZ023</zone>
+            <radar>cpr</radar>
+            <coordinates>42.708771 -110.942171</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Wyoming in the United States -->
           <name>Big Piney</name>
           <coordinates>42.538275 -110.114325</coordinates>
@@ -48000,6 +65249,13 @@
             <radar>cpr</radar>
             <coordinates>41.157778 -104.806944</coordinates>
           </location>
+          <location>
+            <name>Francis E. Warren Air Force Base Heliport</name>
+            <code>KFEW</code>
+            <zone>WYZ117</zone>
+            <radar>cpr</radar>
+            <coordinates>41.133000 -104.867000</coordinates>
+          </location>
         </city>
         <city>
           <!-- A city in Wyoming in the United States -->
@@ -48011,6 +65267,18 @@
             <zone>WYZ002</zone>
             <radar>cpr</radar>
             <coordinates>44.516667 -109.016667</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Wyoming in United States -->
+          <name>Dixon</name>
+          <coordinates>41.037441 -107.492528</coordinates>
+          <location>
+            <name>Dixon Airport</name>
+            <code>KDWX</code>
+            <zone>WYZ111</zone>
+            <radar>cpr</radar>
+            <coordinates>41.037441 -107.492528</coordinates>
           </location>
         </city>
         <city>
@@ -48026,6 +65294,18 @@
           </location>
         </city>
         <city>
+          <!-- A city in Wyoming in United States -->
+          <name>Dubois</name>
+          <coordinates>43.533570 -109.630430</coordinates>
+          <location>
+            <name>Dubois Municipal Airport</name>
+            <code>KDUB</code>
+            <zone>WYZ016</zone>
+            <radar>cpr</radar>
+            <coordinates>43.548651 -109.690828</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Wyoming in the United States -->
           <name>Evanston</name>
           <coordinates>41.268279 -110.963237</coordinates>
@@ -48035,6 +65315,18 @@
             <zone>WYZ021</zone>
             <radar>cpr</radar>
             <coordinates>41.273056 -111.030556</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Wyoming in United States -->
+          <name>Fort Bridger</name>
+          <coordinates>41.393333 -110.405972</coordinates>
+          <location>
+            <name>Fort Bridger Airport</name>
+            <code>KFBR</code>
+            <zone>WYZ021</zone>
+            <radar>cpr</radar>
+            <coordinates>41.393333 -110.405972</coordinates>
           </location>
         </city>
         <city>
@@ -48058,6 +65350,18 @@
           </location>
         </city>
         <city>
+          <!-- A city in Wyoming in United States -->
+          <name>Guernsey</name>
+          <coordinates>42.269690 -104.741630</coordinates>
+          <location>
+            <name>Camp Guernsey Airport</name>
+            <code>KGUR</code>
+            <zone>WYZ107</zone>
+            <radar>cpr</radar>
+            <coordinates>42.259738 -104.728313</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Wyoming in the United States -->
           <name msgctxt="City in Wyoming, United States">Jackson</name>
           <coordinates>43.479929 -110.762428</coordinates>
@@ -48067,6 +65371,18 @@
             <zone>WYZ006</zone>
             <radar>cpr</radar>
             <coordinates>43.600000 -110.733333</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Wyoming in United States -->
+          <name>Kemmerer</name>
+          <coordinates>41.792450 -110.537670</coordinates>
+          <location>
+            <name>Kemmerer Municipal Airport</name>
+            <code>KEMM</code>
+            <zone>WYZ027</zone>
+            <radar>cpr</radar>
+            <coordinates>41.824083 -110.556944</coordinates>
           </location>
         </city>
         <city>
@@ -48094,6 +65410,18 @@
           </location>
         </city>
         <city>
+          <!-- A city in Wyoming in United States -->
+          <name>Newcastle</name>
+          <coordinates>43.854700 -104.204940</coordinates>
+          <location>
+            <name>Mondell Field</name>
+            <code>KECS</code>
+            <zone>WYZ059</zone>
+            <radar>cpr</radar>
+            <coordinates>43.884250 -104.314500</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Wyoming in the United States -->
           <name>Pinedale</name>
           <coordinates>42.866610 -109.860986</coordinates>
@@ -48101,6 +65429,18 @@
             <name>Ralph Wenz Field Airport</name>
             <code>KPNA</code>
             <coordinates>42.795278 -109.806944</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Wyoming in United States -->
+          <name>Powell</name>
+          <coordinates>44.753840 -108.757350</coordinates>
+          <location>
+            <name>Powell Municipal Airport</name>
+            <code>KPOY</code>
+            <zone>MTZ139</zone>
+            <radar>cpr</radar>
+            <coordinates>44.867167 -108.793417</coordinates>
           </location>
         </city>
         <city>
@@ -48126,6 +65466,13 @@
             <radar>cpr</radar>
             <coordinates>43.061944 -108.446389</coordinates>
           </location>
+          <location>
+            <name>Boysen/Thermopolis</name>
+            <code>KTBX</code>
+            <zone>WYZ007</zone>
+            <radar>cpr</radar>
+            <coordinates>43.467000 -108.389000</coordinates>
+          </location>
         </city>
         <city>
           <!-- A city in Wyoming in the United States -->
@@ -48140,6 +65487,18 @@
           </location>
         </city>
         <city>
+          <!-- A city in Wyoming in United States -->
+          <name>Saratoga</name>
+          <coordinates>41.454960 -106.806430</coordinates>
+          <location>
+            <name>Shively Field</name>
+            <code>KSAA</code>
+            <zone>WYZ113</zone>
+            <radar>cpr</radar>
+            <coordinates>41.443528 -106.827528</coordinates>
+          </location>
+        </city>
+        <city>
           <!-- A city in Wyoming in the United States -->
           <name>Sheridan</name>
           <coordinates>44.797194 -106.956179</coordinates>
@@ -48149,6 +65508,18 @@
             <zone>WYZ099</zone>
             <radar>cpr</radar>
             <coordinates>44.769444 -106.968889</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Wyoming in United States -->
+          <name>Thermopolis</name>
+          <coordinates>43.646070 -108.212040</coordinates>
+          <location>
+            <name>Hot Springs County Airport</name>
+            <code>KHSG</code>
+            <zone>WYZ005</zone>
+            <radar>cpr</radar>
+            <coordinates>43.713611 -108.389694</coordinates>
           </location>
         </city>
         <city>
@@ -48171,6 +65542,18 @@
             <zone>WYZ001</zone>
             <radar>cpr</radar>
             <coordinates>44.544444 -110.421111</coordinates>
+          </location>
+        </city>
+        <city>
+          <!-- A city in Wyoming in United States -->
+          <name>Wheatland</name>
+          <coordinates>42.054070 -104.952950</coordinates>
+          <location>
+            <name>Phifer Airfield</name>
+            <code>KEAN</code>
+            <zone>WYZ107</zone>
+            <radar>cpr</radar>
+            <coordinates>42.055520 -104.928283</coordinates>
           </location>
         </city>
         <city>
@@ -48199,14 +65582,10 @@
     </country>
   </region>
 <!-- Could not find information about the following stations:
-     AZUH BKPR CAHR CBBC CERM CMFM CPBT CPEH CPFI CPIR CPRO CPRY CPST
-     CPSV CPXL CQCM CTNK CWDT CWEE CWGM CWHN CWIL CWJU CWKD CWKM CWKW
-     CWLI CWLX CWND CWOB CWPX CWRF CWRH CWRX CWSA CWTU CWUP CWUW CWWL
-     CWWS CWXR CWYM CWZV CXLC CXQA CXTN CYAH CYHH CYKJ CYLA CYOA CYUS
-     CZFA CZUM EQAC EQAI EQBA EQBF EQBH EQBI EQBM EQBP EQBR EQCB EQTK
-     EQYB EQYC EQYG EQYK EQYL EQYN EQYR EQYS FJDG FYWE GMML KBJN KGSM
-     KNSI KS58 KSRN MASA MUCL PAER PAHZ PAKU PALU PAMD PAPT PASY PKWA
-     SBCJ TRPG UGKO UGSB UGTB UOHH UOII UOOO YAMB YCIN YFRT YTEF YTNK
-     YTRE YWGT YWHA YWLM 
+     AZUH CPBT CPEH CPFI CPIR CPRO CPRY CPST CPSV CPXL CQCM CWHN CWIL
+     CWKM CWKW CWLI CWLX CWOB CWPX CWRF CWRH CWRX CWTU CWUP CWUW CWXR
+     CWYM CXLC CXQA CYHH CYOA CYUS EQAC EQAI EQBA EQBF EQBH EQBI EQBM
+     EQBP EQBR EQCB EQTK EQYB EQYC EQYG EQYK EQYL EQYN EQYR EQYS KBJN
+     KGSM KS58 KSRN MASA PAER PAHZ UOHH UOII YTEF YTNK YTRE YWGT YWHA
   -->
 </mateweather>


### PR DESCRIPTION
- **1,673 new stations** across 150 countries (612 US, 123 Canada, 75 India, 36 Turkey, 29 Argentina, 27 Colombia, 26 each for Japan/Brazil/France/Russia, and 140 more countries), verified against live NOAA METAR data
- **5 Uzbekistan ICAO renames**: UTTT→UZTT, UTSS→UZSS, UTNN→UZNN, UTST→UZST, UTNU→UZNU (see #142)
- **1 new country**: Kosovo (XK/KV), placed alphabetically in the Europe region
- **5 new timezone entries** added to existing country blocks where candidates had timezones not already listed (Chile, Netherlands, Norway, Paraguay)
- **EHVB→EHRD** for The Hague (#29) ... Valkenburg closed in 2010, replaced with Rotterdam The Hague Airport
- **Kowloon→Hong Kong** for VHHH (#129) ... Airport moved to Chek Lap Kok in 1998
- US stations include `<zone>` and `<radar>` fields; Puerto Rico stations routed to the existing PR country block under Atlantic

### Data pipeline

Every candidate was verified through a multi-step pipeline:

1. Cross-referenced airportsdata + OurAirports + NOAA ISD + UCAR station lists to build an initial candidate set
2. Enriched with FIPS country codes, city coordinates, NWS forecast zones, radar sites, and timezone data
3. Candidate entries were verified against live METAR data ... Each candidate station was checked against `aviationweather.gov` to confirm that it's actively reporting. 1,265 stale candidates were removed before generating the XML. Stale was defined as last reported date the station was active > 30 days.
4. Deduplicated against the existing `Locations.xml.in` ... No new ICAO code appears twice in the output

### Validation

- `xmllint --dtdvalid data/locations.dtd` passes
- All 1,673 new ICAO codes confirmed present exactly once
- Existing entries preserved (formatting, comments, whitespace intact)

### Known stale stations (not removed in this PR)

The same live METAR verification that filtered candidates also identified **144 existing stations** across 40 countries that are no longer reporting. These are left in place to keep this PR focused on additions. Removing them would be a separate follow-up PR.

<details>
<summary>Stale station list by country (144 stations)</summary>

- **Australia** (1): YSWG
- **Austria** (2): LOWZ, LOXA
- **Belarus** (1): UMMM
- **Bolivia** (2): SLSI, SLSU
- **Botswana** (6): FBFT, FBGZ, FBJW, FBLT, FBSP, FBTS
- **Brazil** (6): SBAA, SBJF, SBLP, SBQV, SBTU, SBUG
- **Bulgaria** (1): LBBG
- **Cambodia** (2): VDPP, VDSR
- **Canada** (9): CWCA, CWER, CWHI, CWJT, CWVH, CWYL, CYGQ, CYJT, CYNC
- **Central African Republic** (1): FEFG
- **Chile** (1): SCTC
- **Cuba** (1): MUMZ
- **Czech Republic** (1): LKHO
- **Egypt** (1): HEBA
- **Finland** (2): EFHF, EFKA
- **France** (13): LFBV, LFCG, LFDH, LFLD, LFLM, LFLQ, LFOC, LFOF, LFOI, LFOR, LFOW, LFSC, LFXA
- **Germany** (3): ETGZ, ETNU, ETSA
- **Greenland** (1): BGCO
- **Hungary** (1): LHUD
- **India** (5): VABJ, VEBD, VIAG, VICG, VILH
- **Iran** (3): OIAI, OIFK, OISA
- **Israel** (1): LLET
- **Italy** (5): LIEB, LIMH, LIMV, LIPF, LIVO
- **Japan** (6): RJCJ, RJFA, RJFZ, RJNH, RJST, RJTJ
- **Kuwait** (1): OKBK
- **Libya** (3): HLLB, HLLS, HLLT
- **Liechtenstein** (1): LOIH
- **Norway** (1): ENFG
- **Pakistan** (2): OPNH, OPRN
- **Russia** (4): ULOL, UUBP, UWPP, UWSS
- **Saint Vincent and the Grenadines** (1): TVSV
- **Slovakia** (1): LZLU
- **South Africa** (2): FADN, FAKD
- **Syria** (3): OSDZ, OSKL, OSLK
- **Tunisia** (1): DTTR
- **Ukraine** (5): UKHH, UKKK, UKLL, UKLR, UKOO
- **United Kingdom** (4): EGDL, EGDX, EGMH, EGYW
- **United States** (25): KCHK, KCQT, KCUL, KFOZ, KGDP, KHTO, KINK, KMEH, KMQE, KNHZ, KPPQ, KRDK, KSKX, KTPF, KTQH, KVDF, KVTP, PAEC, PAEL, PAEM, PAII, PALJ, PAPH, PAWI, PAWR
- **Venezuela** (14): SVBI, SVBS, SVCB, SVCS, SVGD, SVGU, SVJM, SVMD, SVMG, SVMN, SVMT, SVPA, SVPR, SVSZ
- **Wallis and Futuna** (1): NLWW

</details>

### Translation note

The `po-locations/*.po` files are not updated in this PR. The renamed city
("Kowloon" → "Hong Kong") and removed city ("Valkenburg") will become
obsolete entries automatically when `msgmerge` runs against the regenerated
`.pot` template. New station/city names will appear as untranslated strings
until translators pick them up. ICAO code changes (Uzbekistan UT→UZ) are in
`<code>` elements which are not translatable, so they don't affect po files.

### Issues addressed

- #142  Uzbekistan ICAO code changes (UT→UZ)
- #119 Add airport Ingolstadt-Manching (ETSI now included)
- #108 Missing locations in Armenia, Estonia, Kyrgyzstan (new stations added for all three)
- #29 The Hague pointed at EHVB (Valkenburg), closed since 2010; replaced with EHRD
- #129 VHHH renamed from "Kowloon" to "Hong Kong"
- #59 Missing French cities (26 new French stations added)
- #19 Incomplete locations list (1,673 new stations significantly expand coverage)