### PR TITLE
tests: use top_builddir for test data path

### DIFF
--- a/libmateweather/Makefile.am
+++ b/libmateweather/Makefile.am
@@ -73,7 +73,7 @@ test_libmateweather_SOURCES = test_libmateweather.c
 test_libmateweather_LDADD = libmateweather.la $(GTK_LIBS)
 
 AM_TESTS_ENVIRONMENT = \
-	MATEWEATHER_XML_LOCATION_DIR=$(top_srcdir)/data
+	MATEWEATHER_XML_LOCATION_DIR=$(top_builddir)/data
 
 mateweather-enum-types.h: $(mateweather_new_headers)
 	$(AM_V_GEN)( cd $(srcdir) && $(GLIB_MKENUMS) --template mateweather-enum-types.h.tmpl \


### PR DESCRIPTION
distcheck uses a VPATH build where Locations.xml is generated in the build directory, not the source directory. Use top_builddir/data instead of top_srcdir/data so the test finds the generated file.